### PR TITLE
perf: use derived type for all producers when dequeueing

### DIFF
--- a/include/tmc/detail/ex_cpu.ipp
+++ b/include/tmc/detail/ex_cpu.ipp
@@ -150,7 +150,7 @@ void ex_cpu::init_queue_iteration_order(
     ++pidx;
     // pointer to previously consumed-from producer (initially also this
     // thread's producer)
-    producers[pidx] = &work_queues[prio].staticProducers[Slot];
+    producers[pidx] = nullptr;
     ++pidx;
 
     for (size_t i = 1; i < TData.total_size; ++i) {
@@ -167,8 +167,7 @@ void ex_cpu::init_queue_iteration_order(
 void ex_cpu::init_thread_locals(size_t Slot) {
   detail::this_thread::executor = &type_erased_this;
   detail::this_thread::this_task = {
-    .prio = 0, .yield_priority = &thread_states[Slot].yield_priority
-  };
+    .prio = 0, .yield_priority = &thread_states[Slot].yield_priority};
   detail::this_thread::thread_name =
     std::string("cpu thread ") + std::to_string(Slot);
 }

--- a/include/tmc/detail/ex_cpu.ipp
+++ b/include/tmc/detail/ex_cpu.ipp
@@ -148,8 +148,7 @@ void ex_cpu::init_queue_iteration_order(
     // pointer to this thread's producer
     producers[pidx] = &work_queues[prio].staticProducers[Slot];
     ++pidx;
-    // pointer to previously consumed-from producer (initially also this
-    // thread's producer)
+    // pointer to previously consumed-from producer (initially none)
     producers[pidx] = nullptr;
     ++pidx;
 
@@ -167,7 +166,8 @@ void ex_cpu::init_queue_iteration_order(
 void ex_cpu::init_thread_locals(size_t Slot) {
   detail::this_thread::executor = &type_erased_this;
   detail::this_thread::this_task = {
-    .prio = 0, .yield_priority = &thread_states[Slot].yield_priority};
+    .prio = 0, .yield_priority = &thread_states[Slot].yield_priority
+  };
   detail::this_thread::thread_name =
     std::string("cpu thread ") + std::to_string(Slot);
 }

--- a/include/tmc/detail/qu_lockfree.hpp
+++ b/include/tmc/detail/qu_lockfree.hpp
@@ -1323,9 +1323,7 @@ public:
   template <typename It>
   bool enqueue_bulk_ex_cpu(It itemFirst, size_t count, size_t priority) {
     ExplicitProducer** producers =
-      static_cast<ExplicitProducer**>(
-        detail::this_thread::producers
-      );
+      static_cast<ExplicitProducer**>(detail::this_thread::producers);
     if (producers != nullptr) {
       ExplicitProducer* this_thread_prod = static_cast<ExplicitProducer*>(
         producers[priority * dequeueProducerCount]
@@ -1547,13 +1545,12 @@ public:
         static_cast<ImplicitProducer*>(implicit_prod->next_prod());
     }
 
+    // producers[1] is the previously consumed-from producer
+    // If we didn't find work last time, it will be null.
     size_t pidx = producers[1] == nullptr ? 2 : 1;
 
     // CHECK the remaining threads in the predefined order
     for (; pidx < dequeue_count; ++pidx) {
-      // TODO unroll to 2x (check total_size % 2 == 0 [[likely]])
-      // wait on this - there will be an odd number of threads after other
-      // changes
       ExplicitProducer* prod = static_cast<ExplicitProducer*>(producers[pidx]);
       if (prod->dequeue(item)) {
         // update prev_prod


### PR DESCRIPTION
`detail::this_thread::producers[1]` is used to cache the producer that this thread stole work from last time. After #3 , when looking for work in `try_dequeue_ex_cpu`, the ImplicitProducers will always be checked before the `detail::this_thread::producers[1..]` array. Therefore we never need to cache ImplicitProducers in this array as they will have already been checked.

- make `implicit_prod` use the derived type ImplicitProducer
- make `detail::this_thread::producers` use the derived type ExplicitProducer
- roll index 1 into the loop after it

This results in improved code generation and better performance of this loop under most scenarios.

There is one exception - although this makes skynet run about 10% faster on my 5950X, it runs about 5% slower on my EPYC 7742. The generated code is the same; there appears to be some kind of reverse scaling with the performance of the loop on the high core-count CPU. If I inject multiple calls to `_mm_pause();` inside the ExplicitProducers check loop, the overall program runtime actually gets faster on that machine. This is a problem that needs to be resolved in a separate PR and not a reason to hold back this one which is objectively more performant.