### PR TITLE
docs: Remove IsVoid / IsNotVoid concepts and constraints

### DIFF
--- a/include/tmc/detail/concepts.hpp
+++ b/include/tmc/detail/concepts.hpp
@@ -1,11 +1,6 @@
 #pragma once
-#include <type_traits>
 
 namespace tmc {
-template <typename T>
-concept IsVoid = std::is_void_v<T>;
-template <typename T>
-concept IsNotVoid = !std::is_void_v<T>;
 namespace detail {
 template <typename E>
 concept TypeErasableExecutor = requires(E e) { e.type_erased(); };

--- a/include/tmc/spawn_task.hpp
+++ b/include/tmc/spawn_task.hpp
@@ -26,13 +26,6 @@ namespace tmc {
 /// must co_await the returned awaitable later in this function. You cannot
 /// simply destroy it, as the running task will have a pointer to it.
 template <typename Result> aw_spawned_task<Result> spawn(task<Result> Task);
-template <IsVoid Result> aw_spawned_task<Result> spawn(task<Result> Task) {
-  return aw_spawned_task<Result>(Task);
-}
-
-template <IsNotVoid Result> aw_spawned_task<Result> spawn(task<Result> Task) {
-  return aw_spawned_task<Result>(Task);
-}
 
 // Primary template is forward-declared in "tmc/detail/aw_run_early.hpp".
 template <IsNotVoid Result>
@@ -154,7 +147,7 @@ public:
   }
 };
 
-template <IsVoid Result> class aw_spawned_task<Result> {
+template <> class aw_spawned_task<void> {
   detail::type_erased_executor* executor;
   detail::type_erased_executor* continuation_executor;
   task<void> wrapped;
@@ -259,12 +252,20 @@ public:
   ///
   /// This is not how you spawn a task in a detached state! For that, just call
   /// spawn() and discard the return value.
-  inline aw_run_early<Result, Result> run_early() {
+  inline aw_run_early<void, void> run_early() {
     did_await = true; // prevent this from posting afterward
-    return aw_run_early<Result, Result>(
+    return aw_run_early<void, void>(
       wrapped, prio, executor, continuation_executor
     );
   }
 };
+
+template <> aw_spawned_task<void> spawn(task<void> Task) {
+  return aw_spawned_task<void>(Task);
+}
+
+template <IsNotVoid Result> aw_spawned_task<Result> spawn(task<Result> Task) {
+  return aw_spawned_task<Result>(Task);
+}
 
 } // namespace tmc

--- a/include/tmc/spawn_task.hpp
+++ b/include/tmc/spawn_task.hpp
@@ -7,30 +7,10 @@
 #include <coroutine>
 namespace tmc {
 
-/// spawn() creates a task wrapper that allows you to customize a task, by
-/// calling `run_on()`, `resume_on()`, `with_priority()`, and/or `run_early()`
-/// before the task is spawned.
-///
-/// If `Result` is non-void, the task will be spawned when the the wrapper is
-/// co_await'ed:
-/// `auto result = co_await spawn(task_result()).with_priority(1);`
-///
-/// If `Result` is void, you can do the same thing:
-/// `co_await spawn(task_void()).with_priority(1);`
-///
-/// If `Result` is void, you also have the option to spawn it detached -
-/// the task will be spawned when the wrapper temporary is destroyed:
-/// `spawn(task_void()).with_priority(1);`
-///
-/// When `run_early()` is called, the task will be spawned immediately, and you
-/// must co_await the returned awaitable later in this function. You cannot
-/// simply destroy it, as the running task will have a pointer to it.
-template <typename Result> aw_spawned_task<Result> spawn(task<Result> Task);
-
 // Primary template is forward-declared in "tmc/detail/aw_run_early.hpp".
-template <IsNotVoid Result>
+template <typename Result>
 class [[nodiscard("You must co_await the return of spawn(task<Result>) "
-                  "if Result is not void.")]] aw_spawned_task<Result> {
+                  "if Result is not void.")]] aw_spawned_task {
   detail::type_erased_executor* executor;
   detail::type_erased_executor* continuation_executor;
   task<Result> wrapped;
@@ -260,11 +240,25 @@ public:
   }
 };
 
-template <> aw_spawned_task<void> spawn(task<void> Task) {
-  return aw_spawned_task<void>(Task);
-}
-
-template <IsNotVoid Result> aw_spawned_task<Result> spawn(task<Result> Task) {
+/// spawn() creates a task wrapper that allows you to customize a task, by
+/// calling `run_on()`, `resume_on()`, `with_priority()`, and/or `run_early()`
+/// before the task is spawned.
+///
+/// If `Result` is non-void, the task will be spawned when the the wrapper is
+/// co_await'ed:
+/// `auto result = co_await spawn(task_result()).with_priority(1);`
+///
+/// If `Result` is void, you can do the same thing:
+/// `co_await spawn(task_void()).with_priority(1);`
+///
+/// If `Result` is void, you also have the option to spawn it detached -
+/// the task will be spawned when the wrapper temporary is destroyed:
+/// `spawn(task_void()).with_priority(1);`
+///
+/// When `run_early()` is called, the task will be spawned immediately, and you
+/// must co_await the returned awaitable later in this function. You cannot
+/// simply destroy it, as the running task will have a pointer to it.
+template <typename Result> aw_spawned_task<Result> spawn(task<Result> Task) {
   return aw_spawned_task<Result>(Task);
 }
 

--- a/include/tmc/spawn_task.hpp
+++ b/include/tmc/spawn_task.hpp
@@ -117,8 +117,7 @@ public:
   /// Submits the wrapped task immediately, without suspending the current
   /// coroutine. You must await the return type before destroying it.
   ///
-  /// This is not how you spawn a task in a detached state! For that, just call
-  /// spawn() and discard the return value.
+  /// This cannot be used to spawn the task in a detached state.
   inline aw_run_early<Result, Result> run_early() {
     did_await = true; // prevent this from posting afterward
     return aw_run_early<Result, Result>(

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -164,6 +164,10 @@ template <typename Result>
 struct task : std::coroutine_handle<detail::task_promise<Result>> {
   using result_type = Result;
   using promise_type = detail::task_promise<Result>;
+
+  /// Suspend the outer coroutine and run this task directly. The intermediate
+  /// awaitable type `aw_task` cannot be used directly; the return type of the
+  /// `co_await` expression will be `Result` or `void`.
   aw_task<Result> operator co_await() { return aw_task<Result>(*this); }
 
   /// When this task completes, the awaiting coroutine will be resumed


### PR DESCRIPTION
These constraints were causing problems for the Doxygen / Sphinx / Breathe documentation stack. They aren't necessary, as they can be replaced by a primary template + single specialization for `void`. Now, both specializations can be emitted in the docs.

This also has the added advantage of allowing the compiler to understand the `void` specialization more thoroughly, even if all of the functions aren't used. This revealed a bug in the resume_on implementation of spawn_func which has been resolved as part of this PR, in 033ddaf59ad7b81ab87fa8dae8d6f2844b11313c.