### PR TITLE
perf: default-initialize thread local variables

### DIFF
--- a/include/tmc/detail/thread_locals.hpp
+++ b/include/tmc/detail/thread_locals.hpp
@@ -66,7 +66,7 @@ public:
 };
 
 struct running_task_data {
-  size_t prio = 0;
+  size_t prio;
   // pointer to single element
   // this is used both for yielding, and for determining whether spawn_many
   // tasks may symmetric transfer
@@ -74,8 +74,8 @@ struct running_task_data {
 };
 namespace this_thread { // namespace reserved for thread_local variables
 inline thread_local type_erased_executor* executor = nullptr;
-inline thread_local running_task_data this_task;
-inline thread_local std::string thread_name;
+inline thread_local running_task_data this_task = {0, nullptr};
+inline thread_local std::string thread_name{};
 inline thread_local void* producers = nullptr;
 } // namespace this_thread
 } // namespace detail


### PR DESCRIPTION
By initializing all thread-local variables where they are declared, clang is able to omit static initialization checks throughout the code.

Although these are very predictable branches (thus not having a large direct impact on perf), removing these instructions reduces the size of certain functions and allows the compiler to more aggressively inline (`mt1_continuation_resumer::await_suspend` is inlined). This improves perf of skynet by 10% on Ryzen 5950X and 17% on EPYC 7742, and fib by 6% on Ryzen 5950X and 9% on EPYC 7742.

A future PR will explore where it may be judicious to use `force_inline` for certain library functions. However the functions that are being inlined here are mostly await_suspends and we need to be careful no functions are inlined that trigger any of the outstanding bugs in clang - some of which were resolved by automatically marking await_suspends as `noinline`. References:
https://github.com/llvm/llvm-project/issues/65018
https://github.com/llvm/llvm-project/issues/65054
https://github.com/llvm/llvm-project/issues/72006
https://github.com/llvm/llvm-project/issues/64933
https://github.com/llvm/llvm-project/issues/64945

So for this PR we will just allow the compiler to do its default behavior and inline whatever it feels is safe.