### PR TITLE
Documentation-related changes

### DIFF
--- a/include/tmc/detail/aw_run_early.hpp
+++ b/include/tmc/detail/aw_run_early.hpp
@@ -103,7 +103,7 @@ public:
       return true;
     }
     // Resume if remaining <= 0 (worker already finished)
-    if (continuation_executor == detail::this_thread::executor) {
+    if (continuation_executor == nullptr || continuation_executor == detail::this_thread::executor) {
       return false;
     } else {
       // Need to resume on a different executor
@@ -189,7 +189,7 @@ public:
       return true;
     }
     // Resume if remaining <= 0 (worker already finished)
-    if (continuation_executor == detail::this_thread::executor) {
+    if (continuation_executor == nullptr || continuation_executor == detail::this_thread::executor) {
       return false;
     } else {
       // Need to resume on a different executor

--- a/include/tmc/detail/ex_braid.ipp
+++ b/include/tmc/detail/ex_braid.ipp
@@ -49,7 +49,7 @@ void ex_braid::thread_exit_context() {
   // individual tasks are resumed on parent according to their own priority
   // values
   detail::this_thread::this_task = stored_context;
-  detail::this_thread::executor = parent;
+  detail::this_thread::executor = parent_executor;
 }
 
 void ex_braid::post(work_item&& Item, size_t Priority) {
@@ -57,7 +57,7 @@ void ex_braid::post(work_item&& Item, size_t Priority) {
   // If someone already has the lock, we don't need to post, as they will see
   // this item in queue.
   if (!lock->is_locked()) {
-    parent->post(
+    parent_executor->post(
       std::coroutine_handle<>(try_run_loop(lock, destroyed_by_this_thread)),
       Priority
     );
@@ -68,7 +68,7 @@ ex_braid::ex_braid(detail::type_erased_executor* Parent)
     : queue(32), lock{std::make_shared<tiny_lock>()},
       destroyed_by_this_thread{new bool(false)},
       never_yield(std::numeric_limits<size_t>::max()), type_erased_this(*this),
-      parent(Parent) {}
+      parent_executor(Parent) {}
 
 ex_braid::ex_braid() : ex_braid(detail::this_thread::executor) {}
 
@@ -99,7 +99,7 @@ ex_braid::task_enter_context(std::coroutine_handle<> Outer, size_t Priority) {
   if (detail::this_thread::executor == &type_erased_this) {
     // we are already inside of try_run_loop() - don't need to do anything
     return std::noop_coroutine();
-  } else if (detail::this_thread::executor == parent) {
+  } else if (detail::this_thread::executor == parent_executor) {
     // rather than posting to exec, we can just run the queue directly
     return try_run_loop(lock, destroyed_by_this_thread);
   } else {
@@ -107,7 +107,7 @@ ex_braid::task_enter_context(std::coroutine_handle<> Outer, size_t Priority) {
     if (!lock->is_locked()) {
       // post try_run_loop to braid's parent executor
       // (don't allow braids to migrate across thread pools)
-      parent->post(
+      parent_executor->post(
         std::coroutine_handle<>(try_run_loop(lock, destroyed_by_this_thread)),
         Priority
       );

--- a/include/tmc/detail/ex_braid.ipp
+++ b/include/tmc/detail/ex_braid.ipp
@@ -39,7 +39,7 @@ void ex_braid::thread_enter_context() {
   // type_erased_this.parent = detail::this_thread::executor;
 
   // enter
-  detail::this_thread::this_task.yield_priority = &never_yield;
+  detail::this_thread::this_task.yield_priority = &detail::never_yield;
   detail::this_thread::executor = &type_erased_this;
 }
 
@@ -66,8 +66,7 @@ void ex_braid::post(work_item&& Item, size_t Priority) {
 
 ex_braid::ex_braid(detail::type_erased_executor* Parent)
     : queue(32), lock{std::make_shared<tiny_lock>()},
-      destroyed_by_this_thread{new bool(false)},
-      never_yield(std::numeric_limits<size_t>::max()), type_erased_this(this),
+      destroyed_by_this_thread{new bool(false)}, type_erased_this(this),
       parent_executor(Parent) {}
 
 ex_braid::ex_braid() : ex_braid(detail::this_thread::executor) {}

--- a/include/tmc/detail/ex_braid.ipp
+++ b/include/tmc/detail/ex_braid.ipp
@@ -67,7 +67,7 @@ void ex_braid::post(work_item&& Item, size_t Priority) {
 ex_braid::ex_braid(detail::type_erased_executor* Parent)
     : queue(32), lock{std::make_shared<tiny_lock>()},
       destroyed_by_this_thread{new bool(false)},
-      never_yield(std::numeric_limits<size_t>::max()), type_erased_this(*this),
+      never_yield(std::numeric_limits<size_t>::max()), type_erased_this(this),
       parent_executor(Parent) {}
 
 ex_braid::ex_braid() : ex_braid(detail::this_thread::executor) {}

--- a/include/tmc/detail/ex_cpu.ipp
+++ b/include/tmc/detail/ex_cpu.ipp
@@ -238,7 +238,7 @@ detail::type_erased_executor* ex_cpu::type_erased() {
 
 // Default constructor does not call init() - you need to do it afterward
 ex_cpu::ex_cpu()
-    : type_erased_this(*this), thread_stoppers{}, thread_states{nullptr},
+    : type_erased_this(this), thread_stoppers{}, thread_states{nullptr},
       task_stopper_bitsets{nullptr}, ready_task_cv{}, init_params{nullptr}
 #ifndef TMC_PRIORITY_COUNT
       ,

--- a/include/tmc/detail/thread_locals.hpp
+++ b/include/tmc/detail/thread_locals.hpp
@@ -45,7 +45,6 @@ public:
   void (*s_post_bulk)(
     void* Erased, work_item* Items, size_t Priority, size_t Count
   );
-  type_erased_executor* parent;
   inline void post(work_item&& Item, size_t Priority) {
     s_post(executor, std::move(Item), Priority);
   }

--- a/include/tmc/detail/thread_locals.hpp
+++ b/include/tmc/detail/thread_locals.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <atomic>
+#include <limits>
 #include <string>
 
 // Macro hackery to enable defines TMC_WORK_ITEM=CORO / TMC_WORK_ITEM=FUNC, etc
@@ -64,6 +65,7 @@ public:
   }
 };
 
+inline std::atomic<size_t> never_yield = std::numeric_limits<size_t>::max();
 struct running_task_data {
   size_t prio;
   // pointer to single element
@@ -73,7 +75,7 @@ struct running_task_data {
 };
 namespace this_thread { // namespace reserved for thread_local variables
 inline thread_local type_erased_executor* executor = nullptr;
-inline thread_local running_task_data this_task = {0, nullptr};
+inline thread_local running_task_data this_task = {0, &never_yield};
 inline thread_local std::string thread_name{};
 inline thread_local void* producers = nullptr;
 } // namespace this_thread

--- a/include/tmc/detail/thread_locals.hpp
+++ b/include/tmc/detail/thread_locals.hpp
@@ -52,8 +52,8 @@ public:
     s_post_bulk(executor, Items, Priority, Count);
   }
 
-  template <typename T> type_erased_executor(T& Executor) {
-    executor = &Executor;
+  template <typename T> type_erased_executor(T* Executor) {
+    executor = Executor;
     s_post = [](void* Erased, work_item&& Item, size_t Priority) {
       static_cast<T*>(Erased)->post(std::move(Item), Priority);
     };

--- a/include/tmc/ex_braid.hpp
+++ b/include/tmc/ex_braid.hpp
@@ -42,7 +42,6 @@ class ex_braid {
   // it is only w->r by one thread.
   bool* destroyed_by_this_thread;
 
-  std::atomic<size_t> never_yield;
   detail::type_erased_executor type_erased_this;
   detail::type_erased_executor* parent_executor;
   detail::running_task_data stored_context;

--- a/include/tmc/ex_braid.hpp
+++ b/include/tmc/ex_braid.hpp
@@ -44,7 +44,7 @@ class ex_braid {
 
   std::atomic<size_t> never_yield;
   detail::type_erased_executor type_erased_this;
-  detail::type_erased_executor* parent;
+  detail::type_erased_executor* parent_executor;
   detail::running_task_data stored_context;
 
   /// The main loop of the braid; only 1 thread is allowed to enter the inner
@@ -78,7 +78,7 @@ public:
   void post_bulk(It Items, size_t Priority, size_t Count) {
     queue.enqueue_bulk(Items, Count);
     if (!lock->is_locked()) {
-      parent->post(
+      parent_executor->post(
         std::coroutine_handle<>(try_run_loop(lock, destroyed_by_this_thread)),
         Priority
       );

--- a/include/tmc/ex_braid.hpp
+++ b/include/tmc/ex_braid.hpp
@@ -44,6 +44,7 @@ class ex_braid {
 
   std::atomic<size_t> never_yield;
   detail::type_erased_executor type_erased_this;
+  detail::type_erased_executor* parent;
   detail::running_task_data stored_context;
 
   /// The main loop of the braid; only 1 thread is allowed to enter the inner
@@ -77,7 +78,7 @@ public:
   void post_bulk(It Items, size_t Priority, size_t Count) {
     queue.enqueue_bulk(Items, Count);
     if (!lock->is_locked()) {
-      type_erased_this.parent->post(
+      parent->post(
         std::coroutine_handle<>(try_run_loop(lock, destroyed_by_this_thread)),
         Priority
       );

--- a/include/tmc/spawn_func.hpp
+++ b/include/tmc/spawn_func.hpp
@@ -73,7 +73,7 @@ public:
     executor->post(
       [this, Outer, continuation_executor]() {
         result = wrapped();
-        if (continuation_executor == detail::this_thread::executor) {
+        if (continuation_executor == nullptr || continuation_executor == detail::this_thread::executor) {
           Outer.resume();
         } else {
           continuation_executor->post(
@@ -194,7 +194,7 @@ public:
     executor->post(
       [this, Outer, continuation_executor]() {
         wrapped();
-        if (continuation_executor == detail::this_thread::executor) {
+        if (continuation_executor == nullptr || continuation_executor == detail::this_thread::executor) {
           Outer.resume();
         } else {
           continuation_executor->post(

--- a/include/tmc/spawn_func.hpp
+++ b/include/tmc/spawn_func.hpp
@@ -25,11 +25,12 @@ template <typename Result> class aw_spawned_func;
 ///
 /// If `Result` is void, you also have the option to spawn it detached -
 /// the task will be spawned when the wrapper temporary is destroyed:
-/// `spawn(task_void()).with_priority(1);`
-template <typename Result, typename... Arguments>
-aw_spawned_func<Result>
-spawn(std::function<Result(Arguments...)> Func, Arguments... Args) {
-  return aw_spawned_func<Result>(std::bind(Func, Args...));
+template <typename Func, typename... Arguments>
+auto spawn(Func&& func, Arguments&&... args)
+  -> aw_spawned_func<decltype(func(args...))> {
+  return aw_spawned_func<decltype(func(args...))>(
+    std::bind(std::forward<Func>(func), std::forward<Arguments>(args)...)
+  );
 }
 
 template <typename Result>

--- a/include/tmc/spawn_task_many.hpp
+++ b/include/tmc/spawn_task_many.hpp
@@ -20,10 +20,10 @@ namespace tmc {
 ///
 /// Submits `Count` items to the executor.
 template <
-  size_t Count, typename Iter,
-  typename Result = typename std::iter_value_t<Iter>::result_type>
-aw_task_many<Result, Count> spawn_many(Iter TaskIterator)
-  requires(std::is_convertible_v<std::iter_value_t<Iter>, task<Result>>)
+  size_t Count, typename TaskIter,
+  typename Result = typename std::iter_value_t<TaskIter>::result_type>
+aw_task_many<Result, Count> spawn_many(TaskIter TaskIterator)
+  requires(std::is_convertible_v<std::iter_value_t<TaskIter>, task<Result>>)
 {
   static_assert(Count != 0);
   return aw_task_many<Result, Count>(TaskIterator);
@@ -36,9 +36,10 @@ aw_task_many<Result, Count> spawn_many(Iter TaskIterator)
 ///
 /// Submits `count` items to the executor.
 template <
-  size_t Count, typename Iter, typename Functor = std::iter_value_t<Iter>,
+  size_t Count, typename FuncIter,
+  typename Functor = std::iter_value_t<FuncIter>,
   typename Result = std::invoke_result_t<Functor>>
-aw_task_many<Result, Count> spawn_many(Iter FunctorIterator)
+aw_task_many<Result, Count> spawn_many(FuncIter FunctorIterator)
   requires(
     std::is_invocable_r_v<Result, Functor> && (!requires {
       typename Functor::result_type;
@@ -56,10 +57,10 @@ aw_task_many<Result, Count> spawn_many(Iter FunctorIterator)
 ///
 /// Submits `count` items to the executor.
 template <
-  typename Iter,
-  typename Result = typename std::iter_value_t<Iter>::result_type>
-aw_task_many<Result, 0> spawn_many(Iter TaskIterator, size_t TaskCount)
-  requires(std::is_convertible_v<std::iter_value_t<Iter>, task<Result>>)
+  typename TaskIter,
+  typename Result = typename std::iter_value_t<TaskIter>::result_type>
+aw_task_many<Result, 0> spawn_many(TaskIter TaskIterator, size_t TaskCount)
+  requires(std::is_convertible_v<std::iter_value_t<TaskIter>, task<Result>>)
 {
   return aw_task_many<Result, 0>(TaskIterator, TaskCount);
 }
@@ -71,9 +72,10 @@ aw_task_many<Result, 0> spawn_many(Iter TaskIterator, size_t TaskCount)
 ///
 /// Submits `count` items to the executor.
 template <
-  typename Iter, typename Functor = std::iter_value_t<Iter>,
+  typename FuncIter, typename Functor = std::iter_value_t<FuncIter>,
   typename Result = std::invoke_result_t<Functor>>
-aw_task_many<Result, 0> spawn_many(Iter FunctorIterator, size_t FunctorCount)
+aw_task_many<Result, 0>
+spawn_many(FuncIter FunctorIterator, size_t FunctorCount)
   requires(
     std::is_invocable_r_v<Result, Functor> && (!requires {
       typename Functor::result_type;

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -229,26 +229,26 @@ public:
 };
 
 /// Submits `Coro` for execution on `Executor` at priority `Priority`.
-template <typename E, typename T>
-void post(E& Executor, T&& Coro, size_t Priority)
-  requires(std::is_convertible_v<T, std::coroutine_handle<>>)
+template <typename E, typename C>
+void post(E& Executor, C&& Coro, size_t Priority)
+  requires(std::is_convertible_v<C, std::coroutine_handle<>>)
 {
-  Executor.post(std::coroutine_handle<>(std::forward<T>(Coro)), Priority);
+  Executor.post(std::coroutine_handle<>(std::forward<C>(Coro)), Priority);
 }
 
 #if WORK_ITEM_IS(CORO)
 /// Submits void-returning `Func` for execution on `Executor` at priority
 /// `Priority`. Functions that return values cannot be submitted this way; see
 /// `post_waitable` instead.
-template <typename E, typename T>
-void post(E& Executor, T&& Func, size_t Priority)
-  requires(!std::is_convertible_v<T, std::coroutine_handle<>> && std::is_void_v<std::invoke_result_t<T>>)
+template <typename E, typename F>
+void post(E& Executor, F&& Func, size_t Priority)
+  requires(!std::is_convertible_v<F, std::coroutine_handle<>> && std::is_void_v<std::invoke_result_t<F>>)
 {
   Executor.post(
-    std::coroutine_handle<>([](T t) -> task<void> {
+    std::coroutine_handle<>([](F t) -> task<void> {
       t();
       co_return;
-    }(std::forward<T>(Func))),
+    }(std::forward<F>(Func))),
     Priority
   );
 }
@@ -256,11 +256,11 @@ void post(E& Executor, T&& Func, size_t Priority)
 /// Submits void-returning `Func` for execution on `Executor` at priority
 /// `Priority`. Functions that return values cannot be submitted this way; see
 /// `post_waitable` instead.
-template <typename E, typename T>
-void post(E& Executor, T&& Func, size_t Priority)
-  requires(!std::is_convertible_v<T, std::coroutine_handle<>> && std::is_void_v<std::invoke_result_t<T>>)
+template <typename E, typename F>
+void post(E& Executor, F&& Func, size_t Priority)
+  requires(!std::is_convertible_v<F, std::coroutine_handle<>> && std::is_void_v<std::invoke_result_t<F>>)
 {
-  Executor.post(std::forward<T>(Func), Priority);
+  Executor.post(std::forward<F>(Func), Priority);
 }
 #endif
 

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -46,7 +46,7 @@ template <typename Result> struct mt1_continuation_resumer {
         std::coroutine_handle<>::from_address(rawContinuation);
       std::coroutine_handle<> next;
       if (continuation) {
-        if (this_thread::executor == p.continuation_executor) {
+        if (p.continuation_executor == nullptr || p.continuation_executor == this_thread::executor) {
           next = continuation;
         } else {
           static_cast<detail::type_erased_executor*>(p.continuation_executor)
@@ -72,7 +72,7 @@ template <typename Result> struct mt1_continuation_resumer {
           detail::type_erased_executor* continuationExecutor =
             *static_cast<detail::type_erased_executor**>(p.continuation_executor
             );
-          if (this_thread::executor == continuationExecutor) {
+          if (continuationExecutor == nullptr || continuationExecutor == this_thread::executor) {
             next = continuation;
           } else {
             continuationExecutor->post(
@@ -91,10 +91,8 @@ template <typename Result> struct mt1_continuation_resumer {
     }
   }
 };
-
-template <typename Result> struct task_promise;
-
 } // namespace detail
+
 template <typename Result> class aw_task;
 
 /// The main coroutine type used by TooManyCooks. `task` is a lazy / cold

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -212,18 +212,18 @@ public:
 };
 
 template <> class aw_task<void> {
-  task<void> inner;
+  task<void> handle;
 
   friend struct task<void>;
-  constexpr aw_task(const task<void>& Handle) : inner(Handle) {}
+  constexpr aw_task(const task<void>& Handle) : handle(Handle) {}
 
 public:
-  bool await_ready() const noexcept { return inner.done(); }
+  bool await_ready() const noexcept { return handle.done(); }
   std::coroutine_handle<> await_suspend(std::coroutine_handle<> Outer
   ) const noexcept {
-    auto& p = inner.promise();
+    auto& p = handle.promise();
     p.continuation = Outer.address();
-    return inner;
+    return handle;
   }
   constexpr void await_resume() const noexcept {}
 };


### PR DESCRIPTION
### Documentation-Related Changes:
- Give similar template functions unique template parameter names (e.g. FuncIter and TaskIter instead of both being called Iter) so that Sphinx can disambiguate them.

### Other:
- Allow symmetric transfer if continuation_executor == nullptr. This allows tasks created by external threads to continue seamlessly inside TMC.
- Shrink type_erased_executor
- Template FunctorIterator instead of requiring it to be a pointer
- Template spawn_func instead of requiring std::function parameter