### PR TITLE
Implement safe_await_external()

### DIFF
--- a/include/tmc/aw_resume_on.hpp
+++ b/include/tmc/aw_resume_on.hpp
@@ -186,4 +186,9 @@ template <typename E> inline aw_ex_scope_enter<E> enter(E& Executor) {
 template <typename E> inline aw_ex_scope_enter<E> enter(E* Executor) {
   return aw_ex_scope_enter<E>(*Executor);
 }
+/// Returns a pointer to the current thread's executor. Will
+/// return nullptr if this thread is not associated with an executor.
+inline detail::type_erased_executor* current_executor() {
+  return detail::this_thread::executor;
+}
 } // namespace tmc

--- a/include/tmc/aw_yield.hpp
+++ b/include/tmc/aw_yield.hpp
@@ -158,4 +158,7 @@ public:
 template <int64_t N> inline aw_yield_counter<N> check_yield_counter() {
   return aw_yield_counter<N>();
 }
+
+/// Returns the current task's priority.
+inline size_t current_priority() { return detail::this_thread::this_task.prio; }
 } // namespace tmc

--- a/include/tmc/spawn_task.hpp
+++ b/include/tmc/spawn_task.hpp
@@ -111,8 +111,6 @@ public:
 
   /// Submits the wrapped task immediately, without suspending the current
   /// coroutine. You must await the return type before destroying it.
-  ///
-  /// This cannot be used to spawn the task in a detached state.
   inline aw_run_early<Result, Result> run_early() {
     return aw_run_early<Result, Result>(
       std::move(wrapped), prio, executor, continuation_executor
@@ -221,10 +219,7 @@ public:
   }
 
   /// Submits the wrapped task immediately, without suspending the current
-  /// coroutine. You must await the return type before destroying it.
-  ///
-  /// This is not how you spawn a task in a detached state! For that, just call
-  /// spawn() and discard the return value.
+  /// coroutine. You must await the returned before destroying it.
   inline aw_run_early<void, void> run_early() {
     return aw_run_early<void, void>(
       std::move(wrapped), prio, executor, continuation_executor
@@ -232,24 +227,12 @@ public:
   }
 };
 
-/// spawn() creates a task wrapper that allows you to customize a task, by
-/// calling `run_on()`, `resume_on()`, `with_priority()`, and/or `run_early()`
-/// before the task is spawned.
+/// `spawn()` allows you to customize the execution behavior of a task.
 ///
-/// If `Result` is non-void, the task will be spawned when the the wrapper is
-/// co_await'ed:
-/// `auto result = co_await spawn(task_result()).with_priority(1);`
-///
-/// If `Result` is void, you can do the same thing:
-/// `co_await spawn(task_void()).with_priority(1);`
-///
-/// If `Result` is void, you also have the option to spawn it detached -
-/// the task will be spawned when the wrapper temporary is destroyed:
-/// `spawn(task_void()).with_priority(1);`
-///
-/// When `run_early()` is called, the task will be spawned immediately, and you
-/// must co_await the returned awaitable later in this function. You cannot
-/// simply destroy it, as the running task will have a pointer to it.
+/// Before the task is submitted for execution, you may call any or all of
+/// `run_on()`, `resume_on()`, `with_priority()`. The task must then be
+/// submitted for execution by calling exactly one of: `co_await`, `run_early()`
+/// or `detach()`.
 template <typename Result> aw_spawned_task<Result> spawn(task<Result>&& Task) {
   return aw_spawned_task<Result>(std::move(Task));
 }

--- a/include/tmc/spawn_task_many.hpp
+++ b/include/tmc/spawn_task_many.hpp
@@ -34,7 +34,7 @@ aw_task_many<Result, Count> spawn_many(TaskIter TaskIterator)
 /// `Functor` must be a copyable type that implements `Result operator()`.
 /// `FunctorIterator` must be a pointer to an array of `Functor`.
 ///
-/// Submits `count` items to the executor.
+/// Submits `Count` items to the executor.
 template <
   size_t Count, typename FuncIter,
   typename Functor = std::iter_value_t<FuncIter>,
@@ -55,7 +55,7 @@ aw_task_many<Result, Count> spawn_many(FuncIter FunctorIterator)
 /// `It& operator++()`.
 /// `TaskCount` must be non-zero.
 ///
-/// Submits `count` items to the executor.
+/// Submits `TaskCount` items to the executor.
 template <
   typename TaskIter,
   typename Result = typename std::iter_value_t<TaskIter>::result_type>
@@ -70,7 +70,7 @@ aw_task_many<Result, 0> spawn_many(TaskIter TaskIterator, size_t TaskCount)
 /// `FunctorIterator` must be a pointer to an array of `Functor`.
 /// `FunctorCount` must be non-zero.
 ///
-/// Submits `count` items to the executor.
+/// Submits `FunctorCount` items to the executor.
 template <
   typename FuncIter, typename Functor = std::iter_value_t<FuncIter>,
   typename Result = std::invoke_result_t<Functor>>
@@ -340,12 +340,6 @@ public:
 
   /// Submits the wrapped tasks immediately, without suspending the current
   /// coroutine. You must await the return type before destroying it.
-  ///
-  /// This is not how you spawn a task in a detached state! For that, just call
-  /// spawn_many() and discard the return value.
-  ///
-  /// (You cannot spawn tasks that return non-void `Result` in a detached
-  /// state; if the task returns a value, you must consume it).
   inline aw_run_early<Result, ResultArray> run_early() {
     return aw_run_early<Result, ResultArray>(std::move(*this));
   }
@@ -582,9 +576,6 @@ public:
 
   /// Submits the wrapped task immediately, without suspending the current
   /// coroutine. You must await the return type before destroying it.
-  ///
-  /// This is not how you spawn a task in a detached state! For that, just call
-  /// spawn() and discard the return value.
   inline aw_run_early<void, void> run_early() {
     return aw_run_early<void, void>(std::move(*this));
   }


### PR DESCRIPTION
Create the `safe_await_external()` function that allows an external awaitable to be safely awaited, and restores the awaiting task back to the original TMC executor / priority afterward.

Other Changes:
Doc comments cleanup
Add `resume_on().with_priority()` and `change_priority()` functions
Add `current_executor()` and `current_priority()` functions
Block `task<Result>` from being directly `post()`ed (this was always wrong to do but not enforced by the lib)