### PR TITLE
Awaitables as linear types / performance improvements

### DIFF
--- a/include/tmc/aw_resume_on.hpp
+++ b/include/tmc/aw_resume_on.hpp
@@ -34,7 +34,9 @@ public:
 
   /// When awaited, the outer coroutine will be resumed with the provided
   /// priority.
-  inline aw_resume_on& with_priority(size_t Priority) {
+  [[nodiscard("You must co_await aw_resume_on for it to have any "
+              "effect.")]] inline aw_resume_on&
+  with_priority(size_t Priority) {
     // For this to work correctly, we must change the priority of the executor
     // thread by posting the task to the executor with the new priority.
     // Directly changing detail::.this_thread::this_task.prio is insufficient,

--- a/include/tmc/aw_resume_on.hpp
+++ b/include/tmc/aw_resume_on.hpp
@@ -25,7 +25,8 @@ public:
   }
 
   /// Post the outer task to the requested executor.
-  inline void await_suspend(std::coroutine_handle<> Outer) const noexcept {
+  TMC_FORCE_INLINE inline void await_suspend(std::coroutine_handle<> Outer
+  ) const noexcept {
     executor->post(std::move(Outer), prio);
   }
 
@@ -104,7 +105,7 @@ public:
   constexpr bool await_ready() { return false; }
 
   /// Post this task to the continuation executor.
-  inline void await_suspend(std::coroutine_handle<> Outer) {
+  TMC_FORCE_INLINE inline void await_suspend(std::coroutine_handle<> Outer) {
     continuation_executor->post(std::move(Outer), prio);
   }
 
@@ -166,7 +167,8 @@ public:
   }
 
   /// Switch this task to the target executor.
-  inline std::coroutine_handle<> await_suspend(std::coroutine_handle<> Outer) {
+  TMC_FORCE_INLINE inline std::coroutine_handle<>
+  await_suspend(std::coroutine_handle<> Outer) {
     return scope_executor.task_enter_context(Outer, prio);
   }
 

--- a/include/tmc/aw_resume_on.hpp
+++ b/include/tmc/aw_resume_on.hpp
@@ -35,6 +35,10 @@ public:
   /// When awaited, the outer coroutine will be resumed with the provided
   /// priority.
   inline aw_resume_on& with_priority(size_t Priority) {
+    // For this to work correctly, we must change the priority of the executor
+    // thread by posting the task to the executor with the new priority.
+    // Directly changing detail::.this_thread::this_task.prio is insufficient,
+    // as it doesn't update the task_stopper_bitsets.
     prio = Priority;
     return *this;
   }

--- a/include/tmc/aw_yield.hpp
+++ b/include/tmc/aw_yield.hpp
@@ -21,7 +21,8 @@ public:
 
   /// Post the outer task to its current executor, so that a higher priority
   /// task can run.
-  inline void await_suspend(std::coroutine_handle<> Outer) const noexcept {
+  TMC_FORCE_INLINE inline void await_suspend(std::coroutine_handle<> Outer
+  ) const noexcept {
     detail::this_thread::executor->post(
       std::move(Outer), detail::this_thread::this_task.prio
     );
@@ -45,7 +46,8 @@ public:
 
   /// Post the outer task to its current executor, so that a higher priority
   /// task can run.
-  inline void await_suspend(std::coroutine_handle<> Outer) const noexcept {
+  TMC_FORCE_INLINE inline void await_suspend(std::coroutine_handle<> Outer
+  ) const noexcept {
     detail::this_thread::executor->post(
       std::move(Outer), detail::this_thread::this_task.prio
     );
@@ -91,7 +93,8 @@ public:
 
   /// Post the outer task to its current executor, so that a higher priority
   /// task can run.
-  inline void await_suspend(std::coroutine_handle<> Outer) const noexcept {
+  TMC_FORCE_INLINE inline void await_suspend(std::coroutine_handle<> Outer
+  ) const noexcept {
     detail::this_thread::executor->post(
       std::move(Outer), detail::this_thread::this_task.prio
     );
@@ -137,7 +140,8 @@ public:
 
   /// Post the outer task to its current executor, so that a higher priority
   /// task can run.
-  inline void await_suspend(std::coroutine_handle<> Outer) const noexcept {
+  TMC_FORCE_INLINE inline void await_suspend(std::coroutine_handle<> Outer
+  ) const noexcept {
     detail::this_thread::executor->post(
       std::move(Outer), detail::this_thread::this_task.prio
     );

--- a/include/tmc/detail/aw_run_early.hpp
+++ b/include/tmc/detail/aw_run_early.hpp
@@ -15,297 +15,301 @@ namespace tmc {
 template <typename Result> class aw_spawned_task;
 /// The customizable task wrapper / awaitable type returned by
 /// `tmc::spawn_many(tmc::task<Result>)`.
-template <typename Result, size_t Count> class aw_task_many;
+template <typename Result, size_t Count, typename Iter> class aw_task_many;
 
-/// A wrapper that converts lazy task(s) to eager task(s),
-/// and allows the task(s) to be awaited after it has been started.
-/// It is created by calling run_early() on a parent awaitable
-/// from spawn() or spawn_many().
-///
-/// `Result` is the type of a single result value (same as that of the wrapped
-/// `task<Result>`).
-///
-/// `Output` may be a `Result`, `std::vector<Result>`,
-/// or `std::array<Result, Count>` depending on what type of awaitable this
-/// was created from.
-template <typename Result, typename Output>
-class [[nodiscard("You must co_await aw_run_early. "
-                  "It is not safe to destroy aw_run_early without first "
-                  "awaiting it.")]] aw_run_early;
+// /// A wrapper that converts lazy task(s) to eager task(s),
+// /// and allows the task(s) to be awaited after it has been started.
+// /// It is created by calling run_early() on a parent awaitable
+// /// from spawn() or spawn_many().
+// ///
+// /// `Result` is the type of a single result value (same as that of the
+// wrapped
+// /// `task<Result>`).
+// ///
+// /// `Output` may be a `Result`, `std::vector<Result>`,
+// /// or `std::array<Result, Count>` depending on what type of awaitable this
+// /// was created from.
+// template <typename Result, typename Output>
+// class [[nodiscard("You must co_await aw_run_early. "
+//                   "It is not safe to destroy aw_run_early without first "
+//                   "awaiting it.")]] aw_run_early;
 
-template <typename Result, typename Output, bool RValue>
-class aw_run_early_impl;
+// template <typename Result, typename Output, bool RValue>
+// class aw_run_early_impl;
 
-template <typename Result, typename Output, bool RValue>
-class aw_run_early_impl {
-  aw_run_early<Result, Output>& me;
-  friend aw_run_early<Result, Output>;
-  aw_run_early_impl(aw_run_early<Result, Output>& Me);
+// template <typename Result, typename Output, bool RValue>
+// class aw_run_early_impl {
+//   aw_run_early<Result, Output>& me;
+//   friend aw_run_early<Result, Output>;
+//   aw_run_early_impl(aw_run_early<Result, Output>& Me);
 
-public:
-  /// Always suspends.
-  inline bool await_ready() const noexcept;
+// public:
+//   /// Always suspends.
+//   inline bool await_ready() const noexcept;
 
-  /// Suspends the outer coroutine, submits the wrapped task to the
-  /// executor, and waits for it to complete.
-  inline bool await_suspend(std::coroutine_handle<> Outer) noexcept;
+//   /// Suspends the outer coroutine, submits the wrapped task to the
+//   /// executor, and waits for it to complete.
+//   inline bool await_suspend(std::coroutine_handle<> Outer) noexcept;
 
-  /// Returns the value provided by the wrapped task.
-  inline Output& await_resume() noexcept
-    requires(!RValue);
+//   /// Returns the value provided by the wrapped task.
+//   inline Output& await_resume() noexcept
+//     requires(!RValue);
 
-  /// Returns the value provided by the wrapped task.
-  inline Output&& await_resume() noexcept
-    requires(RValue);
-};
+//   /// Returns the value provided by the wrapped task.
+//   inline Output&& await_resume() noexcept
+//     requires(RValue);
+// };
 
-template <> class aw_run_early_impl<void, void, false> {
-  aw_run_early<void, void>& me;
-  friend aw_run_early<void, void>;
+// template <> class aw_run_early_impl<void, void, false> {
+//   aw_run_early<void, void>& me;
+//   friend aw_run_early<void, void>;
 
-  inline aw_run_early_impl(aw_run_early<void, void>& Me);
+//   inline aw_run_early_impl(aw_run_early<void, void>& Me);
 
-public:
-  /// Always suspends.
-  inline bool await_ready() const noexcept;
+// public:
+//   /// Always suspends.
+//   inline bool await_ready() const noexcept;
 
-  /// Suspends the outer coroutine, submits the wrapped task to the
-  /// executor, and waits for it to complete.
-  inline bool await_suspend(std::coroutine_handle<> Outer) noexcept;
+//   /// Suspends the outer coroutine, submits the wrapped task to the
+//   /// executor, and waits for it to complete.
+//   inline bool await_suspend(std::coroutine_handle<> Outer) noexcept;
 
-  /// Does nothing.
-  inline void await_resume() noexcept;
-};
+//   /// Does nothing.
+//   inline void await_resume() noexcept;
+// };
 
-template <typename Result, typename Output> class aw_run_early {
-  friend class aw_spawned_task<Result>;
-  template <typename R, size_t Count> friend class aw_task_many;
-  friend class aw_run_early_impl<Result, Output, true>;
-  friend class aw_run_early_impl<Result, Output, false>;
-  std::coroutine_handle<> continuation;
-  detail::type_erased_executor* continuation_executor;
-  Output result;
-  std::atomic<int64_t> done_count;
+// template <typename Result, typename Output> class aw_run_early {
+//   friend class aw_spawned_task<Result>;
+//   template <typename R, size_t Count> friend class aw_task_many;
+//   friend class aw_run_early_impl<Result, Output, true>;
+//   friend class aw_run_early_impl<Result, Output, false>;
+//   std::coroutine_handle<> continuation;
+//   detail::type_erased_executor* continuation_executor;
+//   Output result;
+//   std::atomic<int64_t> done_count;
 
-  // Private constructor from aw_spawned_task. Takes ownership of parent's
-  // task.
-  aw_run_early(
-    task<Result>&& Task, size_t Priority,
-    detail::type_erased_executor* Executor,
-    detail::type_erased_executor* ContinuationExecutor
-  )
-      : continuation{nullptr}, continuation_executor(ContinuationExecutor),
-        done_count(1) {
-    auto& p = Task.promise();
-    p.continuation = &continuation;
-    p.continuation_executor = &continuation_executor;
-    p.result_ptr = &result;
-    p.done_count = &done_count;
-    // TODO fence maybe not required if there's one inside the queue?
-    std::atomic_thread_fence(std::memory_order_release);
-    Executor->post(std::move(Task), Priority);
-  }
+//   // Private constructor from aw_spawned_task. Takes ownership of parent's
+//   // task.
+//   aw_run_early(
+//     task<Result>&& Task, size_t Priority,
+//     detail::type_erased_executor* Executor,
+//     detail::type_erased_executor* ContinuationExecutor
+//   )
+//       : continuation{nullptr}, continuation_executor(ContinuationExecutor),
+//         done_count(1) {
+//     auto& p = Task.promise();
+//     p.continuation = &continuation;
+//     p.continuation_executor = &continuation_executor;
+//     p.result_ptr = &result;
+//     p.done_count = &done_count;
+//     // TODO fence maybe not required if there's one inside the queue?
+//     std::atomic_thread_fence(std::memory_order_release);
+//     Executor->post(std::move(Task), Priority);
+//   }
 
-  // Private constructor from aw_task_many. Takes ownership of parent's tasks.
-  // For use when count is runtime dynamic - take ownership of parent's result
-  // vector.
-  template <size_t Count> aw_run_early(aw_task_many<Result, Count>&& Parent) {
-    continuation_executor = Parent.continuation_executor;
-    if constexpr (std::is_same_v<Output, std::vector<Result>>) {
-      result = std::move(Parent.result);
-    }
-    const auto size = Parent.wrapped.size();
-    for (size_t i = 0; i < size; ++i) {
-      auto& p = detail::unsafe_task<Result>::from_address(
-                  TMC_WORK_ITEM_AS_STD_CORO(Parent.wrapped[i]).address()
-      )
-                  .promise();
-      p.continuation = &continuation;
-      p.continuation_executor = &continuation_executor;
-      p.done_count = &done_count;
-      p.result_ptr = &result[i];
-    }
-    done_count.store(static_cast<int64_t>(size), std::memory_order_release);
-    Parent.executor->post_bulk(Parent.wrapped.data(), Parent.prio, size);
-    Parent.did_await = true;
-  }
+//   // Private constructor from aw_task_many. Takes ownership of parent's
+//   tasks.
+//   // For use when count is runtime dynamic - take ownership of parent's
+//   result
+//   // vector.
+//   template <size_t Count> aw_run_early(aw_task_many<Result, Count>&& Parent)
+//   {
+//     continuation_executor = Parent.continuation_executor;
+//     if constexpr (std::is_same_v<Output, std::vector<Result>>) {
+//       result = std::move(Parent.result);
+//     }
+//     const auto size = Parent.wrapped.size();
+//     for (size_t i = 0; i < size; ++i) {
+//       auto& p = detail::unsafe_task<Result>::from_address(
+//                   TMC_WORK_ITEM_AS_STD_CORO(Parent.wrapped[i]).address()
+//       )
+//                   .promise();
+//       p.continuation = &continuation;
+//       p.continuation_executor = &continuation_executor;
+//       p.done_count = &done_count;
+//       p.result_ptr = &result[i];
+//     }
+//     done_count.store(static_cast<int64_t>(size), std::memory_order_release);
+//     Parent.executor->post_bulk(Parent.wrapped.data(), Parent.prio, size);
+//     Parent.did_await = true;
+//   }
 
-public:
-  aw_run_early_impl<Result, Output, false> operator co_await() & {
-    return aw_run_early_impl<Result, Output, false>(*this);
-  }
+// public:
+//   aw_run_early_impl<Result, Output, false> operator co_await() & {
+//     return aw_run_early_impl<Result, Output, false>(*this);
+//   }
 
-  aw_run_early_impl<Result, Output, true> operator co_await() && {
-    return aw_run_early_impl<Result, Output, true>(*this);
-  }
+//   aw_run_early_impl<Result, Output, true> operator co_await() && {
+//     return aw_run_early_impl<Result, Output, true>(*this);
+//   }
 
-  // This must be awaited and the child task completed before destruction.
-  ~aw_run_early() noexcept { assert(done_count.load() < 0); }
+//   // This must be awaited and the child task completed before destruction.
+//   ~aw_run_early() noexcept { assert(done_count.load() < 0); }
 
-  // Not movable or copyable due to child task being spawned in constructor,
-  // and having pointers to this.
-  aw_run_early& operator=(const aw_run_early& other) = delete;
-  aw_run_early(const aw_run_early& other) = delete;
-  aw_run_early& operator=(const aw_run_early&& other) = delete;
-  aw_run_early(const aw_run_early&& other) = delete;
-};
+//   // Not movable or copyable due to child task being spawned in constructor,
+//   // and having pointers to this.
+//   aw_run_early& operator=(const aw_run_early& other) = delete;
+//   aw_run_early(const aw_run_early& other) = delete;
+//   aw_run_early& operator=(const aw_run_early&& other) = delete;
+//   aw_run_early(const aw_run_early&& other) = delete;
+// };
 
-template <> class aw_run_early<void, void> {
-  friend class aw_spawned_task<void>;
-  friend class aw_run_early_impl<void, void, false>;
-  template <typename R, size_t Count> friend class aw_task_many;
-  std::coroutine_handle<> continuation;
-  detail::type_erased_executor* continuation_executor;
-  std::atomic<int64_t> done_count;
+// template <> class aw_run_early<void, void> {
+//   friend class aw_spawned_task<void>;
+//   friend class aw_run_early_impl<void, void, false>;
+//   template <typename R, size_t Count> friend class aw_task_many;
+//   std::coroutine_handle<> continuation;
+//   detail::type_erased_executor* continuation_executor;
+//   std::atomic<int64_t> done_count;
 
-  // Private constructor from aw_spawned_task. Takes ownership of parent's
-  // task.
-  aw_run_early(
-    task<void>&& Task, size_t Priority, detail::type_erased_executor* Executor,
-    detail::type_erased_executor* ContinuationExecutor
-  )
-      : continuation{nullptr}, continuation_executor(ContinuationExecutor),
-        done_count(1) {
-    auto& p = Task.promise();
-    p.continuation = &continuation;
-    p.continuation_executor = &continuation_executor;
-    p.done_count = &done_count;
-    // TODO fence maybe not required if there's one inside the queue?
-    std::atomic_thread_fence(std::memory_order_release);
-    Executor->post(std::move(Task), Priority);
-  }
+//   // Private constructor from aw_spawned_task. Takes ownership of parent's
+//   // task.
+//   aw_run_early(
+//     task<void>&& Task, size_t Priority, detail::type_erased_executor*
+//     Executor, detail::type_erased_executor* ContinuationExecutor
+//   )
+//       : continuation{nullptr}, continuation_executor(ContinuationExecutor),
+//         done_count(1) {
+//     auto& p = Task.promise();
+//     p.continuation = &continuation;
+//     p.continuation_executor = &continuation_executor;
+//     p.done_count = &done_count;
+//     // TODO fence maybe not required if there's one inside the queue?
+//     std::atomic_thread_fence(std::memory_order_release);
+//     Executor->post(std::move(Task), Priority);
+//   }
 
-  // Private constructor from aw_task_many. Takes ownership of parent's tasks.
-  template <size_t Count> aw_run_early(aw_task_many<void, Count>&& Parent) {
-    continuation_executor = Parent.continuation_executor;
-    const auto size = Parent.wrapped.size();
-    for (size_t i = 0; i < size; ++i) {
-      auto& p = detail::unsafe_task<void>::from_address(
-                  TMC_WORK_ITEM_AS_STD_CORO(Parent.wrapped[i]).address()
-      )
-                  .promise();
-      p.continuation = &continuation;
-      p.continuation_executor = &continuation_executor;
-      p.done_count = &done_count;
-    }
-    done_count.store(static_cast<int64_t>(size), std::memory_order_release);
-    Parent.executor->post_bulk(Parent.wrapped.data(), Parent.prio, size);
-    Parent.did_await = true;
-  }
+//   // Private constructor from aw_task_many. Takes ownership of parent's
+//   tasks. template <size_t Count> aw_run_early(aw_task_many<void, Count>&&
+//   Parent) {
+//     continuation_executor = Parent.continuation_executor;
+//     const auto size = Parent.wrapped.size();
+//     for (size_t i = 0; i < size; ++i) {
+//       auto& p = detail::unsafe_task<void>::from_address(
+//                   TMC_WORK_ITEM_AS_STD_CORO(Parent.wrapped[i]).address()
+//       )
+//                   .promise();
+//       p.continuation = &continuation;
+//       p.continuation_executor = &continuation_executor;
+//       p.done_count = &done_count;
+//     }
+//     done_count.store(static_cast<int64_t>(size), std::memory_order_release);
+//     Parent.executor->post_bulk(Parent.wrapped.data(), Parent.prio, size);
+//     Parent.did_await = true;
+//   }
 
-public:
-  aw_run_early_impl<void, void, false> operator co_await() {
-    return aw_run_early_impl<void, void, false>(*this);
-  }
+// public:
+//   aw_run_early_impl<void, void, false> operator co_await() {
+//     return aw_run_early_impl<void, void, false>(*this);
+//   }
 
-  // This must be awaited and the child task completed before destruction.
-  ~aw_run_early() noexcept { assert(done_count.load() < 0); }
+//   // This must be awaited and the child task completed before destruction.
+//   ~aw_run_early() noexcept { assert(done_count.load() < 0); }
 
-  // Not movable or copyable due to child task being spawned in constructor,
-  // and having pointers to this.
-  aw_run_early& operator=(const aw_run_early& Other) = delete;
-  aw_run_early(const aw_run_early& Other) = delete;
-  aw_run_early& operator=(const aw_run_early&& Other) = delete;
-  aw_run_early(const aw_run_early&& Other) = delete;
-};
+//   // Not movable or copyable due to child task being spawned in constructor,
+//   // and having pointers to this.
+//   aw_run_early& operator=(const aw_run_early& Other) = delete;
+//   aw_run_early(const aw_run_early& Other) = delete;
+//   aw_run_early& operator=(const aw_run_early&& Other) = delete;
+//   aw_run_early(const aw_run_early&& Other) = delete;
+// };
 
-template <typename Result, typename Output, bool RValue>
-aw_run_early_impl<Result, Output, RValue>::aw_run_early_impl(
-  aw_run_early<Result, Output>& Me
-)
-    : me(Me) {}
+// template <typename Result, typename Output, bool RValue>
+// aw_run_early_impl<Result, Output, RValue>::aw_run_early_impl(
+//   aw_run_early<Result, Output>& Me
+// )
+//     : me(Me) {}
 
-/// Always suspends.
-template <typename Result, typename Output, bool RValue>
-inline bool
-aw_run_early_impl<Result, Output, RValue>::await_ready() const noexcept {
-  return false;
-}
+// /// Always suspends.
+// template <typename Result, typename Output, bool RValue>
+// inline bool
+// aw_run_early_impl<Result, Output, RValue>::await_ready() const noexcept {
+//   return false;
+// }
 
-/// Suspends the outer coroutine, submits the wrapped task to the
-/// executor, and waits for it to complete.
-template <typename Result, typename Output, bool RValue>
-inline bool aw_run_early_impl<Result, Output, RValue>::await_suspend(
-  std::coroutine_handle<> Outer
-) noexcept {
-  // For unknown reasons, it doesn't work to start with done_count at 0,
-  // Then increment here and check before storing continuation...
-  me.continuation = Outer;
-  auto remaining = me.done_count.fetch_sub(1, std::memory_order_acq_rel);
-  // Worker was already posted.
-  // Suspend if remaining > 0 (worker is still running)
-  if (remaining > 0) {
-    return true;
-  }
-  // Resume if remaining <= 0 (worker already finished)
-  if (me.continuation_executor == nullptr ||
-      me.continuation_executor == detail::this_thread::executor) {
-    return false;
-  } else {
-    // Need to resume on a different executor
-    me.continuation_executor->post(
-      std::move(Outer), detail::this_thread::this_task.prio
-    );
-    return true;
-  }
+// /// Suspends the outer coroutine, submits the wrapped task to the
+// /// executor, and waits for it to complete.
+// template <typename Result, typename Output, bool RValue>
+// inline bool aw_run_early_impl<Result, Output, RValue>::await_suspend(
+//   std::coroutine_handle<> Outer
+// ) noexcept {
+//   // For unknown reasons, it doesn't work to start with done_count at 0,
+//   // Then increment here and check before storing continuation...
+//   me.continuation = Outer;
+//   auto remaining = me.done_count.fetch_sub(1, std::memory_order_acq_rel);
+//   // Worker was already posted.
+//   // Suspend if remaining > 0 (worker is still running)
+//   if (remaining > 0) {
+//     return true;
+//   }
+//   // Resume if remaining <= 0 (worker already finished)
+//   if (me.continuation_executor == nullptr ||
+//       me.continuation_executor == detail::this_thread::executor) {
+//     return false;
+//   } else {
+//     // Need to resume on a different executor
+//     me.continuation_executor->post(
+//       std::move(Outer), detail::this_thread::this_task.prio
+//     );
+//     return true;
+//   }
+// }
 
-  return (remaining > 0);
-}
+// /// Returns the value provided by the wrapped function.
+// template <typename Result, typename Output, bool RValue>
+// inline Output&
+// aw_run_early_impl<Result, Output, RValue>::await_resume() noexcept
+//   requires(!RValue)
+// {
+//   return me.result;
+// }
 
-/// Returns the value provided by the wrapped function.
-template <typename Result, typename Output, bool RValue>
-inline Output&
-aw_run_early_impl<Result, Output, RValue>::await_resume() noexcept
-  requires(!RValue)
-{
-  return me.result;
-}
+// /// Returns the value provided by the wrapped function.
+// template <typename Result, typename Output, bool RValue>
+// inline Output&&
+// aw_run_early_impl<Result, Output, RValue>::await_resume() noexcept
+//   requires(RValue)
+// {
+//   return std::move(me.result);
+// }
 
-/// Returns the value provided by the wrapped function.
-template <typename Result, typename Output, bool RValue>
-inline Output&&
-aw_run_early_impl<Result, Output, RValue>::await_resume() noexcept
-  requires(RValue)
-{
-  return std::move(me.result);
-}
+// inline aw_run_early_impl<void, void, false>::aw_run_early_impl(
+//   aw_run_early<void, void>& Me
+// )
+//     : me(Me) {}
 
-inline aw_run_early_impl<void, void, false>::aw_run_early_impl(
-  aw_run_early<void, void>& Me
-)
-    : me(Me) {}
+// inline bool aw_run_early_impl<void, void, false>::await_ready() const
+// noexcept {
+//   return false;
+// }
 
-inline bool aw_run_early_impl<void, void, false>::await_ready() const noexcept {
-  return false;
-}
+// /// Suspends the outer coroutine, submits the wrapped task to the
+// /// executor, and waits for it to complete.
+// inline bool aw_run_early_impl<void, void, false>::await_suspend(
+//   std::coroutine_handle<> Outer
+// ) noexcept {
+//   // For unknown reasons, it doesn't work to start with done_count at 0,
+//   // Then increment here and check before storing continuation...
+//   me.continuation = Outer;
+//   auto remaining = me.done_count.fetch_sub(1, std::memory_order_acq_rel);
+//   // Worker was already posted.
+//   // Suspend if remaining > 0 (worker is still running)
+//   if (remaining > 0) {
+//     return true;
+//   }
+//   // Resume if remaining <= 0 (worker already finished)
+//   if (me.continuation_executor == nullptr ||
+//       me.continuation_executor == detail::this_thread::executor) {
+//     return false;
+//   } else {
+//     // Need to resume on a different executor
+//     me.continuation_executor->post(
+//       std::move(Outer), detail::this_thread::this_task.prio
+//     );
+//     return true;
+//   }
+// }
 
-/// Suspends the outer coroutine, submits the wrapped task to the
-/// executor, and waits for it to complete.
-inline bool aw_run_early_impl<void, void, false>::await_suspend(
-  std::coroutine_handle<> Outer
-) noexcept {
-  // For unknown reasons, it doesn't work to start with done_count at 0,
-  // Then increment here and check before storing continuation...
-  me.continuation = Outer;
-  auto remaining = me.done_count.fetch_sub(1, std::memory_order_acq_rel);
-  // Worker was already posted.
-  // Suspend if remaining > 0 (worker is still running)
-  if (remaining > 0) {
-    return true;
-  }
-  // Resume if remaining <= 0 (worker already finished)
-  if (me.continuation_executor == nullptr ||
-      me.continuation_executor == detail::this_thread::executor) {
-    return false;
-  } else {
-    // Need to resume on a different executor
-    me.continuation_executor->post(
-      std::move(Outer), detail::this_thread::this_task.prio
-    );
-    return true;
-  }
-}
-
-/// Does nothing.
-inline void aw_run_early_impl<void, void, false>::await_resume() noexcept {}
+// /// Does nothing.
+// inline void aw_run_early_impl<void, void, false>::await_resume() noexcept {}
 } // namespace tmc

--- a/include/tmc/detail/aw_run_early.hpp
+++ b/include/tmc/detail/aw_run_early.hpp
@@ -70,8 +70,10 @@ template <typename Result, typename Output> class aw_run_early {
     }
     const auto size = Parent.wrapped.size();
     for (size_t i = 0; i < size; ++i) {
-      auto& p =
-        task<Result>::from_address(Parent.wrapped[i].address()).promise();
+      auto& p = task<Result>::from_address(
+                  TMC_WORK_ITEM_AS_STD_CORO(Parent.wrapped[i]).address()
+      )
+                  .promise();
       p.continuation = &continuation;
       p.continuation_executor = &continuation_executor;
       p.done_count = &done_count;
@@ -103,7 +105,8 @@ public:
       return true;
     }
     // Resume if remaining <= 0 (worker already finished)
-    if (continuation_executor == nullptr || continuation_executor == detail::this_thread::executor) {
+    if (continuation_executor == nullptr ||
+        continuation_executor == detail::this_thread::executor) {
       return false;
     } else {
       // Need to resume on a different executor
@@ -166,7 +169,10 @@ template <> class aw_run_early<void, void> {
     continuation_executor = Parent.continuation_executor;
     const auto size = Parent.wrapped.size();
     for (size_t i = 0; i < size; ++i) {
-      auto& p = task<void>::from_address(Parent.wrapped[i].address()).promise();
+      auto& p = task<void>::from_address(
+                  TMC_WORK_ITEM_AS_STD_CORO(Parent.wrapped[i]).address()
+      )
+                  .promise();
       p.continuation = &continuation;
       p.continuation_executor = &continuation_executor;
       p.done_count = &done_count;
@@ -196,7 +202,8 @@ public:
       return true;
     }
     // Resume if remaining <= 0 (worker already finished)
-    if (continuation_executor == nullptr || continuation_executor == detail::this_thread::executor) {
+    if (continuation_executor == nullptr ||
+        continuation_executor == detail::this_thread::executor) {
       return false;
     } else {
       // Need to resume on a different executor

--- a/include/tmc/detail/aw_run_early.hpp
+++ b/include/tmc/detail/aw_run_early.hpp
@@ -16,23 +16,20 @@ template <typename Result> class aw_spawned_task;
 /// A wrapper that converts lazy task(s) to eager task(s),
 /// and allows the task(s) to be awaited after it has been started.
 /// It is created by calling run_early() on a parent awaitable
-/// from spawn() or spawn_many().
+/// from spawn().
 ///
 /// `Result` is the type of a single result value (same as that of the wrapped
 /// `task<Result>`).
-///
-/// `Output` may be a `Result`, `std::vector<Result>`,
-/// or `std::array<Result, Count>` depending on what type of awaitable this
-/// was created from.
-template <typename Result, typename Output>
+
+template <typename Result>
 class [[nodiscard("You must co_await aw_run_early. "
                   "It is not safe to destroy aw_run_early without first "
                   "awaiting it.")]] aw_run_early;
 
-template <typename Result, typename Output> class aw_run_early {
+template <typename Result> class aw_run_early {
   friend class aw_spawned_task<Result>;
   detail::type_erased_executor* continuation_executor;
-  Output result;
+  Result result;
   std::atomic<int64_t> done_count;
   std::coroutine_handle<> continuation;
 
@@ -84,7 +81,7 @@ public:
   }
 
   /// Returns the value provided by the wrapped function.
-  inline Output&& await_resume() noexcept { return std::move(result); }
+  inline Result&& await_resume() noexcept { return std::move(result); }
 
   // This must be awaited and the child task completed before destruction.
 #ifndef NDEBUG
@@ -99,7 +96,7 @@ public:
   aw_run_early(const aw_run_early&& other) = delete;
 };
 
-template <> class aw_run_early<void, void> {
+template <> class aw_run_early<void> {
   friend class aw_spawned_task<void>;
   detail::type_erased_executor* continuation_executor;
   std::atomic<int64_t> done_count;

--- a/include/tmc/detail/aw_run_early.hpp
+++ b/include/tmc/detail/aw_run_early.hpp
@@ -15,12 +15,11 @@ template <typename Result> class aw_spawned_task;
 
 /// A wrapper that converts lazy task(s) to eager task(s),
 /// and allows the task(s) to be awaited after it has been started.
-/// It is created by calling run_early() on a parent awaitable
-/// from spawn().
+/// It is created by calling `run_early()` on a parent awaitable
+/// from `spawn()`.
 ///
 /// `Result` is the type of a single result value (same as that of the wrapped
 /// `task<Result>`).
-
 template <typename Result>
 class [[nodiscard("You must co_await aw_run_early. "
                   "It is not safe to destroy aw_run_early without first "

--- a/include/tmc/detail/aw_run_early.hpp
+++ b/include/tmc/detail/aw_run_early.hpp
@@ -70,7 +70,7 @@ template <typename Result, typename Output> class aw_run_early {
     }
     const auto size = Parent.wrapped.size();
     for (size_t i = 0; i < size; ++i) {
-      auto& p = task<Result>::from_address(
+      auto& p = detail::unsafe_task<Result>::from_address(
                   TMC_WORK_ITEM_AS_STD_CORO(Parent.wrapped[i]).address()
       )
                   .promise();
@@ -169,7 +169,7 @@ template <> class aw_run_early<void, void> {
     continuation_executor = Parent.continuation_executor;
     const auto size = Parent.wrapped.size();
     for (size_t i = 0; i < size; ++i) {
-      auto& p = task<void>::from_address(
+      auto& p = detail::unsafe_task<void>::from_address(
                   TMC_WORK_ITEM_AS_STD_CORO(Parent.wrapped[i]).address()
       )
                   .promise();

--- a/include/tmc/detail/aw_run_early.hpp
+++ b/include/tmc/detail/aw_run_early.hpp
@@ -13,303 +13,250 @@ namespace tmc {
 /// The customizable task wrapper / awaitable type returned by
 /// `tmc::spawn(tmc::task<Result>)`.
 template <typename Result> class aw_spawned_task;
-/// The customizable task wrapper / awaitable type returned by
-/// `tmc::spawn_many(tmc::task<Result>)`.
-template <typename Result, size_t Count, typename Iter> class aw_task_many;
 
-// /// A wrapper that converts lazy task(s) to eager task(s),
-// /// and allows the task(s) to be awaited after it has been started.
-// /// It is created by calling run_early() on a parent awaitable
-// /// from spawn() or spawn_many().
-// ///
-// /// `Result` is the type of a single result value (same as that of the
-// wrapped
-// /// `task<Result>`).
-// ///
-// /// `Output` may be a `Result`, `std::vector<Result>`,
-// /// or `std::array<Result, Count>` depending on what type of awaitable this
-// /// was created from.
-// template <typename Result, typename Output>
-// class [[nodiscard("You must co_await aw_run_early. "
-//                   "It is not safe to destroy aw_run_early without first "
-//                   "awaiting it.")]] aw_run_early;
+/// A wrapper that converts lazy task(s) to eager task(s),
+/// and allows the task(s) to be awaited after it has been started.
+/// It is created by calling run_early() on a parent awaitable
+/// from spawn() or spawn_many().
+///
+/// `Result` is the type of a single result value (same as that of the wrapped
+/// `task<Result>`).
+///
+/// `Output` may be a `Result`, `std::vector<Result>`,
+/// or `std::array<Result, Count>` depending on what type of awaitable this
+/// was created from.
+template <typename Result, typename Output>
+class [[nodiscard("You must co_await aw_run_early. "
+                  "It is not safe to destroy aw_run_early without first "
+                  "awaiting it.")]] aw_run_early;
 
-// template <typename Result, typename Output, bool RValue>
-// class aw_run_early_impl;
+template <typename Result, typename Output, bool RValue>
+class aw_run_early_impl;
 
-// template <typename Result, typename Output, bool RValue>
-// class aw_run_early_impl {
-//   aw_run_early<Result, Output>& me;
-//   friend aw_run_early<Result, Output>;
-//   aw_run_early_impl(aw_run_early<Result, Output>& Me);
+template <typename Result, typename Output, bool RValue>
+class aw_run_early_impl {
+  aw_run_early<Result, Output>& me;
+  friend aw_run_early<Result, Output>;
+  aw_run_early_impl(aw_run_early<Result, Output>& Me);
 
-// public:
-//   /// Always suspends.
-//   inline bool await_ready() const noexcept;
+public:
+  /// Always suspends.
+  inline bool await_ready() const noexcept;
 
-//   /// Suspends the outer coroutine, submits the wrapped task to the
-//   /// executor, and waits for it to complete.
-//   inline bool await_suspend(std::coroutine_handle<> Outer) noexcept;
+  /// Suspends the outer coroutine, submits the wrapped task to the
+  /// executor, and waits for it to complete.
+  inline bool await_suspend(std::coroutine_handle<> Outer) noexcept;
 
-//   /// Returns the value provided by the wrapped task.
-//   inline Output& await_resume() noexcept
-//     requires(!RValue);
+  /// Returns the value provided by the wrapped task.
+  inline Output& await_resume() noexcept
+    requires(!RValue);
 
-//   /// Returns the value provided by the wrapped task.
-//   inline Output&& await_resume() noexcept
-//     requires(RValue);
-// };
+  /// Returns the value provided by the wrapped task.
+  inline Output&& await_resume() noexcept
+    requires(RValue);
+};
 
-// template <> class aw_run_early_impl<void, void, false> {
-//   aw_run_early<void, void>& me;
-//   friend aw_run_early<void, void>;
+template <> class aw_run_early_impl<void, void, false> {
+  aw_run_early<void, void>& me;
+  friend aw_run_early<void, void>;
 
-//   inline aw_run_early_impl(aw_run_early<void, void>& Me);
+  inline aw_run_early_impl(aw_run_early<void, void>& Me);
 
-// public:
-//   /// Always suspends.
-//   inline bool await_ready() const noexcept;
+public:
+  /// Always suspends.
+  inline bool await_ready() const noexcept;
 
-//   /// Suspends the outer coroutine, submits the wrapped task to the
-//   /// executor, and waits for it to complete.
-//   inline bool await_suspend(std::coroutine_handle<> Outer) noexcept;
+  /// Suspends the outer coroutine, submits the wrapped task to the
+  /// executor, and waits for it to complete.
+  inline bool await_suspend(std::coroutine_handle<> Outer) noexcept;
 
-//   /// Does nothing.
-//   inline void await_resume() noexcept;
-// };
+  /// Does nothing.
+  inline void await_resume() noexcept;
+};
 
-// template <typename Result, typename Output> class aw_run_early {
-//   friend class aw_spawned_task<Result>;
-//   template <typename R, size_t Count> friend class aw_task_many;
-//   friend class aw_run_early_impl<Result, Output, true>;
-//   friend class aw_run_early_impl<Result, Output, false>;
-//   std::coroutine_handle<> continuation;
-//   detail::type_erased_executor* continuation_executor;
-//   Output result;
-//   std::atomic<int64_t> done_count;
+template <typename Result, typename Output> class aw_run_early {
+  friend class aw_spawned_task<Result>;
+  friend class aw_run_early_impl<Result, Output, true>;
+  friend class aw_run_early_impl<Result, Output, false>;
+  std::coroutine_handle<> continuation;
+  detail::type_erased_executor* continuation_executor;
+  Output result;
+  std::atomic<int64_t> done_count;
 
-//   // Private constructor from aw_spawned_task. Takes ownership of parent's
-//   // task.
-//   aw_run_early(
-//     task<Result>&& Task, size_t Priority,
-//     detail::type_erased_executor* Executor,
-//     detail::type_erased_executor* ContinuationExecutor
-//   )
-//       : continuation{nullptr}, continuation_executor(ContinuationExecutor),
-//         done_count(1) {
-//     auto& p = Task.promise();
-//     p.continuation = &continuation;
-//     p.continuation_executor = &continuation_executor;
-//     p.result_ptr = &result;
-//     p.done_count = &done_count;
-//     // TODO fence maybe not required if there's one inside the queue?
-//     std::atomic_thread_fence(std::memory_order_release);
-//     Executor->post(std::move(Task), Priority);
-//   }
+  // Private constructor from aw_spawned_task. Takes ownership of parent's
+  // task.
+  aw_run_early(
+    task<Result>&& Task, size_t Priority,
+    detail::type_erased_executor* Executor,
+    detail::type_erased_executor* ContinuationExecutor
+  )
+      : continuation{nullptr}, continuation_executor(ContinuationExecutor),
+        done_count(1) {
+    auto& p = Task.promise();
+    p.continuation = &continuation;
+    p.continuation_executor = &continuation_executor;
+    p.result_ptr = &result;
+    p.done_count = &done_count;
+    // TODO fence maybe not required if there's one inside the queue?
+    std::atomic_thread_fence(std::memory_order_release);
+    Executor->post(std::move(Task), Priority);
+  }
 
-//   // Private constructor from aw_task_many. Takes ownership of parent's
-//   tasks.
-//   // For use when count is runtime dynamic - take ownership of parent's
-//   result
-//   // vector.
-//   template <size_t Count> aw_run_early(aw_task_many<Result, Count>&& Parent)
-//   {
-//     continuation_executor = Parent.continuation_executor;
-//     if constexpr (std::is_same_v<Output, std::vector<Result>>) {
-//       result = std::move(Parent.result);
-//     }
-//     const auto size = Parent.wrapped.size();
-//     for (size_t i = 0; i < size; ++i) {
-//       auto& p = detail::unsafe_task<Result>::from_address(
-//                   TMC_WORK_ITEM_AS_STD_CORO(Parent.wrapped[i]).address()
-//       )
-//                   .promise();
-//       p.continuation = &continuation;
-//       p.continuation_executor = &continuation_executor;
-//       p.done_count = &done_count;
-//       p.result_ptr = &result[i];
-//     }
-//     done_count.store(static_cast<int64_t>(size), std::memory_order_release);
-//     Parent.executor->post_bulk(Parent.wrapped.data(), Parent.prio, size);
-//     Parent.did_await = true;
-//   }
+public:
+  aw_run_early_impl<Result, Output, false> operator co_await() & {
+    return aw_run_early_impl<Result, Output, false>(*this);
+  }
 
-// public:
-//   aw_run_early_impl<Result, Output, false> operator co_await() & {
-//     return aw_run_early_impl<Result, Output, false>(*this);
-//   }
+  aw_run_early_impl<Result, Output, true> operator co_await() && {
+    return aw_run_early_impl<Result, Output, true>(*this);
+  }
 
-//   aw_run_early_impl<Result, Output, true> operator co_await() && {
-//     return aw_run_early_impl<Result, Output, true>(*this);
-//   }
+  // This must be awaited and the child task completed before destruction.
+  ~aw_run_early() noexcept { assert(done_count.load() < 0); }
 
-//   // This must be awaited and the child task completed before destruction.
-//   ~aw_run_early() noexcept { assert(done_count.load() < 0); }
+  // Not movable or copyable due to child task being spawned in constructor,
+  // and having pointers to this.
+  aw_run_early& operator=(const aw_run_early& other) = delete;
+  aw_run_early(const aw_run_early& other) = delete;
+  aw_run_early& operator=(const aw_run_early&& other) = delete;
+  aw_run_early(const aw_run_early&& other) = delete;
+};
 
-//   // Not movable or copyable due to child task being spawned in constructor,
-//   // and having pointers to this.
-//   aw_run_early& operator=(const aw_run_early& other) = delete;
-//   aw_run_early(const aw_run_early& other) = delete;
-//   aw_run_early& operator=(const aw_run_early&& other) = delete;
-//   aw_run_early(const aw_run_early&& other) = delete;
-// };
+template <> class aw_run_early<void, void> {
+  friend class aw_spawned_task<void>;
+  friend class aw_run_early_impl<void, void, false>;
+  std::coroutine_handle<> continuation;
+  detail::type_erased_executor* continuation_executor;
+  std::atomic<int64_t> done_count;
 
-// template <> class aw_run_early<void, void> {
-//   friend class aw_spawned_task<void>;
-//   friend class aw_run_early_impl<void, void, false>;
-//   template <typename R, size_t Count> friend class aw_task_many;
-//   std::coroutine_handle<> continuation;
-//   detail::type_erased_executor* continuation_executor;
-//   std::atomic<int64_t> done_count;
+  // Private constructor from aw_spawned_task. Takes ownership of parent's
+  // task.
+  aw_run_early(
+    task<void>&& Task, size_t Priority, detail::type_erased_executor* Executor,
+    detail::type_erased_executor* ContinuationExecutor
+  )
+      : continuation{nullptr}, continuation_executor(ContinuationExecutor),
+        done_count(1) {
+    auto& p = Task.promise();
+    p.continuation = &continuation;
+    p.continuation_executor = &continuation_executor;
+    p.done_count = &done_count;
+    // TODO fence maybe not required if there's one inside the queue?
+    std::atomic_thread_fence(std::memory_order_release);
+    Executor->post(std::move(Task), Priority);
+  }
 
-//   // Private constructor from aw_spawned_task. Takes ownership of parent's
-//   // task.
-//   aw_run_early(
-//     task<void>&& Task, size_t Priority, detail::type_erased_executor*
-//     Executor, detail::type_erased_executor* ContinuationExecutor
-//   )
-//       : continuation{nullptr}, continuation_executor(ContinuationExecutor),
-//         done_count(1) {
-//     auto& p = Task.promise();
-//     p.continuation = &continuation;
-//     p.continuation_executor = &continuation_executor;
-//     p.done_count = &done_count;
-//     // TODO fence maybe not required if there's one inside the queue?
-//     std::atomic_thread_fence(std::memory_order_release);
-//     Executor->post(std::move(Task), Priority);
-//   }
+public:
+  aw_run_early_impl<void, void, false> operator co_await() {
+    return aw_run_early_impl<void, void, false>(*this);
+  }
 
-//   // Private constructor from aw_task_many. Takes ownership of parent's
-//   tasks. template <size_t Count> aw_run_early(aw_task_many<void, Count>&&
-//   Parent) {
-//     continuation_executor = Parent.continuation_executor;
-//     const auto size = Parent.wrapped.size();
-//     for (size_t i = 0; i < size; ++i) {
-//       auto& p = detail::unsafe_task<void>::from_address(
-//                   TMC_WORK_ITEM_AS_STD_CORO(Parent.wrapped[i]).address()
-//       )
-//                   .promise();
-//       p.continuation = &continuation;
-//       p.continuation_executor = &continuation_executor;
-//       p.done_count = &done_count;
-//     }
-//     done_count.store(static_cast<int64_t>(size), std::memory_order_release);
-//     Parent.executor->post_bulk(Parent.wrapped.data(), Parent.prio, size);
-//     Parent.did_await = true;
-//   }
+  // This must be awaited and the child task completed before destruction.
+  ~aw_run_early() noexcept { assert(done_count.load() < 0); }
 
-// public:
-//   aw_run_early_impl<void, void, false> operator co_await() {
-//     return aw_run_early_impl<void, void, false>(*this);
-//   }
+  // Not movable or copyable due to child task being spawned in constructor,
+  // and having pointers to this.
+  aw_run_early& operator=(const aw_run_early& Other) = delete;
+  aw_run_early(const aw_run_early& Other) = delete;
+  aw_run_early& operator=(const aw_run_early&& Other) = delete;
+  aw_run_early(const aw_run_early&& Other) = delete;
+};
 
-//   // This must be awaited and the child task completed before destruction.
-//   ~aw_run_early() noexcept { assert(done_count.load() < 0); }
+template <typename Result, typename Output, bool RValue>
+aw_run_early_impl<Result, Output, RValue>::aw_run_early_impl(
+  aw_run_early<Result, Output>& Me
+)
+    : me(Me) {}
 
-//   // Not movable or copyable due to child task being spawned in constructor,
-//   // and having pointers to this.
-//   aw_run_early& operator=(const aw_run_early& Other) = delete;
-//   aw_run_early(const aw_run_early& Other) = delete;
-//   aw_run_early& operator=(const aw_run_early&& Other) = delete;
-//   aw_run_early(const aw_run_early&& Other) = delete;
-// };
+/// Always suspends.
+template <typename Result, typename Output, bool RValue>
+inline bool
+aw_run_early_impl<Result, Output, RValue>::await_ready() const noexcept {
+  return false;
+}
 
-// template <typename Result, typename Output, bool RValue>
-// aw_run_early_impl<Result, Output, RValue>::aw_run_early_impl(
-//   aw_run_early<Result, Output>& Me
-// )
-//     : me(Me) {}
+/// Suspends the outer coroutine, submits the wrapped task to the
+/// executor, and waits for it to complete.
+template <typename Result, typename Output, bool RValue>
+inline bool aw_run_early_impl<Result, Output, RValue>::await_suspend(
+  std::coroutine_handle<> Outer
+) noexcept {
+  // For unknown reasons, it doesn't work to start with done_count at 0,
+  // Then increment here and check before storing continuation...
+  me.continuation = Outer;
+  auto remaining = me.done_count.fetch_sub(1, std::memory_order_acq_rel);
+  // Worker was already posted.
+  // Suspend if remaining > 0 (worker is still running)
+  if (remaining > 0) {
+    return true;
+  }
+  // Resume if remaining <= 0 (worker already finished)
+  if (me.continuation_executor == nullptr ||
+      me.continuation_executor == detail::this_thread::executor) {
+    return false;
+  } else {
+    // Need to resume on a different executor
+    me.continuation_executor->post(
+      std::move(Outer), detail::this_thread::this_task.prio
+    );
+    return true;
+  }
+}
 
-// /// Always suspends.
-// template <typename Result, typename Output, bool RValue>
-// inline bool
-// aw_run_early_impl<Result, Output, RValue>::await_ready() const noexcept {
-//   return false;
-// }
+/// Returns the value provided by the wrapped function.
+template <typename Result, typename Output, bool RValue>
+inline Output&
+aw_run_early_impl<Result, Output, RValue>::await_resume() noexcept
+  requires(!RValue)
+{
+  return me.result;
+}
 
-// /// Suspends the outer coroutine, submits the wrapped task to the
-// /// executor, and waits for it to complete.
-// template <typename Result, typename Output, bool RValue>
-// inline bool aw_run_early_impl<Result, Output, RValue>::await_suspend(
-//   std::coroutine_handle<> Outer
-// ) noexcept {
-//   // For unknown reasons, it doesn't work to start with done_count at 0,
-//   // Then increment here and check before storing continuation...
-//   me.continuation = Outer;
-//   auto remaining = me.done_count.fetch_sub(1, std::memory_order_acq_rel);
-//   // Worker was already posted.
-//   // Suspend if remaining > 0 (worker is still running)
-//   if (remaining > 0) {
-//     return true;
-//   }
-//   // Resume if remaining <= 0 (worker already finished)
-//   if (me.continuation_executor == nullptr ||
-//       me.continuation_executor == detail::this_thread::executor) {
-//     return false;
-//   } else {
-//     // Need to resume on a different executor
-//     me.continuation_executor->post(
-//       std::move(Outer), detail::this_thread::this_task.prio
-//     );
-//     return true;
-//   }
-// }
+/// Returns the value provided by the wrapped function.
+template <typename Result, typename Output, bool RValue>
+inline Output&&
+aw_run_early_impl<Result, Output, RValue>::await_resume() noexcept
+  requires(RValue)
+{
+  return std::move(me.result);
+}
 
-// /// Returns the value provided by the wrapped function.
-// template <typename Result, typename Output, bool RValue>
-// inline Output&
-// aw_run_early_impl<Result, Output, RValue>::await_resume() noexcept
-//   requires(!RValue)
-// {
-//   return me.result;
-// }
+inline aw_run_early_impl<void, void, false>::aw_run_early_impl(
+  aw_run_early<void, void>& Me
+)
+    : me(Me) {}
 
-// /// Returns the value provided by the wrapped function.
-// template <typename Result, typename Output, bool RValue>
-// inline Output&&
-// aw_run_early_impl<Result, Output, RValue>::await_resume() noexcept
-//   requires(RValue)
-// {
-//   return std::move(me.result);
-// }
+inline bool aw_run_early_impl<void, void, false>::await_ready() const noexcept {
+  return false;
+}
 
-// inline aw_run_early_impl<void, void, false>::aw_run_early_impl(
-//   aw_run_early<void, void>& Me
-// )
-//     : me(Me) {}
+/// Suspends the outer coroutine, submits the wrapped task to the
+/// executor, and waits for it to complete.
+inline bool aw_run_early_impl<void, void, false>::await_suspend(
+  std::coroutine_handle<> Outer
+) noexcept {
+  // For unknown reasons, it doesn't work to start with done_count at 0,
+  // Then increment here and check before storing continuation...
+  me.continuation = Outer;
+  auto remaining = me.done_count.fetch_sub(1, std::memory_order_acq_rel);
+  // Worker was already posted.
+  // Suspend if remaining > 0 (worker is still running)
+  if (remaining > 0) {
+    return true;
+  }
+  // Resume if remaining <= 0 (worker already finished)
+  if (me.continuation_executor == nullptr ||
+      me.continuation_executor == detail::this_thread::executor) {
+    return false;
+  } else {
+    // Need to resume on a different executor
+    me.continuation_executor->post(
+      std::move(Outer), detail::this_thread::this_task.prio
+    );
+    return true;
+  }
+}
 
-// inline bool aw_run_early_impl<void, void, false>::await_ready() const
-// noexcept {
-//   return false;
-// }
-
-// /// Suspends the outer coroutine, submits the wrapped task to the
-// /// executor, and waits for it to complete.
-// inline bool aw_run_early_impl<void, void, false>::await_suspend(
-//   std::coroutine_handle<> Outer
-// ) noexcept {
-//   // For unknown reasons, it doesn't work to start with done_count at 0,
-//   // Then increment here and check before storing continuation...
-//   me.continuation = Outer;
-//   auto remaining = me.done_count.fetch_sub(1, std::memory_order_acq_rel);
-//   // Worker was already posted.
-//   // Suspend if remaining > 0 (worker is still running)
-//   if (remaining > 0) {
-//     return true;
-//   }
-//   // Resume if remaining <= 0 (worker already finished)
-//   if (me.continuation_executor == nullptr ||
-//       me.continuation_executor == detail::this_thread::executor) {
-//     return false;
-//   } else {
-//     // Need to resume on a different executor
-//     me.continuation_executor->post(
-//       std::move(Outer), detail::this_thread::this_task.prio
-//     );
-//     return true;
-//   }
-// }
-
-// /// Does nothing.
-// inline void aw_run_early_impl<void, void, false>::await_resume() noexcept {}
+/// Does nothing.
+inline void aw_run_early_impl<void, void, false>::await_resume() noexcept {}
 } // namespace tmc

--- a/include/tmc/detail/aw_run_early.hpp
+++ b/include/tmc/detail/aw_run_early.hpp
@@ -78,17 +78,16 @@ template <typename Result, typename Output> class aw_run_early {
   friend class aw_spawned_task<Result>;
   friend class aw_run_early_impl<Result, Output, true>;
   friend class aw_run_early_impl<Result, Output, false>;
-  std::coroutine_handle<> continuation;
   detail::type_erased_executor* continuation_executor;
   Output result;
   std::atomic<int64_t> done_count;
+  std::coroutine_handle<> continuation;
 
   // Private constructor from aw_spawned_task. Takes ownership of parent's
   // task.
   aw_run_early(
-    task<Result>&& Task, size_t Priority,
-    detail::type_erased_executor* Executor,
-    detail::type_erased_executor* ContinuationExecutor
+    task<Result>&& Task, detail::type_erased_executor* Executor,
+    detail::type_erased_executor* ContinuationExecutor, size_t Priority
   )
       : continuation{nullptr}, continuation_executor(ContinuationExecutor),
         done_count(1) {
@@ -125,15 +124,15 @@ public:
 template <> class aw_run_early<void, void> {
   friend class aw_spawned_task<void>;
   friend class aw_run_early_impl<void, void, false>;
-  std::coroutine_handle<> continuation;
   detail::type_erased_executor* continuation_executor;
   std::atomic<int64_t> done_count;
+  std::coroutine_handle<> continuation;
 
   // Private constructor from aw_spawned_task. Takes ownership of parent's
   // task.
   aw_run_early(
-    task<void>&& Task, size_t Priority, detail::type_erased_executor* Executor,
-    detail::type_erased_executor* ContinuationExecutor
+    task<void>&& Task, detail::type_erased_executor* Executor,
+    detail::type_erased_executor* ContinuationExecutor, size_t Priority
   )
       : continuation{nullptr}, continuation_executor(ContinuationExecutor),
         done_count(1) {

--- a/include/tmc/detail/ex_cpu.ipp
+++ b/include/tmc/detail/ex_cpu.ipp
@@ -603,8 +603,8 @@ namespace detail {
 tmc::task<void> client_main_awaiter(
   tmc::task<int> ClientMainTask, std::atomic<int>* ExitCode_out
 ) {
-  ClientMainTask.resume_on(tmc::cpu_executor());
-  int exitCode = co_await std::move(ClientMainTask);
+  int exitCode =
+    co_await std::move(ClientMainTask.resume_on(tmc::cpu_executor()));
   ExitCode_out->store(exitCode);
   ExitCode_out->notify_all();
 }

--- a/include/tmc/detail/mixins.hpp
+++ b/include/tmc/detail/mixins.hpp
@@ -9,37 +9,39 @@ namespace detail {
 template <typename Derived> class run_on_mixin {
 public:
   /// The wrapped task will run on the provided executor.
-  inline Derived& run_on(detail::type_erased_executor* Executor) & {
+  [[nodiscard]] inline Derived& run_on(detail::type_erased_executor* Executor
+  ) & {
     static_cast<Derived*>(this)->executor = Executor;
     return static_cast<Derived&>(*this);
   }
   /// The wrapped task will run on the provided executor.
   template <detail::TypeErasableExecutor Exec>
-  Derived& run_on(Exec& Executor) & {
+  [[nodiscard]] Derived& run_on(Exec& Executor) & {
     static_cast<Derived*>(this)->executor = Executor.type_erased();
     return static_cast<Derived&>(*this);
   }
   /// The wrapped task will run on the provided executor.
   template <detail::TypeErasableExecutor Exec>
-  Derived& run_on(Exec* Executor) & {
+  [[nodiscard]] Derived& run_on(Exec* Executor) & {
     static_cast<Derived*>(this)->executor = Executor->type_erased();
     return static_cast<Derived&>(*this);
   }
 
   /// The wrapped task will run on the provided executor.
-  inline Derived&& run_on(detail::type_erased_executor* Executor) && {
+  [[nodiscard]] inline Derived&& run_on(detail::type_erased_executor* Executor
+  ) && {
     static_cast<Derived*>(this)->executor = Executor;
     return static_cast<Derived&&>(*this);
   }
   /// The wrapped task will run on the provided executor.
   template <detail::TypeErasableExecutor Exec>
-  Derived&& run_on(Exec& Executor) && {
+  [[nodiscard]] Derived&& run_on(Exec& Executor) && {
     static_cast<Derived*>(this)->executor = Executor.type_erased();
     return static_cast<Derived&&>(*this);
   }
   /// The wrapped task will run on the provided executor.
   template <detail::TypeErasableExecutor Exec>
-  Derived&& run_on(Exec* Executor) && {
+  [[nodiscard]] Derived&& run_on(Exec* Executor) && {
     static_cast<Derived*>(this)->executor = Executor->type_erased();
     return static_cast<Derived&&>(*this);
   }
@@ -48,38 +50,40 @@ public:
 template <typename Derived> class resume_on_mixin {
 public:
   /// The wrapped task will run on the provided executor.
-  inline Derived& resume_on(detail::type_erased_executor* Executor) & {
+  [[nodiscard]] inline Derived& resume_on(detail::type_erased_executor* Executor
+  ) & {
     static_cast<Derived*>(this)->continuation_executor = Executor;
     return static_cast<Derived&>(*this);
   }
   /// The wrapped task will run on the provided executor.
   template <detail::TypeErasableExecutor Exec>
-  Derived& resume_on(Exec& Executor) & {
+  [[nodiscard]] Derived& resume_on(Exec& Executor) & {
     static_cast<Derived*>(this)->continuation_executor = Executor.type_erased();
     return static_cast<Derived&>(*this);
   }
   /// The wrapped task will run on the provided executor.
   template <detail::TypeErasableExecutor Exec>
-  Derived& resume_on(Exec* Executor) & {
+  [[nodiscard]] Derived& resume_on(Exec* Executor) & {
     static_cast<Derived*>(this)->continuation_executor =
       Executor->type_erased();
     return static_cast<Derived&>(*this);
   }
 
   /// The wrapped task will run on the provided executor.
-  inline Derived&& resume_on(detail::type_erased_executor* Executor) && {
+  [[nodiscard]] inline Derived&&
+  resume_on(detail::type_erased_executor* Executor) && {
     static_cast<Derived*>(this)->continuation_executor = Executor;
     return static_cast<Derived&&>(*this);
   }
   /// The wrapped task will run on the provided executor.
   template <detail::TypeErasableExecutor Exec>
-  Derived&& resume_on(Exec& Executor) && {
+  [[nodiscard]] Derived&& resume_on(Exec& Executor) && {
     static_cast<Derived*>(this)->continuation_executor = Executor.type_erased();
     return static_cast<Derived&&>(*this);
   }
   /// The wrapped task will run on the provided executor.
   template <detail::TypeErasableExecutor Exec>
-  Derived&& resume_on(Exec* Executor) && {
+  [[nodiscard]] Derived&& resume_on(Exec* Executor) && {
     static_cast<Derived*>(this)->continuation_executor =
       Executor->type_erased();
     return static_cast<Derived&&>(*this);
@@ -90,14 +94,14 @@ template <typename Derived> class with_priority_mixin {
 public:
   /// Sets the priority of the wrapped task. If co_awaited, the outer
   /// coroutine will also be resumed with this priority.
-  inline Derived& with_priority(size_t Priority) & {
+  [[nodiscard]] inline Derived& with_priority(size_t Priority) & {
     static_cast<Derived*>(this)->prio = Priority;
     return static_cast<Derived&>(*this);
   }
 
   /// Sets the priority of the wrapped task. If co_awaited, the outer
   /// coroutine will also be resumed with this priority.
-  inline Derived&& with_priority(size_t Priority) && {
+  [[nodiscard]] inline Derived&& with_priority(size_t Priority) && {
     static_cast<Derived*>(this)->prio = Priority;
     return static_cast<Derived&&>(*this);
   }

--- a/include/tmc/detail/mixins.hpp
+++ b/include/tmc/detail/mixins.hpp
@@ -3,6 +3,8 @@
 #include "tmc/detail/thread_locals.hpp"
 namespace tmc {
 namespace detail {
+// These mixins provide the `run_on`, `resume_on`, and `with_priority` methods
+// for the fluent pattern that preserve the value category of the object.
 
 template <typename Derived> class run_on_mixin {
 public:

--- a/include/tmc/detail/mixins.hpp
+++ b/include/tmc/detail/mixins.hpp
@@ -107,5 +107,16 @@ public:
   }
 };
 
+template <typename Base> class rvalue_only_awaitable : private Base {
+  /// The purpose of this class is to enforce good code hygiene. You must
+  /// move-from your awaitables.
+  /// If you get a compile error about private inheritance, you need to
+  /// `co_await std::move(your_object);`
+  using Base::Base;
+
+public:
+  Base&& operator co_await() && { return static_cast<Base&&>(*this); }
+};
+
 } // namespace detail
 } // namespace tmc

--- a/include/tmc/detail/mixins.hpp
+++ b/include/tmc/detail/mixins.hpp
@@ -1,0 +1,105 @@
+#pragma once
+#include "tmc/detail/concepts.hpp"
+#include "tmc/detail/thread_locals.hpp"
+namespace tmc {
+namespace detail {
+
+template <typename Derived> class run_on_mixin {
+public:
+  /// The wrapped task will run on the provided executor.
+  inline Derived& run_on(detail::type_erased_executor* Executor) & {
+    static_cast<Derived*>(this)->executor = Executor;
+    return static_cast<Derived&>(*this);
+  }
+  /// The wrapped task will run on the provided executor.
+  template <detail::TypeErasableExecutor Exec>
+  Derived& run_on(Exec& Executor) & {
+    static_cast<Derived*>(this)->executor = Executor.type_erased();
+    return static_cast<Derived&>(*this);
+  }
+  /// The wrapped task will run on the provided executor.
+  template <detail::TypeErasableExecutor Exec>
+  Derived& run_on(Exec* Executor) & {
+    static_cast<Derived*>(this)->executor = Executor->type_erased();
+    return static_cast<Derived&>(*this);
+  }
+
+  /// The wrapped task will run on the provided executor.
+  inline Derived&& run_on(detail::type_erased_executor* Executor) && {
+    static_cast<Derived*>(this)->executor = Executor;
+    return static_cast<Derived&&>(*this);
+  }
+  /// The wrapped task will run on the provided executor.
+  template <detail::TypeErasableExecutor Exec>
+  Derived&& run_on(Exec& Executor) && {
+    static_cast<Derived*>(this)->executor = Executor.type_erased();
+    return static_cast<Derived&&>(*this);
+  }
+  /// The wrapped task will run on the provided executor.
+  template <detail::TypeErasableExecutor Exec>
+  Derived&& run_on(Exec* Executor) && {
+    static_cast<Derived*>(this)->executor = Executor->type_erased();
+    return static_cast<Derived&&>(*this);
+  }
+};
+
+template <typename Derived> class resume_on_mixin {
+public:
+  /// The wrapped task will run on the provided executor.
+  inline Derived& resume_on(detail::type_erased_executor* Executor) & {
+    static_cast<Derived*>(this)->continuation_executor = Executor;
+    return static_cast<Derived&>(*this);
+  }
+  /// The wrapped task will run on the provided executor.
+  template <detail::TypeErasableExecutor Exec>
+  Derived& resume_on(Exec& Executor) & {
+    static_cast<Derived*>(this)->continuation_executor = Executor.type_erased();
+    return static_cast<Derived&>(*this);
+  }
+  /// The wrapped task will run on the provided executor.
+  template <detail::TypeErasableExecutor Exec>
+  Derived& resume_on(Exec* Executor) & {
+    static_cast<Derived*>(this)->continuation_executor =
+      Executor->type_erased();
+    return static_cast<Derived&>(*this);
+  }
+
+  /// The wrapped task will run on the provided executor.
+  inline Derived&& resume_on(detail::type_erased_executor* Executor) && {
+    static_cast<Derived*>(this)->continuation_executor = Executor;
+    return static_cast<Derived&&>(*this);
+  }
+  /// The wrapped task will run on the provided executor.
+  template <detail::TypeErasableExecutor Exec>
+  Derived&& resume_on(Exec& Executor) && {
+    static_cast<Derived*>(this)->continuation_executor = Executor.type_erased();
+    return static_cast<Derived&&>(*this);
+  }
+  /// The wrapped task will run on the provided executor.
+  template <detail::TypeErasableExecutor Exec>
+  Derived&& resume_on(Exec* Executor) && {
+    static_cast<Derived*>(this)->continuation_executor =
+      Executor->type_erased();
+    return static_cast<Derived&&>(*this);
+  }
+};
+
+template <typename Derived> class with_priority_mixin {
+public:
+  /// Sets the priority of the wrapped task. If co_awaited, the outer
+  /// coroutine will also be resumed with this priority.
+  inline Derived& with_priority(size_t Priority) & {
+    static_cast<Derived*>(this)->prio = Priority;
+    return static_cast<Derived&>(*this);
+  }
+
+  /// Sets the priority of the wrapped task. If co_awaited, the outer
+  /// coroutine will also be resumed with this priority.
+  inline Derived&& with_priority(size_t Priority) && {
+    static_cast<Derived*>(this)->prio = Priority;
+    return static_cast<Derived&&>(*this);
+  }
+};
+
+} // namespace detail
+} // namespace tmc

--- a/include/tmc/detail/thread_locals.hpp
+++ b/include/tmc/detail/thread_locals.hpp
@@ -7,33 +7,33 @@
 #define TMC_WORK_ITEM_FUNC 1
 #define TMC_WORK_ITEM_FUNCORO 2
 #define TMC_WORK_ITEM_FUNCORO32 3
-#define CONCAT_impl(a, b) a##b
-#define CONCAT(a, b) CONCAT_impl(a, b)
-#define WORK_ITEM_IS_impl(WORK_ITEM_TYPE)                                      \
-  CONCAT(TMC_WORK_ITEM_, TMC_WORK_ITEM) ==                                     \
-    CONCAT(TMC_WORK_ITEM_, WORK_ITEM_TYPE)
-#define WORK_ITEM_IS(WORK_ITEM_TYPE) WORK_ITEM_IS_impl(WORK_ITEM_TYPE)
+#define TMC_CONCAT_impl(a, b) a##b
+#define TMC_CONCAT(a, b) TMC_CONCAT_impl(a, b)
+#define TMC_WORK_ITEM_IS_impl(WORK_ITEM_TYPE)                                  \
+  TMC_CONCAT(TMC_WORK_ITEM_, TMC_WORK_ITEM) ==                                 \
+    TMC_CONCAT(TMC_WORK_ITEM_, WORK_ITEM_TYPE)
+#define TMC_WORK_ITEM_IS(WORK_ITEM_TYPE) TMC_WORK_ITEM_IS_impl(WORK_ITEM_TYPE)
 
-#if WORK_ITEM_IS(CORO)
+#if TMC_WORK_ITEM_IS(CORO)
 #include <coroutine>
 namespace tmc {
 using work_item = std::coroutine_handle<>;
 }
 #define TMC_WORK_ITEM_AS_STD_CORO(x) (x)
-#elif WORK_ITEM_IS(FUNC)
+#elif TMC_WORK_ITEM_IS(FUNC)
 #include <functional>
 namespace tmc {
 using work_item = std::function<void()>;
 }
 #define TMC_WORK_ITEM_AS_STD_CORO(x)                                           \
   (*x.template target<std::coroutine_handle<>>())
-#elif WORK_ITEM_IS(FUNCORO)
+#elif TMC_WORK_ITEM_IS(FUNCORO)
 #include "tmc/detail/coro_functor.hpp"
 namespace tmc {
 using work_item = tmc::coro_functor;
 }
 #define TMC_WORK_ITEM_AS_STD_CORO(x) (x.as_coroutine())
-#elif WORK_ITEM_IS(FUNCORO32)
+#elif TMC_WORK_ITEM_IS(FUNCORO32)
 #include "tmc/detail/coro_functor32.hpp"
 namespace tmc {
 using work_item = tmc::coro_functor32;

--- a/include/tmc/detail/thread_locals.hpp
+++ b/include/tmc/detail/thread_locals.hpp
@@ -19,21 +19,26 @@
 namespace tmc {
 using work_item = std::coroutine_handle<>;
 }
+#define TMC_WORK_ITEM_AS_STD_CORO(x) (x)
 #elif WORK_ITEM_IS(FUNC)
 #include <functional>
 namespace tmc {
 using work_item = std::function<void()>;
 }
+#define TMC_WORK_ITEM_AS_STD_CORO(x)                                           \
+  (*x.template target<std::coroutine_handle<>>())
 #elif WORK_ITEM_IS(FUNCORO)
 #include "tmc/detail/coro_functor.hpp"
 namespace tmc {
 using work_item = tmc::coro_functor;
 }
+#define TMC_WORK_ITEM_AS_STD_CORO(x) (x.as_coroutine())
 #elif WORK_ITEM_IS(FUNCORO32)
 #include "tmc/detail/coro_functor32.hpp"
 namespace tmc {
 using work_item = tmc::coro_functor32;
 }
+#define TMC_WORK_ITEM_AS_STD_CORO(x) (x.as_coroutine())
 #endif
 
 namespace tmc {

--- a/include/tmc/detail/thread_locals.hpp
+++ b/include/tmc/detail/thread_locals.hpp
@@ -84,3 +84,9 @@ inline constinit thread_local void* producers = nullptr;
 } // namespace this_thread
 } // namespace detail
 } // namespace tmc
+
+#ifdef _MSC_VER
+#define TMC_FORCE_INLINE __forceinline
+#else
+#define TMC_FORCE_INLINE __attribute__((always_inline))
+#endif

--- a/include/tmc/spawn_func.hpp
+++ b/include/tmc/spawn_func.hpp
@@ -194,7 +194,7 @@ public:
   /// afterward.
   void detach() {
     assert(!did_await);
-#if WORK_ITEM_IS(CORO)
+#if TMC_WORK_ITEM_IS(CORO)
     executor->post(
       [](std::function<void()> Func) -> task<void> {
         Func();
@@ -292,7 +292,7 @@ inline void aw_spawned_func_impl<Result, RValue>::await_suspend(
   std::coroutine_handle<> Outer
 ) noexcept {
   me.did_await = true;
-#if WORK_ITEM_IS(CORO)
+#if TMC_WORK_ITEM_IS(CORO)
   auto t = [](aw_spawned_func<Result>* f) -> task<void> {
     f->result = f->wrapped();
     co_return;
@@ -352,7 +352,7 @@ inline void
 aw_spawned_func_impl<void, false>::await_suspend(std::coroutine_handle<> Outer
 ) noexcept {
   me.did_await = true;
-#if WORK_ITEM_IS(CORO)
+#if TMC_WORK_ITEM_IS(CORO)
   auto t = [](aw_spawned_func<void>* f) -> task<void> {
     f->wrapped();
     co_return;

--- a/include/tmc/spawn_func.hpp
+++ b/include/tmc/spawn_func.hpp
@@ -35,7 +35,8 @@ public:
 
   /// Suspends the outer coroutine, submits the wrapped task to the
   /// executor, and waits for it to complete.
-  inline void await_suspend(std::coroutine_handle<> Outer) noexcept {
+  TMC_FORCE_INLINE inline void await_suspend(std::coroutine_handle<> Outer
+  ) noexcept {
 #if TMC_WORK_ITEM_IS(CORO)
     auto t = detail::into_unsafe_task(wrapped);
     auto& p = t.promise();
@@ -87,7 +88,8 @@ public:
 
   /// Suspends the outer coroutine, submits the wrapped task to the
   /// executor, and waits for it to complete.
-  inline void await_suspend(std::coroutine_handle<> Outer) noexcept {
+  TMC_FORCE_INLINE inline void await_suspend(std::coroutine_handle<> Outer
+  ) noexcept {
 #if TMC_WORK_ITEM_IS(CORO)
     auto t = detail::into_unsafe_task(wrapped);
     auto& p = t.promise();

--- a/include/tmc/spawn_func.hpp
+++ b/include/tmc/spawn_func.hpp
@@ -305,8 +305,8 @@ inline void aw_spawned_func_impl<Result, RValue>::await_suspend(
   me.executor->post(
     [this, Outer]() {
       me.result = me.wrapped();
-      if (continuation_executor == nullptr ||
-          continuation_executor == detail::this_thread::executor) {
+      if (me.continuation_executor == nullptr ||
+          me.continuation_executor == detail::this_thread::executor) {
         Outer.resume();
       } else {
         me.continuation_executor->post(
@@ -364,9 +364,9 @@ aw_spawned_func_impl<void, false>::await_suspend(std::coroutine_handle<> Outer
 #else
   me.executor->post(
     [this, Outer]() {
-      wrapped();
-      if (continuation_executor == nullptr ||
-          continuation_executor == detail::this_thread::executor) {
+      me.wrapped();
+      if (me.continuation_executor == nullptr ||
+          me.continuation_executor == detail::this_thread::executor) {
         Outer.resume();
       } else {
         me.continuation_executor->post(

--- a/include/tmc/spawn_func.hpp
+++ b/include/tmc/spawn_func.hpp
@@ -93,7 +93,7 @@ public:
         wrapped(std::move(Func)), prio(detail::this_thread::this_task.prio),
         did_await(false) {}
 
-  aw_spawned_func_impl<Result> operator co_await() {
+  aw_spawned_func_impl<Result> operator co_await() && {
     return aw_spawned_func_impl<Result>(*this);
   }
 
@@ -147,7 +147,7 @@ public:
         wrapped(std::move(Func)), prio(detail::this_thread::this_task.prio),
         did_await(false) {}
 
-  aw_spawned_func_impl<void> operator co_await() {
+  aw_spawned_func_impl<void> operator co_await() && {
     return aw_spawned_func_impl<void>(*this);
   }
 

--- a/include/tmc/spawn_task.hpp
+++ b/include/tmc/spawn_task.hpp
@@ -7,91 +7,96 @@
 #include <coroutine>
 namespace tmc {
 
-template <typename Result, bool RValue> class aw_spawned_task_impl;
+template <typename Result> class aw_spawned_task_impl;
 
-template <typename Result, bool RValue> class aw_spawned_task_impl {
-  aw_spawned_task<Result>& me;
+template <typename Result> class aw_spawned_task_impl {
+  task<Result> wrapped;
+  detail::type_erased_executor* executor;
+  detail::type_erased_executor* continuation_executor;
+  size_t prio;
+  Result result;
   friend aw_spawned_task<Result>;
-  aw_spawned_task_impl(aw_spawned_task<Result>& Me);
+  aw_spawned_task_impl(
+    task<Result> Task, detail::type_erased_executor* Executor,
+    detail::type_erased_executor* ContinuationExecutor, size_t Prio
+  );
 
 public:
   /// Always suspends.
-  constexpr bool await_ready() const noexcept;
+  inline bool await_ready() const noexcept;
 
   /// Suspends the outer coroutine, submits the wrapped task to the
   /// executor, and waits for it to complete.
-  constexpr void await_suspend(std::coroutine_handle<> Outer) noexcept;
+  inline void await_suspend(std::coroutine_handle<> Outer) noexcept;
 
   /// Returns the value provided by the wrapped task.
-  constexpr Result& await_resume() noexcept
-    requires(!RValue);
-
-  /// Returns the value provided by the wrapped task.
-  constexpr Result&& await_resume() noexcept
-    requires(RValue);
+  inline Result&& await_resume() noexcept;
 };
 
-template <> class aw_spawned_task_impl<void, false> {
-  aw_spawned_task<void>& me;
+template <> class aw_spawned_task_impl<void> {
+  task<void> wrapped;
+  detail::type_erased_executor* executor;
+  detail::type_erased_executor* continuation_executor;
+  size_t prio;
   friend aw_spawned_task<void>;
 
-  constexpr aw_spawned_task_impl(aw_spawned_task<void>& Me);
+  inline aw_spawned_task_impl(
+    task<void> Task, detail::type_erased_executor* Executor,
+    detail::type_erased_executor* ContinuationExecutor, size_t Prio
+  );
 
 public:
   /// Always suspends.
-  constexpr bool await_ready() const noexcept;
+  inline bool await_ready() const noexcept;
 
   /// Suspends the outer coroutine, submits the wrapped task to the
   /// executor, and waits for it to complete.
-  constexpr void await_suspend(std::coroutine_handle<> Outer) noexcept;
+  inline void await_suspend(std::coroutine_handle<> Outer) noexcept;
 
   /// Does nothing.
-  constexpr void await_resume() noexcept;
+  inline void await_resume() noexcept;
 };
 
 // Primary template is forward-declared in "tmc/detail/aw_run_early.hpp".
 template <typename Result>
 class [[nodiscard("You must use the aw_spawned_task<Result> by one of: 1. "
                   "co_await 2. run_early()")]] aw_spawned_task {
+  task<Result> wrapped;
   detail::type_erased_executor* executor;
   detail::type_erased_executor* continuation_executor;
-  task<Result> wrapped;
-  Result result;
   size_t prio;
-
-  friend class aw_spawned_task_impl<Result, false>;
-  friend class aw_spawned_task_impl<Result, true>;
 
 public:
   /// It is recommended to call `spawn()` instead of using this constructor
   /// directly.
   aw_spawned_task(task<Result>&& Task)
-      : executor(detail::this_thread::executor),
+      : wrapped(std::move(Task)), executor(detail::this_thread::executor),
         continuation_executor(detail::this_thread::executor),
-        wrapped(std::move(Task)), prio(detail::this_thread::this_task.prio) {}
+        prio(detail::this_thread::this_task.prio) {}
 
-  aw_spawned_task_impl<Result, false> operator co_await() & {
-    return aw_spawned_task_impl<Result, false>(*this);
+  aw_spawned_task_impl<Result> operator co_await() {
+    return aw_spawned_task_impl<Result>(
+      std::move(wrapped), executor, continuation_executor, prio
+    );
   }
 
-  aw_spawned_task_impl<Result, true> operator co_await() && {
-    return aw_spawned_task_impl<Result, true>(*this);
-  }
-
+#ifndef NDEBUG
   ~aw_spawned_task() noexcept {
     // If you spawn a task that returns a non-void type,
     // then you must co_await the return of spawn!
     assert(!wrapped);
   }
+#endif
   aw_spawned_task(const aw_spawned_task&) = delete;
   aw_spawned_task& operator=(const aw_spawned_task&) = delete;
   aw_spawned_task(aw_spawned_task&& Other)
-      : executor(std::move(Other.executor)), wrapped(std::move(Other.wrapped)),
-        result(std::move(Other.result)), prio(Other.prio) {}
+      : wrapped(std::move(Other.wrapped)), executor(std::move(Other.executor)),
+        continuation_executor(std::move(Other.continuation_executor)),
+        prio(Other.prio) {}
   aw_spawned_task& operator=(aw_spawned_task&& Other) {
-    executor = std::move(Other.executor);
     wrapped = std::move(Other.wrapped);
-    result = std::move(Other.result);
+    executor = std::move(Other.executor);
+    continuation_executor = std::move(Other.continuation_executor);
     prio = Other.prio;
     return *this;
   }
@@ -142,7 +147,7 @@ public:
   /// coroutine. You must await the return type before destroying it.
   inline aw_run_early<Result, Result> run_early() && {
     return aw_run_early<Result, Result>(
-      std::move(wrapped), prio, executor, continuation_executor
+      std::move(wrapped), executor, continuation_executor, prio
     );
   }
 };
@@ -152,23 +157,23 @@ class [[nodiscard(
   "You must use the aw_spawned_task<void> by one of: 1. co_await 2. "
   "detach() 3. run_early()"
 )]] aw_spawned_task<void> {
+  task<void> wrapped;
   detail::type_erased_executor* executor;
   detail::type_erased_executor* continuation_executor;
-  task<void> wrapped;
   size_t prio;
-
-  friend class aw_spawned_task_impl<void, false>;
 
 public:
   /// It is recommended to call `spawn()` instead of using this constructor
   /// directly.
   aw_spawned_task(task<void>&& Task)
-      : executor(detail::this_thread::executor),
+      : wrapped(std::move(Task)), executor(detail::this_thread::executor),
         continuation_executor(detail::this_thread::executor),
-        wrapped(std::move(Task)), prio(detail::this_thread::this_task.prio) {}
+        prio(detail::this_thread::this_task.prio) {}
 
-  aw_spawned_task_impl<void, false> operator co_await() {
-    return aw_spawned_task_impl<void, false>(*this);
+  aw_spawned_task_impl<void> operator co_await() {
+    return aw_spawned_task_impl<void>(
+      std::move(wrapped), executor, continuation_executor, prio
+    );
   }
 
   /// Submit the task to the executor immediately. It cannot be awaited
@@ -178,19 +183,23 @@ public:
     executor->post(std::move(wrapped), prio);
   }
 
+#ifndef NDEBUG
   ~aw_spawned_task() noexcept {
     // If you spawn a task that returns a void type,
     // then you must co_await or detach the return of spawn!
     assert(!wrapped);
   }
+#endif
   aw_spawned_task(const aw_spawned_task&) = delete;
   aw_spawned_task& operator=(const aw_spawned_task&) = delete;
   aw_spawned_task(aw_spawned_task&& Other)
-      : executor(std::move(Other.executor)), wrapped(std::move(Other.wrapped)),
+      : wrapped(std::move(Other.wrapped)), executor(std::move(Other.executor)),
+        continuation_executor(std::move(Other.continuation_executor)),
         prio(Other.prio) {}
   aw_spawned_task& operator=(aw_spawned_task&& Other) {
-    executor = std::move(Other.executor);
     wrapped = std::move(Other.wrapped);
+    executor = std::move(Other.executor);
+    continuation_executor = std::move(Other.continuation_executor);
     prio = Other.prio;
     return *this;
   }
@@ -241,7 +250,7 @@ public:
   /// coroutine. You must await the returned before destroying it.
   inline aw_run_early<void, void> run_early() && {
     return aw_run_early<void, void>(
-      std::move(wrapped), prio, executor, continuation_executor
+      std::move(wrapped), executor, continuation_executor, prio
     );
   }
 };
@@ -256,73 +265,66 @@ template <typename Result> aw_spawned_task<Result> spawn(task<Result>&& Task) {
   return aw_spawned_task<Result>(std::move(Task));
 }
 
-template <typename Result, bool RValue>
-aw_spawned_task_impl<Result, RValue>::aw_spawned_task_impl(
-  aw_spawned_task<Result>& Me
+template <typename Result>
+aw_spawned_task_impl<Result>::aw_spawned_task_impl(
+  task<Result> Task, detail::type_erased_executor* Executor,
+  detail::type_erased_executor* ContinuationExecutor, size_t Prio
 )
-    : me(Me) {}
+    : wrapped{std::move(Task)}, executor{Executor},
+      continuation_executor{ContinuationExecutor}, prio{Prio} {}
 
 /// Always suspends.
-template <typename Result, bool RValue>
-constexpr bool
-aw_spawned_task_impl<Result, RValue>::await_ready() const noexcept {
+template <typename Result>
+inline bool aw_spawned_task_impl<Result>::await_ready() const noexcept {
   return false;
 }
 
 /// Suspends the outer coroutine, submits the wrapped task to the
 /// executor, and waits for it to complete.
-template <typename Result, bool RValue>
-constexpr void aw_spawned_task_impl<Result, RValue>::await_suspend(
-  std::coroutine_handle<> Outer
+template <typename Result>
+inline void
+aw_spawned_task_impl<Result>::await_suspend(std::coroutine_handle<> Outer
 ) noexcept {
-  assert(me.wrapped);
-  auto& p = me.wrapped.promise();
+  assert(wrapped);
+  auto& p = wrapped.promise();
   p.continuation = Outer.address();
-  p.continuation_executor = me.continuation_executor;
-  p.result_ptr = &me.result;
-  me.executor->post(std::move(me.wrapped), me.prio);
+  p.continuation_executor = continuation_executor;
+  p.result_ptr = &result;
+  executor->post(std::move(wrapped), prio);
 }
 
 /// Returns the value provided by the wrapped task.
-template <typename Result, bool RValue>
-constexpr Result& aw_spawned_task_impl<Result, RValue>::await_resume() noexcept
-  requires(!RValue)
-{
-  return me.result;
-}
-
-/// Returns the value provided by the wrapped task.
-template <typename Result, bool RValue>
-constexpr Result&& aw_spawned_task_impl<Result, RValue>::await_resume() noexcept
-  requires(RValue)
-{
+template <typename Result>
+inline Result&& aw_spawned_task_impl<Result>::await_resume() noexcept {
   // This appears to never be used - the 'this' parameter to
   // await_resume() is always an lvalue
-  return std::move(me.result);
+  return std::move(result);
 }
 
-constexpr aw_spawned_task_impl<void, false>::aw_spawned_task_impl(
-  aw_spawned_task<void>& Me
+inline aw_spawned_task_impl<void>::aw_spawned_task_impl(
+  task<void> Task, detail::type_erased_executor* Executor,
+  detail::type_erased_executor* ContinuationExecutor, size_t Prio
 )
-    : me(Me) {}
+    : wrapped{std::move(Task)}, executor{Executor},
+      continuation_executor{ContinuationExecutor}, prio{Prio} {}
 
-constexpr bool aw_spawned_task_impl<void, false>::await_ready() const noexcept {
+inline bool aw_spawned_task_impl<void>::await_ready() const noexcept {
   return false;
 }
 
 /// Suspends the outer coroutine, submits the wrapped task to the
 /// executor, and waits for it to complete.
-constexpr void
-aw_spawned_task_impl<void, false>::await_suspend(std::coroutine_handle<> Outer
+inline void
+aw_spawned_task_impl<void>::await_suspend(std::coroutine_handle<> Outer
 ) noexcept {
-  assert(me.wrapped);
-  auto& p = me.wrapped.promise();
+  assert(wrapped);
+  auto& p = wrapped.promise();
   p.continuation = Outer.address();
-  p.continuation_executor = me.continuation_executor;
-  me.executor->post(std::move(me.wrapped), me.prio);
+  p.continuation_executor = continuation_executor;
+  executor->post(std::move(wrapped), prio);
 }
 
 /// Does nothing.
-constexpr void aw_spawned_task_impl<void, false>::await_resume() noexcept {}
+inline void aw_spawned_task_impl<void>::await_resume() noexcept {}
 
 } // namespace tmc

--- a/include/tmc/spawn_task.hpp
+++ b/include/tmc/spawn_task.hpp
@@ -140,7 +140,7 @@ public:
 
   /// Submits the wrapped task immediately, without suspending the current
   /// coroutine. You must await the return type before destroying it.
-  inline aw_run_early<Result, Result> run_early() {
+  inline aw_run_early<Result, Result> run_early() && {
     return aw_run_early<Result, Result>(
       std::move(wrapped), prio, executor, continuation_executor
     );
@@ -239,7 +239,7 @@ public:
 
   /// Submits the wrapped task immediately, without suspending the current
   /// coroutine. You must await the returned before destroying it.
-  inline aw_run_early<void, void> run_early() {
+  inline aw_run_early<void, void> run_early() && {
     return aw_run_early<void, void>(
       std::move(wrapped), prio, executor, continuation_executor
     );

--- a/include/tmc/spawn_task.hpp
+++ b/include/tmc/spawn_task.hpp
@@ -30,7 +30,8 @@ public:
 
   /// Suspends the outer coroutine, submits the wrapped task to the
   /// executor, and waits for it to complete.
-  inline void await_suspend(std::coroutine_handle<> Outer) noexcept {
+  TMC_FORCE_INLINE inline void await_suspend(std::coroutine_handle<> Outer
+  ) noexcept {
     assert(wrapped);
     auto& p = wrapped.promise();
     p.continuation = Outer.address();
@@ -67,7 +68,8 @@ public:
 
   /// Suspends the outer coroutine, submits the wrapped task to the
   /// executor, and waits for it to complete.
-  inline void await_suspend(std::coroutine_handle<> Outer) noexcept {
+  TMC_FORCE_INLINE inline void await_suspend(std::coroutine_handle<> Outer
+  ) noexcept {
     assert(wrapped);
     auto& p = wrapped.promise();
     p.continuation = Outer.address();

--- a/include/tmc/spawn_task.hpp
+++ b/include/tmc/spawn_task.hpp
@@ -166,8 +166,8 @@ public:
 
   /// Submits the wrapped task immediately, without suspending the current
   /// coroutine. You must await the return type before destroying it.
-  inline aw_run_early<Result, Result> run_early() && {
-    return aw_run_early<Result, Result>(
+  inline aw_run_early<Result> run_early() && {
+    return aw_run_early<Result>(
       std::move(wrapped), executor, continuation_executor, prio
     );
   }
@@ -269,8 +269,8 @@ public:
 
   /// Submits the wrapped task immediately, without suspending the current
   /// coroutine. You must await the returned before destroying it.
-  inline aw_run_early<void, void> run_early() && {
-    return aw_run_early<void, void>(
+  inline aw_run_early<void> run_early() && {
+    return aw_run_early<void>(
       std::move(wrapped), executor, continuation_executor, prio
     );
   }

--- a/include/tmc/spawn_task.hpp
+++ b/include/tmc/spawn_task.hpp
@@ -140,11 +140,11 @@ public:
 
   /// Submits the wrapped task immediately, without suspending the current
   /// coroutine. You must await the return type before destroying it.
-  inline aw_run_early<Result, Result> run_early() && {
-    return aw_run_early<Result, Result>(
-      std::move(wrapped), prio, executor, continuation_executor
-    );
-  }
+  // inline aw_run_early<Result, Result> run_early() && {
+  //   return aw_run_early<Result, Result>(
+  //     std::move(wrapped), prio, executor, continuation_executor
+  //   );
+  // }
 };
 
 template <>
@@ -239,11 +239,11 @@ public:
 
   /// Submits the wrapped task immediately, without suspending the current
   /// coroutine. You must await the returned before destroying it.
-  inline aw_run_early<void, void> run_early() && {
-    return aw_run_early<void, void>(
-      std::move(wrapped), prio, executor, continuation_executor
-    );
-  }
+  // inline aw_run_early<void, void> run_early() && {
+  //   return aw_run_early<void, void>(
+  //     std::move(wrapped), prio, executor, continuation_executor
+  //   );
+  // }
 };
 
 /// `spawn()` allows you to customize the execution behavior of a task.

--- a/include/tmc/spawn_task.hpp
+++ b/include/tmc/spawn_task.hpp
@@ -140,11 +140,11 @@ public:
 
   /// Submits the wrapped task immediately, without suspending the current
   /// coroutine. You must await the return type before destroying it.
-  // inline aw_run_early<Result, Result> run_early() && {
-  //   return aw_run_early<Result, Result>(
-  //     std::move(wrapped), prio, executor, continuation_executor
-  //   );
-  // }
+  inline aw_run_early<Result, Result> run_early() && {
+    return aw_run_early<Result, Result>(
+      std::move(wrapped), prio, executor, continuation_executor
+    );
+  }
 };
 
 template <>
@@ -239,11 +239,11 @@ public:
 
   /// Submits the wrapped task immediately, without suspending the current
   /// coroutine. You must await the returned before destroying it.
-  // inline aw_run_early<void, void> run_early() && {
-  //   return aw_run_early<void, void>(
-  //     std::move(wrapped), prio, executor, continuation_executor
-  //   );
-  // }
+  inline aw_run_early<void, void> run_early() && {
+    return aw_run_early<void, void>(
+      std::move(wrapped), prio, executor, continuation_executor
+    );
+  }
 };
 
 /// `spawn()` allows you to customize the execution behavior of a task.

--- a/include/tmc/spawn_task_many.hpp
+++ b/include/tmc/spawn_task_many.hpp
@@ -336,12 +336,11 @@ public:
     requires(Count != 0)
       : aw_task_many(TaskIterator, Count) {}
 
-  aw_task_many_impl<Result, Count> operator co_await() {
+  aw_task_many_impl<Result, Count> operator co_await() && {
 #ifndef NDEBUG
     assert(!did_await);
     did_await = true;
 #endif
-
     bool doSymmetricTransfer =
       executor == detail::this_thread::executor &&
       prio <= detail::this_thread::this_task.yield_priority->load(
@@ -438,7 +437,7 @@ public:
     requires(Count != 0)
       : aw_task_many(TaskIterator, Count) {}
 
-  aw_task_many_impl<void, Count> operator co_await() {
+  aw_task_many_impl<void, Count> operator co_await() && {
 #ifndef NDEBUG
     assert(!did_await);
     did_await = true;

--- a/include/tmc/spawn_task_many.hpp
+++ b/include/tmc/spawn_task_many.hpp
@@ -519,31 +519,3 @@ public:
 };
 
 } // namespace tmc
-
-// some ways to capture transformer iterator instead of entire wrapper
-// (and reduce size of this struct)
-// causes problems with CTAD; need to split Functor and non-Functor versions
-// template <typename InputIter> struct TaskIterTransformer {
-//     InputIter task_iter;
-//     aw_task_many *me;
-//     std::coroutine_handle<> operator()(size_t i) {
-//       task<void> t = *task_iter;
-//       ++task_iter;
-//       auto &p = t.promise();
-//       p.continuation = &me->continuation;
-//       p.done_count = &me->done_count;
-//       p.result_ptr = &me->result[i];
-//       return t;
-//     }
-//   };
-// iter = iter_adapter(0, TaskIterTransformer{std::move(task_iter), this});
-// iter = [this, task_iter = std::move(task_iter)](
-//     size_t i) -> std::coroutine_handle<> {
-//   task<void> t = *task_iter;
-//   ++task_iter;
-//   auto &p = t.promise();
-//   p.continuation = &continuation;
-//   p.done_count = &done_count;
-//   p.result_ptr = &result[i];
-//   return t;
-// });

--- a/include/tmc/spawn_task_many.hpp
+++ b/include/tmc/spawn_task_many.hpp
@@ -350,7 +350,7 @@ public:
 
   /// Submits the wrapped tasks immediately, without suspending the current
   /// coroutine. You must await the return type before destroying it.
-  inline aw_run_early<Result, ResultArray> run_early() {
+  inline aw_run_early<Result, ResultArray> run_early() && {
     return aw_run_early<Result, ResultArray>(std::move(*this));
   }
 };
@@ -553,7 +553,7 @@ public:
 
   /// Submits the wrapped task immediately, without suspending the current
   /// coroutine. You must await the return type before destroying it.
-  inline aw_run_early<void, void> run_early() {
+  inline aw_run_early<void, void> run_early() && {
     return aw_run_early<void, void>(std::move(*this));
   }
 };

--- a/include/tmc/spawn_task_many.hpp
+++ b/include/tmc/spawn_task_many.hpp
@@ -152,7 +152,7 @@ public:
 
   /// Suspends the outer coroutine, submits the wrapped task to the
   /// executor, and waits for it to complete.
-  inline TMC_FORCE_INLINE std::coroutine_handle<>
+  TMC_FORCE_INLINE inline std::coroutine_handle<>
   await_suspend(std::coroutine_handle<> Outer) noexcept {
     continuation = Outer;
     std::coroutine_handle<> next;
@@ -248,7 +248,7 @@ public:
 
   /// Suspends the outer coroutine, submits the wrapped task to the
   /// executor, and waits for it to complete.
-  inline TMC_FORCE_INLINE std::coroutine_handle<>
+  TMC_FORCE_INLINE inline std::coroutine_handle<>
   await_suspend(std::coroutine_handle<> Outer) noexcept {
     continuation = Outer;
     std::coroutine_handle<> next;

--- a/include/tmc/spawn_task_many.hpp
+++ b/include/tmc/spawn_task_many.hpp
@@ -179,10 +179,9 @@ public:
   /// For use when `Count` is known at compile time
   /// It is recommended to call `spawn_many()` instead of using this constructor
   /// directly.
-  template <typename Iter>
-  aw_task_many(Iter TaskIterator)
+  aw_task_many(TaskIter TaskIterator)
     requires(std::is_convertible_v<
-              typename std::iter_value_t<Iter>, task<Result>>)
+              typename std::iter_value_t<TaskIter>, task<Result>>)
       : iter{TaskIterator}, count{Count},
         executor(detail::this_thread::executor),
         continuation_executor(detail::this_thread::executor),
@@ -197,10 +196,10 @@ public:
   /// For use when `Count` is a runtime parameter.
   /// It is recommended to call `spawn_many()` instead of using this constructor
   /// directly.
-  template <typename Iter>
-  aw_task_many(Iter TaskIterator, size_t TaskCount)
-    requires(Count == 0 && std::is_convertible_v<
-                             typename std::iter_value_t<Iter>, task<Result>>)
+  aw_task_many(TaskIter TaskIterator, size_t TaskCount)
+    requires(Count == 0 &&
+             std::is_convertible_v<
+               typename std::iter_value_t<TaskIter>, task<Result>>)
       : iter{TaskIterator}, count{TaskCount},
         executor(detail::this_thread::executor),
         continuation_executor(detail::this_thread::executor),
@@ -370,10 +369,9 @@ public:
   /// For use when `Count` is known at compile time
   /// It is recommended to call `spawn_many()` instead of using this constructor
   /// directly.
-  template <typename Iter>
-  aw_task_many(Iter TaskIterator)
+  aw_task_many(TaskIter TaskIterator)
     requires(std::is_convertible_v<
-              typename std::iter_value_t<Iter>, task<void>>)
+              typename std::iter_value_t<TaskIter>, task<void>>)
       : iter{TaskIterator}, count{Count},
         executor(detail::this_thread::executor),
         continuation_executor(detail::this_thread::executor),
@@ -388,10 +386,9 @@ public:
   /// For use when `Count` is a runtime parameter.
   /// It is recommended to call `spawn_many()` instead of using this constructor
   /// directly.
-  template <typename Iter>
-  aw_task_many(Iter TaskIterator, size_t TaskCount)
+  aw_task_many(TaskIter TaskIterator, size_t TaskCount)
     requires(std::is_convertible_v<
-              typename std::iter_value_t<Iter>, task<void>>)
+              typename std::iter_value_t<TaskIter>, task<void>>)
       : iter{TaskIterator}, count{TaskCount},
         executor(detail::this_thread::executor),
         continuation_executor(detail::this_thread::executor),

--- a/include/tmc/spawn_task_many.hpp
+++ b/include/tmc/spawn_task_many.hpp
@@ -596,13 +596,7 @@ aw_task_many_impl<Result, Count, RValue>::await_suspend(
   }
   if (doSymmetricTransfer) {
     // symmetric transfer to the last task IF it should run immediately
-#if WORK_ITEM_IS(CORO)
-    return me.wrapped.back();
-#elif WORK_ITEM_IS(FUNCORO) || WORK_ITEM_IS(FUNCORO32)
-    return me.wrapped.back().as_coroutine();
-#elif WORK_ITEM_IS(FUNC)
-    return *me.wrapped.back().template target<std::coroutine_handle<>>();
-#endif
+    return TMC_WORK_ITEM_AS_STD_CORO(me.wrapped.back());
   } else {
     return std::noop_coroutine();
   }
@@ -661,14 +655,8 @@ aw_task_many_impl<void, Count, false>::await_suspend(
     me.executor->post_bulk(me.wrapped.data(), me.prio, postCount);
   }
   if (doSymmetricTransfer) {
-// symmetric transfer to the last task IF it should run immediately
-#if WORK_ITEM_IS(CORO)
-    return me.wrapped.back();
-#elif WORK_ITEM_IS(FUNCORO) || WORK_ITEM_IS(FUNCORO32)
-    return me.wrapped.back().as_coroutine();
-#elif WORK_ITEM_IS(FUNC)
-    return *me.wrapped.back().template target<std::coroutine_handle<>>();
-#endif
+    // symmetric transfer to the last task IF it should run immediately
+    return TMC_WORK_ITEM_AS_STD_CORO(me.wrapped.back());
   } else {
     return std::noop_coroutine();
   }

--- a/include/tmc/spawn_task_many.hpp
+++ b/include/tmc/spawn_task_many.hpp
@@ -153,6 +153,8 @@ class [[nodiscard(
   detail::type_erased_executor* continuation_executor;
   size_t prio;
   bool did_await;
+  // result[i] and done_count are both written by each coroutine
+  // for cache sharing efficiency, they should be adjacent
   ResultArray result;
   std::atomic<int64_t> done_count;
 

--- a/include/tmc/spawn_task_many.hpp
+++ b/include/tmc/spawn_task_many.hpp
@@ -270,10 +270,14 @@ public:
   }
 
   aw_task_many_impl<ResultArray, Count, false> operator co_await() & {
+    assert(!did_await);
+    did_await = true;
     return aw_task_many_impl<ResultArray, Count, false>(*this);
   }
 
   aw_task_many_impl<ResultArray, Count, true> operator co_await() && {
+    assert(!did_await);
+    did_await = true;
     return aw_task_many_impl<ResultArray, Count, true>(*this);
   }
 
@@ -474,6 +478,8 @@ public:
   }
 
   aw_task_many_impl<void, Count, false> operator co_await() {
+    assert(!did_await);
+    did_await = true;
     return aw_task_many_impl<void, Count, false>(*this);
   }
 
@@ -579,8 +585,6 @@ aw_task_many_impl<Result, Count, RValue>::await_suspend(
   std::coroutine_handle<> Outer
 ) noexcept {
   me.continuation = Outer;
-  assert(!me.did_await);
-  me.did_await = true;
   // if the newly posted tasks are at least as high priority as the currently
   // running or next-running (yield requested) task, we can directly transfer
   // to one
@@ -639,8 +643,6 @@ aw_task_many_impl<void, Count, false>::await_suspend(
   std::coroutine_handle<> Outer
 ) noexcept {
   me.continuation = Outer;
-  assert(!me.did_await);
-  me.did_await = true;
   // if the newly posted tasks are at least as high priority as the currently
   // running or next-running (yield requested) task, we can directly transfer
   // to one

--- a/include/tmc/spawn_task_many.hpp
+++ b/include/tmc/spawn_task_many.hpp
@@ -492,7 +492,7 @@ inline bool aw_task_many_impl<Result, Count>::await_ready() const noexcept {
 /// Suspends the outer coroutine, submits the wrapped task to the
 /// executor, and waits for it to complete.
 template <typename Result, size_t Count>
-inline std::coroutine_handle<> __attribute__((always_inline))
+inline TMC_FORCE_INLINE std::coroutine_handle<>
 aw_task_many_impl<Result, Count>::await_suspend(std::coroutine_handle<> Outer
 ) noexcept {
   continuation = Outer;
@@ -586,7 +586,7 @@ inline bool aw_task_many_impl<void, Count>::await_ready() const noexcept {
 /// Suspends the outer coroutine, submits the wrapped task to the
 /// executor, and waits for it to complete.
 template <size_t Count>
-inline std::coroutine_handle<> __attribute__((always_inline))
+inline TMC_FORCE_INLINE std::coroutine_handle<>
 aw_task_many_impl<void, Count>::await_suspend(std::coroutine_handle<> Outer
 ) noexcept {
   continuation = Outer;

--- a/include/tmc/sync.hpp
+++ b/include/tmc/sync.hpp
@@ -179,7 +179,7 @@ std::future<void> post_bulk_waitable(
   };
   std::shared_ptr<BulkSyncState> sharedState =
     std::make_shared<BulkSyncState>(std::promise<void>(), Count - 1);
-#if WORK_ITEM_IS(CORO)
+#if TMC_WORK_ITEM_IS(CORO)
   Executor.post_bulk(
     iter_adapter(
       FunctorIterator,
@@ -188,7 +188,8 @@ std::future<void> post_bulk_waitable(
                  T t, std::shared_ptr<BulkSyncState> SharedState
                ) -> task<void> {
           t();
-          if (SharedState->done_count.fetch_sub(1, std::memory_order_acq_rel) == 0) {
+          if (SharedState->done_count.fetch_sub(1, std::memory_order_acq_rel) ==
+              0) {
             SharedState->promise.set_value();
           }
           co_return;
@@ -204,7 +205,8 @@ std::future<void> post_bulk_waitable(
       [sharedState](Iter iter) mutable -> auto {
         return [f = *iter, sharedState]() {
           f();
-          if (sharedState->done_count.fetch_sub(1, std::memory_order_acq_rel) == 0) {
+          if (sharedState->done_count.fetch_sub(1, std::memory_order_acq_rel) ==
+              0) {
             sharedState->promise.set_value();
           }
         };

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -253,11 +253,11 @@ template <typename Result> struct task_promise {
   }
 
   static void* operator new(std::size_t n) noexcept {
+    // DEBUG - Print the size of the coroutine allocation.
+    // std::printf("task_promise new %zu -> %zu\n", n, (n + 63) & -64);
     // Round up the coroutine allocation to next 64 bytes.
     // This reduces false sharing with adjacent coroutines.
     n = (n + 63) & -64;
-    // DEBUG - Print the size of the coroutine allocation.
-    // std::printf("task_promise new %zu\n", n);
     return std::malloc(n);
   }
 

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -253,6 +253,14 @@ template <typename Result> struct task_promise {
     *result_ptr = Value;
   }
 
+  // For debug / development purposes only. Capture the size of the coroutine
+  // static void* operator new(std::size_t n) noexcept {
+  //   std::printf("task_promise new %zu\n", n);
+  //   return std::malloc(n);
+  // }
+
+  // static void operator delete(void* ptr) noexcept { std::free(ptr); }
+
   void* continuation;
   void* continuation_executor;
   std::atomic<int64_t>* done_count;

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -97,7 +97,7 @@ template <typename Result> struct mt1_continuation_resumer {
 };
 } // namespace detail
 
-template <typename Result, bool RValue> class aw_task;
+template <typename Result> class aw_task;
 
 /// The main coroutine type used by TooManyCooks. `task` is a lazy / cold
 /// coroutine and will not begin running immediately.
@@ -121,8 +121,8 @@ template <typename Result> struct task {
   /// Suspend the outer coroutine and run this task directly. The intermediate
   /// awaitable type `aw_task` cannot be used directly; the return type of the
   /// `co_await` expression will be `Result` or `void`.
-  aw_task<Result, true> operator co_await() && {
-    return aw_task<Result, true>(std::move(*this));
+  aw_task<Result> operator co_await() && {
+    return aw_task<Result>(std::move(*this));
   }
 
   /// When this task completes, the awaiting coroutine will be resumed
@@ -360,7 +360,7 @@ unsafe_task<void> into_unsafe_task(Original FuncVoid) {
 
 } // namespace detail
 
-template <typename Result, bool RValue> class aw_task {
+template <typename Result> class aw_task {
   task<Result> handle;
   Result result;
 
@@ -377,26 +377,11 @@ public:
     return std::move(handle);
   }
 
-  // I'd like to have specialiations based on the value category of this,
-  // but it turns out the awaiter is always an lvalue. So we have to customize
-  // the type based on the value category of the task that created this.
-
   /// Returns the value provided by the awaited task.
-  constexpr Result& await_resume() noexcept
-    requires(!RValue)
-  {
-    return result;
-  }
-
-  /// Returns the value provided by the awaited task.
-  constexpr Result&& await_resume() noexcept
-    requires(RValue)
-  {
-    return std::move(result);
-  }
+  constexpr Result&& await_resume() noexcept { return std::move(result); }
 };
 
-template <bool RValue> class aw_task<void, RValue> {
+template <> class aw_task<void> {
   task<void> handle;
 
   friend struct task<void>;

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -8,7 +8,9 @@
 #include <type_traits>
 
 namespace tmc {
-template <typename Result> struct task;
+template <typename Result>
+struct [[nodiscard("You must submit or co_await task for execution. Failure to "
+                   "do so will result in a memory leak.")]] task;
 
 namespace detail {
 
@@ -127,39 +129,51 @@ template <typename Result> struct task {
 
   /// When this task completes, the awaiting coroutine will be resumed
   /// on the provided executor.
-  inline task& resume_on(detail::type_erased_executor* Executor) & {
+  [[nodiscard("You must submit or co_await task for execution. Failure to "
+              "do so will result in a memory leak.")]] inline task&
+  resume_on(detail::type_erased_executor* Executor) & {
     handle.promise().continuation_executor = Executor;
     return *this;
   }
   /// When this task completes, the awaiting coroutine will be resumed
   /// on the provided executor.
   template <detail::TypeErasableExecutor Exec>
-  task& resume_on(Exec& Executor) & {
+  [[nodiscard("You must submit or co_await task for execution. Failure to "
+              "do so will result in a memory leak.")]] task&
+  resume_on(Exec& Executor) & {
     return resume_on(Executor.type_erased());
   }
   /// When this task completes, the awaiting coroutine will be resumed
   /// on the provided executor.
   template <detail::TypeErasableExecutor Exec>
-  task& resume_on(Exec* Executor) & {
+  [[nodiscard("You must submit or co_await task for execution. Failure to "
+              "do so will result in a memory leak.")]] task&
+  resume_on(Exec* Executor) & {
     return resume_on(Executor->type_erased());
   }
 
   /// When this task completes, the awaiting coroutine will be resumed
   /// on the provided executor.
-  inline task&& resume_on(detail::type_erased_executor* Executor) && {
+  [[nodiscard("You must submit or co_await task for execution. Failure to "
+              "do so will result in a memory leak.")]] inline task&&
+  resume_on(detail::type_erased_executor* Executor) && {
     handle.promise().continuation_executor = Executor;
     return *this;
   }
   /// When this task completes, the awaiting coroutine will be resumed
   /// on the provided executor.
   template <detail::TypeErasableExecutor Exec>
-  task&& resume_on(Exec& Executor) && {
+  [[nodiscard("You must submit or co_await task for execution. Failure to "
+              "do so will result in a memory leak.")]] task&&
+  resume_on(Exec& Executor) && {
     return resume_on(Executor.type_erased());
   }
   /// When this task completes, the awaiting coroutine will be resumed
   /// on the provided executor.
   template <detail::TypeErasableExecutor Exec>
-  task&& resume_on(Exec* Executor) && {
+  [[nodiscard("You must submit or co_await task for execution. Failure to "
+              "do so will result in a memory leak.")]] task&&
+  resume_on(Exec* Executor) && {
     return resume_on(Executor->type_erased());
   }
 

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -253,13 +253,16 @@ template <typename Result> struct task_promise {
     *result_ptr = Value;
   }
 
-  // For debug / development purposes only. Capture the size of the coroutine
-  // static void* operator new(std::size_t n) noexcept {
-  //   std::printf("task_promise new %zu\n", n);
-  //   return std::malloc(n);
-  // }
+  static void* operator new(std::size_t n) noexcept {
+    // Round up the coroutine allocation to next 64 bytes.
+    // This reduces false sharing with adjacent coroutines.
+    n = (n + 63) & -64;
+    // DEBUG - Print the size of the coroutine allocation.
+    // std::printf("task_promise new %zu\n", n);
+    return std::malloc(n);
+  }
 
-  // static void operator delete(void* ptr) noexcept { std::free(ptr); }
+  static void operator delete(void* ptr) noexcept { std::free(ptr); }
 
   void* continuation;
   void* continuation_executor;

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -4,7 +4,7 @@
 #include <atomic>
 #include <cassert>
 #include <coroutine>
-#include <cstdlib>
+#include <new>
 #include <type_traits>
 
 namespace tmc {
@@ -260,10 +260,8 @@ template <typename Result> struct task_promise {
     // Round up the coroutine allocation to next 64 bytes.
     // This reduces false sharing with adjacent coroutines.
     n = (n + 63) & -64;
-    return std::malloc(n);
+    return ::operator new(n);
   }
-
-  static void operator delete(void* ptr) noexcept { std::free(ptr); }
 
   void* continuation;
   void* continuation_executor;

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -48,7 +48,8 @@ template <typename Result> struct mt1_continuation_resumer {
         std::coroutine_handle<>::from_address(rawContinuation);
       std::coroutine_handle<> next;
       if (continuation) {
-        if (p.continuation_executor == nullptr || p.continuation_executor == this_thread::executor) {
+        if (p.continuation_executor == nullptr ||
+            p.continuation_executor == this_thread::executor) {
           next = continuation;
         } else {
           static_cast<detail::type_erased_executor*>(p.continuation_executor)
@@ -74,7 +75,8 @@ template <typename Result> struct mt1_continuation_resumer {
           detail::type_erased_executor* continuationExecutor =
             *static_cast<detail::type_erased_executor**>(p.continuation_executor
             );
-          if (continuationExecutor == nullptr || continuationExecutor == this_thread::executor) {
+          if (continuationExecutor == nullptr ||
+              continuationExecutor == this_thread::executor) {
             next = continuation;
           } else {
             continuationExecutor->post(
@@ -365,7 +367,7 @@ void post(E& Executor, C&& Coro, size_t Priority)
   Executor.post(std::coroutine_handle<>(static_cast<C&&>(Coro)), Priority);
 }
 
-#if WORK_ITEM_IS(CORO)
+#if TMC_WORK_ITEM_IS(CORO)
 /// Submits void-returning `Func` for execution on `Executor` at priority
 /// `Priority`. Functions that return values cannot be submitted this way; see
 /// `post_waitable` instead.

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -296,6 +296,10 @@ template <> struct task_promise<void> {
   // std::exception_ptr exc;
 };
 
+/// For internal usage only! to efficiently modify/pass coroutine handles.
+template <typename Result>
+using unsafe_task = std::coroutine_handle<task_promise<Result>>;
+
 } // namespace detail
 
 template <typename Result, bool RValue> class aw_task {

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -4,6 +4,7 @@
 #include <atomic>
 #include <cassert>
 #include <coroutine>
+#include <cstdlib>
 #include <type_traits>
 
 namespace tmc {
@@ -47,8 +48,7 @@ template <typename Result> struct mt1_continuation_resumer {
         std::coroutine_handle<>::from_address(rawContinuation);
       std::coroutine_handle<> next;
       if (continuation) {
-        if (p.continuation_executor == nullptr ||
-            p.continuation_executor == this_thread::executor) {
+        if (p.continuation_executor == nullptr || p.continuation_executor == this_thread::executor) {
           next = continuation;
         } else {
           static_cast<detail::type_erased_executor*>(p.continuation_executor)
@@ -74,8 +74,7 @@ template <typename Result> struct mt1_continuation_resumer {
           detail::type_erased_executor* continuationExecutor =
             *static_cast<detail::type_erased_executor**>(p.continuation_executor
             );
-          if (continuationExecutor == nullptr ||
-              continuationExecutor == this_thread::executor) {
+          if (continuationExecutor == nullptr || continuationExecutor == this_thread::executor) {
             next = continuation;
           } else {
             continuationExecutor->post(

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -127,18 +127,39 @@ template <typename Result> struct task {
 
   /// When this task completes, the awaiting coroutine will be resumed
   /// on the provided executor.
-  inline task& resume_on(detail::type_erased_executor* Executor) {
+  inline task& resume_on(detail::type_erased_executor* Executor) & {
     handle.promise().continuation_executor = Executor;
     return *this;
   }
   /// When this task completes, the awaiting coroutine will be resumed
   /// on the provided executor.
-  template <detail::TypeErasableExecutor Exec> task& resume_on(Exec& Executor) {
+  template <detail::TypeErasableExecutor Exec>
+  task& resume_on(Exec& Executor) & {
     return resume_on(Executor.type_erased());
   }
   /// When this task completes, the awaiting coroutine will be resumed
   /// on the provided executor.
-  template <detail::TypeErasableExecutor Exec> task& resume_on(Exec* Executor) {
+  template <detail::TypeErasableExecutor Exec>
+  task& resume_on(Exec* Executor) & {
+    return resume_on(Executor->type_erased());
+  }
+
+  /// When this task completes, the awaiting coroutine will be resumed
+  /// on the provided executor.
+  inline task&& resume_on(detail::type_erased_executor* Executor) && {
+    handle.promise().continuation_executor = Executor;
+    return *this;
+  }
+  /// When this task completes, the awaiting coroutine will be resumed
+  /// on the provided executor.
+  template <detail::TypeErasableExecutor Exec>
+  task&& resume_on(Exec& Executor) && {
+    return resume_on(Executor.type_erased());
+  }
+  /// When this task completes, the awaiting coroutine will be resumed
+  /// on the provided executor.
+  template <detail::TypeErasableExecutor Exec>
+  task&& resume_on(Exec* Executor) && {
     return resume_on(Executor->type_erased());
   }
 

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -365,8 +365,8 @@ unsafe_task<Result> into_unsafe_task(Original FuncResult)
   co_return FuncResult();
 }
 
-template <typename Original>
-  requires(std::is_invocable_r_v<void, Original> && !is_instance_of_v<std::decay_t<Original>, task>)
+template <typename Original, typename Result = std::invoke_result_t<Original>>
+  requires(std::is_void_v<Result> && !is_instance_of_v<std::decay_t<Original>, task>)
 unsafe_task<void> into_unsafe_task(Original FuncVoid) {
   FuncVoid();
   co_return;

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -289,6 +289,11 @@ template <typename Result> struct task_promise {
     *result_ptr = Value;
   }
 
+  // Yes, I marked operator new as noexcept. This means that if the allocation
+  // throws, std::terminate will be called.
+  // I recommend using tcmalloc with TooManyCooks, as it will also directly
+  // crash the program rather than throwing an exception:
+  // https://github.com/google/tcmalloc/blob/master/docs/reference.md#operator-new--operator-new
   static void* operator new(std::size_t n) noexcept {
     // DEBUG - Print the size of the coroutine allocation.
     // std::printf("task_promise new %zu -> %zu\n", n, (n + 63) & -64);
@@ -296,6 +301,12 @@ template <typename Result> struct task_promise {
     // This reduces false sharing with adjacent coroutines.
     n = (n + 63) & -64;
     return ::operator new(n);
+  }
+
+  static void* operator new(std::size_t n, std::align_val_t al) noexcept {
+    // Don't try to round up the allocation size if there is also a required
+    // alignment. If we end up with size > alignment, that could cause issues.
+    return ::operator new(n, al);
   }
 
   void* continuation;

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -294,7 +294,7 @@ template <> struct task_promise<void> {
   // std::exception_ptr exc;
 };
 
-/// For internal usage only! to efficiently modify/pass coroutine handles.
+/// For internal usage only! To modify promises without taking ownership.
 template <typename Result>
 using unsafe_task = std::coroutine_handle<task_promise<Result>>;
 


### PR DESCRIPTION
### Breaking Changes
Require all co_await/detach/post expressions be on an rvalue. This emphasizes that tmc::task, and other awaitables that wrap tasks, are linear types - operations that transform them into another type (or void, by submitting it to the executor) "take ownership" by moving-from them.
```cpp
// Valid
co_await task();
co_await spawn(task());
co_await spawn(task()).run_early();
spawn(task()).detach();

// Not valid
auto x = task(); co_await x;
auto y = spawn(task()); co_await y;
auto z = spawn(task()).run_early(); co_await z;
auto w = spawn(task(); w.detach();

// Valid
auto x = task(); co_await std::move(x);
auto y = spawn(task()); co_await std::move(y);
auto z = spawn(task()).run_early(); co_await std::move(z);
auto w = spawn(task(); std::move(w).detach();
```

Return type of co_await is always an rvalue:
```cpp
// Valid
auto x = co_await task();
auto y = co_await spawn(task());
auto z = co_await spawn(task()).run_early();

// Not valid
auto& x = co_await task();
auto& y = co_await spawn(task());
auto& z = co_await spawn(task()).run_early();
```

### Performance Improvements
It was observed that rounding up the coroutine frame size in `operator new()` to the nearest 64 bytes leads to a small improvement in performance - because other threads can't false share with adjacent coroutine frames. For skynet. which had a starting coroutine frame size of 280 bytes, this meant rounding up to 320 bytes, and improved runtime on the EPYC 7742 from 730ms -> 695ms. Because this implemention also marks the operator new as `noexcept` (which means that the program will terminate if allocation fails), you must explicitly opt-in to this (roundup + noexcept) behavior by defining `TMC_CUSTOM_CORO_ALLOC`.

Then, as part of the implementation of the linear type rules above, all task/spawn awaitables were separated into a pre-await type and a post-await type (returned by operator co_await). This allows the compiler to reason about their separate lifetimes, and reduces the size of the coroutine frame. Additionally, for spawn_many(), the materialization of the supplied iterator into an array of tasks is delayed until await_suspend(). This causes the array of tasks to be created on the stack instead of in the coroutine frame. Overall, this reduces the raw coroutine frame size of skynet from 280 bytes to 184 bytes. This is then rounded-up by `operator new()` to 192 bytes (with `TMC_CUSTOM_CORO_ALLOC` enabled).

This also means that Clang is able to perform coroutine RVO!

TMC_FORCE_INLINE was applied to most await_suspend functions - I believe these should be inlined anyway as they result in only a few assembly instructions. It may be that these are not inlined automatically because Clang still decorates them with `noinline` as part of the bugfix for incorrect code generation (spilling coroutine variables to the coroutine frame after it was suspended). However, in Clang 18 that bug has been resolved so the `noinline` specifier should have been removed. This application of TMC_FORCE_INLINE reduces the runtime of `fib 42` from 440ms -> 410ms.

### Other
- Mark all builder functions as nodiscard.
- Preserve value category across builder function chains.
- Implement mixins to simplify reuse of builder functions / maintain value category / linear type rules.
- Implement into_unsafe_task to simplify internal handling of move-only tasks (rules for thee... and not for me!)