### PR TITLE
Compile without warnings on GCC and MSVC

### DIFF
--- a/include/tmc/aw_resume_on.hpp
+++ b/include/tmc/aw_resume_on.hpp
@@ -102,7 +102,7 @@ public:
   }
 
   /// Always suspends.
-  constexpr bool await_ready() { return false; }
+  inline bool await_ready() { return false; }
 
   /// Post this task to the continuation executor.
   TMC_FORCE_INLINE inline void await_suspend(std::coroutine_handle<> Outer) {
@@ -112,7 +112,7 @@ public:
   /// Restores the original priority.
   /// Only necessary in case of resuming onto an executor where post()
   /// doesn't respect priority, such as ex_asio.
-  constexpr void await_resume() { detail::this_thread::this_task.prio = prio; }
+  inline void await_resume() { detail::this_thread::this_task.prio = prio; }
 
   /// When awaited, the outer coroutine will be resumed on the provided
   /// executor.
@@ -159,7 +159,7 @@ class [[nodiscard("You must co_await aw_ex_scope_enter for it to have any "
 
 public:
   /// Always suspends.
-  constexpr bool await_ready() {
+  inline bool await_ready() {
     // always have to suspend here, even if we can get the lock right away
     // we need to resume() inside of run_loop so that if this coro gets
     // suspended, it won't suspend while holding the lock forever

--- a/include/tmc/aw_yield.hpp
+++ b/include/tmc/aw_yield.hpp
@@ -17,7 +17,7 @@ class [[nodiscard("You must co_await aw_yield for it to have any effect."
 )]] aw_yield {
 public:
   /// This awaitable always suspends outer.
-  inline constexpr bool await_ready() const noexcept { return false; }
+  inline bool await_ready() const noexcept { return false; }
 
   /// Post the outer task to its current executor, so that a higher priority
   /// task can run.

--- a/include/tmc/detail/aw_run_early.hpp
+++ b/include/tmc/detail/aw_run_early.hpp
@@ -86,7 +86,7 @@ public:
 
   // This must be awaited and the child task completed before destruction.
 #ifndef NDEBUG
-  ~aw_run_early() noexcept { assert(done_count.load() < 0); }
+  ~aw_run_early_impl() noexcept { assert(done_count.load() < 0); }
 #endif
 
   // Not movable or copyable due to child task being spawned in constructor,
@@ -154,7 +154,7 @@ public:
 
 // This must be awaited and the child task completed before destruction.
 #ifndef NDEBUG
-  ~aw_run_early() noexcept { assert(done_count.load() < 0); }
+  ~aw_run_early_impl() noexcept { assert(done_count.load() < 0); }
 #endif
 
   // Not movable or copyable due to child task being spawned in constructor,

--- a/include/tmc/detail/thread_layout.hpp
+++ b/include/tmc/detail/thread_layout.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#ifdef TMC_USE_HWLOC
 #include <hwloc.h>
+#endif
 #include <vector>
 namespace tmc {
 namespace detail {

--- a/include/tmc/detail/thread_locals.hpp
+++ b/include/tmc/detail/thread_locals.hpp
@@ -85,8 +85,8 @@ inline constinit thread_local void* producers = nullptr;
 } // namespace detail
 } // namespace tmc
 
-#ifdef _MSC_VER
-#define TMC_FORCE_INLINE __forceinline
+#if defined(_MSC_VER) && !defined(__clang__)
+#define TMC_FORCE_INLINE [[msvc::forceinline]]
 #else
 #define TMC_FORCE_INLINE __attribute__((always_inline))
 #endif

--- a/include/tmc/spawn_func.hpp
+++ b/include/tmc/spawn_func.hpp
@@ -38,7 +38,7 @@ public:
   TMC_FORCE_INLINE inline void await_suspend(std::coroutine_handle<> Outer
   ) noexcept {
 #if TMC_WORK_ITEM_IS(CORO)
-    auto t = detail::into_unsafe_task(wrapped);
+    detail::unsafe_task<Result> t(detail::into_task(wrapped));
     auto& p = t.promise();
     p.continuation = Outer.address();
     p.continuation_executor = continuation_executor;
@@ -91,7 +91,7 @@ public:
   TMC_FORCE_INLINE inline void await_suspend(std::coroutine_handle<> Outer
   ) noexcept {
 #if TMC_WORK_ITEM_IS(CORO)
-    auto t = detail::into_unsafe_task(wrapped);
+    detail::unsafe_task<void> t(detail::into_task(wrapped));
     auto& p = t.promise();
     p.continuation = Outer.address();
     p.continuation_executor = continuation_executor;
@@ -256,7 +256,7 @@ public:
     did_await = true;
 #endif
 #if TMC_WORK_ITEM_IS(CORO)
-    executor->post(detail::into_unsafe_task(wrapped), prio);
+    executor->post(detail::into_task(wrapped), prio);
 #else
     executor->post(std::move(wrapped), prio);
 #endif

--- a/include/tmc/spawn_task_many.hpp
+++ b/include/tmc/spawn_task_many.hpp
@@ -122,7 +122,7 @@ template <typename Result, size_t Count> class aw_task_many_impl {
     for (; i < size; ++i) {
       // TODO this std::move allows silently moving-from pointers and arrays
       // reimplement those usages with move_iterator instead
-      detail::unsafe_task<Result> t(detail::into_unsafe_task(std::move(*Iter)));
+      detail::unsafe_task<Result> t(detail::into_task(std::move(*Iter)));
       auto& p = t.promise();
       p.continuation = &continuation;
       p.continuation_executor = &continuation_executor;
@@ -219,7 +219,7 @@ template <size_t Count> class aw_task_many_impl<void, Count> {
     for (; i < size; ++i) {
       // TODO this std::move allows silently moving-from pointers and arrays
       // reimplement those usages with move_iterator instead
-      detail::unsafe_task<void> t(detail::into_unsafe_task(std::move(*Iter)));
+      detail::unsafe_task<void> t(detail::into_task(std::move(*Iter)));
       auto& p = t.promise();
       p.continuation = &continuation;
       p.continuation_executor = &continuation_executor;
@@ -475,7 +475,7 @@ public:
     for (size_t i = 0; i < size; ++i) {
       // TODO this std::move allows silently moving-from pointers and arrays
       // reimplement those usages with move_iterator instead
-      taskArr[i] = detail::into_unsafe_task(std::move(*iter));
+      taskArr[i] = detail::into_task(std::move(*iter));
       ++iter;
     }
     executor->post_bulk(taskArr.data(), prio, size);

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -34,10 +34,10 @@ template <typename Result> struct mt1_continuation_resumer {
   static_assert(alignof(void*) == alignof(std::coroutine_handle<>));
   static_assert(std::is_trivially_copyable_v<std::coroutine_handle<>>);
   static_assert(std::is_trivially_destructible_v<std::coroutine_handle<>>);
-  constexpr bool await_ready() const noexcept { return false; }
-  constexpr void await_resume() const noexcept {}
+  inline bool await_ready() const noexcept { return false; }
+  inline void await_resume() const noexcept {}
 
-  constexpr std::coroutine_handle<>
+  inline std::coroutine_handle<>
   await_suspend(std::coroutine_handle<task_promise<Result>> Handle
   ) const noexcept {
     auto& p = Handle.promise();
@@ -177,7 +177,7 @@ template <typename Result> struct task {
     return resume_on(Executor->type_erased());
   }
 
-  constexpr task() noexcept : handle(nullptr) {}
+  inline task() noexcept : handle(nullptr) {}
 
 #ifndef TMC_TRIVIAL_TASK
   /// Tasks are move-only
@@ -229,7 +229,7 @@ template <typename Result> struct task {
     return std::coroutine_handle<promise_type>::from_address(addr);
   }
 
-  static constexpr task from_address(void* addr) noexcept {
+  static task from_address(void* addr) noexcept {
     task t;
     t.handle = std::coroutine_handle<promise_type>::from_address(addr);
     return t;
@@ -243,7 +243,7 @@ template <typename Result> struct task {
 
   bool done() const noexcept { return handle.done(); }
 
-  constexpr void* address() const noexcept { return handle.address(); }
+  inline void* address() const noexcept { return handle.address(); }
 
   // std::coroutine_handle::destroy() is const, but this isn't - it nulls the
   // pointer afterward
@@ -267,8 +267,8 @@ template <typename Result> struct task_promise {
   task_promise()
       : continuation{nullptr}, continuation_executor{this_thread::executor},
         done_count{nullptr}, result_ptr{nullptr} {}
-  constexpr std::suspend_always initial_suspend() const noexcept { return {}; }
-  constexpr mt1_continuation_resumer<Result> final_suspend() const noexcept {
+  inline std::suspend_always initial_suspend() const noexcept { return {}; }
+  inline mt1_continuation_resumer<Result> final_suspend() const noexcept {
     return {};
   }
   task<Result> get_return_object() noexcept {
@@ -323,8 +323,8 @@ template <> struct task_promise<void> {
   task_promise()
       : continuation{nullptr}, continuation_executor{this_thread::executor},
         done_count{nullptr} {}
-  constexpr std::suspend_always initial_suspend() const noexcept { return {}; }
-  constexpr mt1_continuation_resumer<void> final_suspend() const noexcept {
+  inline std::suspend_always initial_suspend() const noexcept { return {}; }
+  inline mt1_continuation_resumer<void> final_suspend() const noexcept {
     return {};
   }
   task<void> get_return_object() noexcept {
@@ -358,10 +358,10 @@ namespace tmc {
 namespace detail {
 
 template <class T, template <class...> class U>
-inline constexpr bool is_instance_of_v = std::false_type{};
+constexpr inline bool is_instance_of_v = std::false_type{};
 
 template <template <class...> class U, class... Vs>
-inline constexpr bool is_instance_of_v<U<Vs...>, U> = std::true_type{};
+constexpr inline bool is_instance_of_v<U<Vs...>, U> = std::true_type{};
 
 /// Makes a detail::unsafe_task<Result> from a task<Result> or a Result(void)
 /// functor.
@@ -396,8 +396,8 @@ template <typename Result> class aw_task {
   aw_task(task<Result>&& Handle) : handle(std::move(Handle)) {}
 
 public:
-  constexpr bool await_ready() const noexcept { return handle.done(); }
-  constexpr std::coroutine_handle<> await_suspend(std::coroutine_handle<> Outer
+  inline bool await_ready() const noexcept { return handle.done(); }
+  inline std::coroutine_handle<> await_suspend(std::coroutine_handle<> Outer
   ) noexcept {
     auto& p = handle.promise();
     p.continuation = Outer.address();
@@ -406,7 +406,7 @@ public:
   }
 
   /// Returns the value provided by the awaited task.
-  constexpr Result&& await_resume() noexcept { return std::move(result); }
+  inline Result&& await_resume() noexcept { return std::move(result); }
 };
 
 template <> class aw_task<void> {
@@ -416,14 +416,14 @@ template <> class aw_task<void> {
   inline aw_task(task<void>&& Handle) : handle(std::move(Handle)) {}
 
 public:
-  constexpr bool await_ready() const noexcept { return handle.done(); }
-  constexpr std::coroutine_handle<> await_suspend(std::coroutine_handle<> Outer
+  inline bool await_ready() const noexcept { return handle.done(); }
+  inline std::coroutine_handle<> await_suspend(std::coroutine_handle<> Outer
   ) noexcept {
     auto& p = handle.promise();
     p.continuation = Outer.address();
     return std::move(handle);
   }
-  constexpr void await_resume() noexcept {}
+  inline void await_resume() noexcept {}
 };
 
 /// Submits `Coro` for execution on `Executor` at priority `Priority`. Tasks


### PR DESCRIPTION
Some of this is my fault / sloppiness.
Some of it is GCC sucking - the BaseWrapper workaround feels like it shouldn't be necessary.