### PR TITLE
More bulk submission / iterator enhancements

### DIFF
--- a/include/tmc/aw_yield.hpp
+++ b/include/tmc/aw_yield.hpp
@@ -4,7 +4,7 @@
 
 namespace tmc {
 /// Returns true if a higher priority task is requesting to run on this thread.
-static inline bool yield_requested() {
+inline bool yield_requested() {
   // yield if the yield_priority value is smaller (higher priority)
   // than our currently running task
   return detail::this_thread::this_task.yield_priority->load(

--- a/include/tmc/detail/ex_cpu.ipp
+++ b/include/tmc/detail/ex_cpu.ipp
@@ -6,7 +6,7 @@
 #include "tmc/ex_cpu.hpp"
 
 namespace tmc {
-void ex_cpu::notify_n(size_t Priority, size_t Count) {
+void ex_cpu::notify_n(size_t Count, size_t Priority) {
 // TODO set notified threads prev_prod (index 1) to this?
 #ifdef _MSC_VER
   size_t workingThreadCount = static_cast<size_t>(

--- a/include/tmc/detail/thread_locals.hpp
+++ b/include/tmc/detail/thread_locals.hpp
@@ -48,13 +48,13 @@ public:
   void* executor;
   void (*s_post)(void* Erased, work_item&& Item, size_t Priority);
   void (*s_post_bulk)(
-    void* Erased, work_item* Items, size_t Priority, size_t Count
+    void* Erased, work_item* Items, size_t Count, size_t Priority
   );
   inline void post(work_item&& Item, size_t Priority) {
     s_post(executor, std::move(Item), Priority);
   }
-  inline void post_bulk(work_item* Items, size_t Priority, size_t Count) {
-    s_post_bulk(executor, Items, Priority, Count);
+  inline void post_bulk(work_item* Items, size_t Count, size_t Priority) {
+    s_post_bulk(executor, Items, Count, Priority);
   }
 
   template <typename T> type_erased_executor(T* Executor) {
@@ -63,8 +63,8 @@ public:
       static_cast<T*>(Erased)->post(std::move(Item), Priority);
     };
     s_post_bulk =
-      [](void* Erased, work_item* Items, size_t Priority, size_t Count) {
-        static_cast<T*>(Erased)->post_bulk(Items, Priority, Count);
+      [](void* Erased, work_item* Items, size_t Count, size_t Priority) {
+        static_cast<T*>(Erased)->post_bulk(Items, Count, Priority);
       };
   }
 };

--- a/include/tmc/ex_braid.hpp
+++ b/include/tmc/ex_braid.hpp
@@ -74,8 +74,8 @@ public:
   /// start executing tasks on the braid. `It` must be an iterator
   /// type that implements `operator*()` and `It& operator++()`.
   template <typename It>
-  void post_bulk(It Items, size_t Priority, size_t Count) {
-    queue.enqueue_bulk(Items, Count);
+  void post_bulk(It&& Items, size_t Priority, size_t Count) {
+    queue.enqueue_bulk(std::forward<It>(Items), Count);
     if (!lock->is_locked()) {
       parent_executor->post(
         try_run_loop(lock, destroyed_by_this_thread), Priority

--- a/include/tmc/ex_braid.hpp
+++ b/include/tmc/ex_braid.hpp
@@ -74,7 +74,7 @@ public:
   /// start executing tasks on the braid. `It` must be an iterator
   /// type that implements `operator*()` and `It& operator++()`.
   template <typename It>
-  void post_bulk(It&& Items, size_t Priority, size_t Count) {
+  void post_bulk(It&& Items, size_t Count, size_t Priority) {
     queue.enqueue_bulk(std::forward<It>(Items), Count);
     if (!lock->is_locked()) {
       parent_executor->post(

--- a/include/tmc/ex_cpu.hpp
+++ b/include/tmc/ex_cpu.hpp
@@ -159,8 +159,10 @@ public:
   /// Submits `count` items to the executor. `It` is expected to be an iterator
   /// type that implements `operator*()` and `It& operator++()`.
   template <typename It>
-  void post_bulk(It Items, size_t Priority, size_t Count) {
-    work_queues[Priority].enqueue_bulk_ex_cpu(Items, Count, Priority);
+  void post_bulk(It&& Items, size_t Priority, size_t Count) {
+    work_queues[Priority].enqueue_bulk_ex_cpu(
+      std::forward<It>(Items), Count, Priority
+    );
     notify_n(Priority, Count);
   }
 };

--- a/include/tmc/ex_cpu.hpp
+++ b/include/tmc/ex_cpu.hpp
@@ -66,7 +66,7 @@ class ex_cpu {
   size_t NO_TASK_RUNNING;
 #endif
 
-  void notify_n(size_t Priority, size_t Count);
+  void notify_n(size_t Count, size_t Priority);
   void init_thread_locals(size_t Slot);
 #ifndef TMC_USE_MUTEXQ
   void init_queue_iteration_order(
@@ -159,11 +159,11 @@ public:
   /// Submits `count` items to the executor. `It` is expected to be an iterator
   /// type that implements `operator*()` and `It& operator++()`.
   template <typename It>
-  void post_bulk(It&& Items, size_t Priority, size_t Count) {
+  void post_bulk(It&& Items, size_t Count, size_t Priority) {
     work_queues[Priority].enqueue_bulk_ex_cpu(
       std::forward<It>(Items), Count, Priority
     );
-    notify_n(Priority, Count);
+    notify_n(Count, Priority);
   }
 };
 

--- a/include/tmc/spawn_many.hpp
+++ b/include/tmc/spawn_many.hpp
@@ -24,10 +24,10 @@ class aw_task_many;
 ///
 /// Submits items in range [Begin, Begin + Count) to the executor.
 template <
-  size_t Count, typename TaskIter,
-  typename Result = typename std::iter_value_t<TaskIter>::result_type>
+  size_t Count, typename TaskIter, typename Task = std::iter_value_t<TaskIter>,
+  typename Result = Task::result_type>
 aw_task_many<Result, Count, TaskIter, size_t> spawn_many(TaskIter&& Begin)
-  requires(std::is_convertible_v<std::iter_value_t<TaskIter>, task<Result>>)
+  requires(detail::is_task_result_v<Task, Result>)
 {
   static_assert(Count != 0);
   return aw_task_many<Result, Count, TaskIter, size_t>(
@@ -42,11 +42,11 @@ aw_task_many<Result, Count, TaskIter, size_t> spawn_many(TaskIter&& Begin)
 ///
 /// Submits items in range [Begin, Begin + TaskCount) to the executor.
 template <
-  typename TaskIter,
-  typename Result = typename std::iter_value_t<TaskIter>::result_type>
+  typename TaskIter, typename Task = std::iter_value_t<TaskIter>,
+  typename Result = Task::result_type>
 aw_task_many<Result, 0, TaskIter, size_t>
 spawn_many(TaskIter&& Begin, size_t TaskCount)
-  requires(std::is_convertible_v<std::iter_value_t<TaskIter>, task<Result>>)
+  requires(detail::is_task_result_v<Task, Result>)
 {
   return aw_task_many<Result, 0, TaskIter, size_t>(
     std::forward<TaskIter>(Begin), TaskCount, 0
@@ -70,10 +70,11 @@ spawn_many(TaskIter&& Begin, size_t TaskCount)
 /// Submits items in range [Begin, End) to the executor.
 template <
   size_t MaxCount = 0, typename TaskIter,
-  typename Result = typename std::iter_value_t<TaskIter>::result_type>
+  typename Task = std::iter_value_t<TaskIter>,
+  typename Result = Task::result_type>
 aw_task_many<Result, MaxCount, TaskIter, TaskIter>
 spawn_many(TaskIter&& Begin, TaskIter&& End)
-  requires(std::is_convertible_v<std::iter_value_t<TaskIter>, task<Result>>)
+  requires(detail::is_task_result_v<Task, Result>)
 {
   return aw_task_many<Result, MaxCount, TaskIter, TaskIter>(
     std::forward<TaskIter>(Begin), std::forward<TaskIter>(End),
@@ -92,11 +93,11 @@ spawn_many(TaskIter&& Begin, TaskIter&& End)
 ///
 /// Submits items in range [Begin, min(Begin + MaxCount, End)) to the executor.
 template <
-  typename TaskIter,
-  typename Result = typename std::iter_value_t<TaskIter>::result_type>
+  typename TaskIter, typename Task = std::iter_value_t<TaskIter>,
+  typename Result = Task::result_type>
 aw_task_many<Result, 0, TaskIter, TaskIter>
 spawn_many(TaskIter&& Begin, TaskIter&& End, size_t MaxCount)
-  requires(std::is_convertible_v<std::iter_value_t<TaskIter>, task<Result>>)
+  requires(detail::is_task_result_v<Task, Result>)
 {
   return aw_task_many<Result, 0, TaskIter, TaskIter>(
     std::forward<TaskIter>(Begin), std::forward<TaskIter>(End), MaxCount
@@ -116,11 +117,7 @@ template <
   typename Result = std::invoke_result_t<Functor>>
 aw_task_many<Result, Count, FuncIter, size_t>
 spawn_many(FuncIter&& FunctorIterator)
-  requires(
-    std::is_invocable_r_v<Result, Functor> && (!requires {
-      typename Functor::result_type;
-    } || !std::is_convertible_v<Functor, task<typename Functor::result_type>>)
-  )
+  requires(detail::is_func_result_v<Functor, Result>)
 {
   static_assert(Count != 0);
   return aw_task_many<Result, Count, FuncIter, size_t>(
@@ -140,11 +137,7 @@ template <
   typename Result = std::invoke_result_t<Functor>>
 aw_task_many<Result, 0, FuncIter, size_t>
 spawn_many(FuncIter&& FunctorIterator, size_t FunctorCount)
-  requires(
-    std::is_invocable_r_v<Result, Functor> && (!requires {
-      typename Functor::result_type;
-    } || !std::is_convertible_v<Functor, task<typename Functor::result_type>>)
-  )
+  requires(detail::is_func_result_v<Functor, Result>)
 {
   return aw_task_many<Result, 0, FuncIter, size_t>(
     std::forward<FuncIter>(FunctorIterator), FunctorCount, 0
@@ -174,11 +167,7 @@ template <
   typename Result = std::invoke_result_t<Functor>>
 aw_task_many<Result, MaxCount, FuncIter, FuncIter>
 spawn_many(FuncIter&& Begin, FuncIter&& End)
-  requires(
-    std::is_invocable_r_v<Result, Functor> && (!requires {
-      typename Functor::result_type;
-    } || !std::is_convertible_v<Functor, task<typename Functor::result_type>>)
-  )
+  requires(detail::is_func_result_v<Functor, Result>)
 {
   return aw_task_many<Result, MaxCount, FuncIter, FuncIter>(
     std::forward<FuncIter>(Begin), std::forward<FuncIter>(End),
@@ -202,11 +191,7 @@ template <
   typename Result = std::invoke_result_t<Functor>>
 aw_task_many<Result, 0, FuncIter, FuncIter>
 spawn_many(FuncIter&& Begin, FuncIter&& End, size_t MaxCount)
-  requires(
-    std::is_invocable_r_v<Result, Functor> && (!requires {
-      typename Functor::result_type;
-    } || !std::is_convertible_v<Functor, task<typename Functor::result_type>>)
-  )
+  requires(detail::is_func_result_v<Functor, Result>)
 {
   return aw_task_many<Result, 0, FuncIter, FuncIter>(
     std::forward<FuncIter>(Begin), std::forward<FuncIter>(End), MaxCount

--- a/include/tmc/spawn_many.hpp
+++ b/include/tmc/spawn_many.hpp
@@ -17,7 +17,7 @@ namespace tmc {
 template <typename Result, size_t Count, typename IterBegin, typename IterEnd>
 class aw_task_many;
 
-/// For use when the number of items to spawn is known at compile time
+/// For use when the number of items to spawn is known at compile time.
 /// `Count` must be non-zero.
 /// `TaskIter` must be an iterator type that implements `operator*()` and
 /// `TaskIter& operator++()`.
@@ -92,7 +92,7 @@ spawn_many(TaskIter Begin, TaskIter End, size_t MaxCount)
   return aw_task_many<Result, 0, TaskIter, TaskIter>(Begin, End, MaxCount);
 }
 
-/// For use when the number of items to spawn is known at compile time
+/// For use when the number of items to spawn is known at compile time.
 /// `Count` must be non-zero.
 /// `Functor` must be a copyable type that implements `Result operator()`.
 /// `FuncIter` must be an iterator type that implements `operator*()` and

--- a/include/tmc/spawn_many.hpp
+++ b/include/tmc/spawn_many.hpp
@@ -26,11 +26,14 @@ class aw_task_many;
 template <
   size_t Count, typename TaskIter,
   typename Result = typename std::iter_value_t<TaskIter>::result_type>
-aw_task_many<Result, Count, TaskIter, size_t> spawn_many(TaskIter TaskIterator)
+aw_task_many<Result, Count, TaskIter, size_t> spawn_many(TaskIter&& TaskIterator
+)
   requires(std::is_convertible_v<std::iter_value_t<TaskIter>, task<Result>>)
 {
   static_assert(Count != 0);
-  return aw_task_many<Result, Count, TaskIter, size_t>(TaskIterator, 0, 0);
+  return aw_task_many<Result, Count, TaskIter, size_t>(
+    std::forward<TaskIter>(TaskIterator), 0, 0
+  );
 }
 
 /// For use when the number of items to spawn is a runtime parameter.
@@ -43,10 +46,12 @@ template <
   typename TaskIter,
   typename Result = typename std::iter_value_t<TaskIter>::result_type>
 aw_task_many<Result, 0, TaskIter, size_t>
-spawn_many(TaskIter TaskIterator, size_t TaskCount)
+spawn_many(TaskIter&& TaskIterator, size_t TaskCount)
   requires(std::is_convertible_v<std::iter_value_t<TaskIter>, task<Result>>)
 {
-  return aw_task_many<Result, 0, TaskIter, size_t>(TaskIterator, TaskCount, 0);
+  return aw_task_many<Result, 0, TaskIter, size_t>(
+    std::forward<TaskIter>(TaskIterator), TaskCount, 0
+  );
 }
 
 /// For use when the number of items to spawn may be variable.
@@ -66,11 +71,12 @@ template <
   size_t MaxCount = 0, typename TaskIter,
   typename Result = typename std::iter_value_t<TaskIter>::result_type>
 aw_task_many<Result, MaxCount, TaskIter, TaskIter>
-spawn_many(TaskIter Begin, TaskIter End)
+spawn_many(TaskIter&& Begin, TaskIter&& End)
   requires(std::is_convertible_v<std::iter_value_t<TaskIter>, task<Result>>)
 {
   return aw_task_many<Result, MaxCount, TaskIter, TaskIter>(
-    Begin, End, std::numeric_limits<size_t>::max()
+    std::forward<TaskIter>(Begin), std::forward<TaskIter>(End),
+    std::numeric_limits<size_t>::max()
   );
 }
 
@@ -86,10 +92,12 @@ template <
   typename TaskIter,
   typename Result = typename std::iter_value_t<TaskIter>::result_type>
 aw_task_many<Result, 0, TaskIter, TaskIter>
-spawn_many(TaskIter Begin, TaskIter End, size_t MaxCount)
+spawn_many(TaskIter&& Begin, TaskIter&& End, size_t MaxCount)
   requires(std::is_convertible_v<std::iter_value_t<TaskIter>, task<Result>>)
 {
-  return aw_task_many<Result, 0, TaskIter, TaskIter>(Begin, End, MaxCount);
+  return aw_task_many<Result, 0, TaskIter, TaskIter>(
+    std::forward<TaskIter>(Begin), std::forward<TaskIter>(End), MaxCount
+  );
 }
 
 /// For use when the number of items to spawn is known at compile time.
@@ -104,7 +112,7 @@ template <
   typename Functor = std::iter_value_t<FuncIter>,
   typename Result = std::invoke_result_t<Functor>>
 aw_task_many<Result, Count, FuncIter, size_t>
-spawn_many(FuncIter FunctorIterator)
+spawn_many(FuncIter&& FunctorIterator)
   requires(
     std::is_invocable_r_v<Result, Functor> && (!requires {
       typename Functor::result_type;
@@ -112,7 +120,9 @@ spawn_many(FuncIter FunctorIterator)
   )
 {
   static_assert(Count != 0);
-  return aw_task_many<Result, Count, FuncIter, size_t>(FunctorIterator, 0, 0);
+  return aw_task_many<Result, Count, FuncIter, size_t>(
+    std::forward<FuncIter>(FunctorIterator), 0, 0
+  );
 }
 
 /// For use when the number of items to spawn is a runtime parameter.
@@ -126,7 +136,7 @@ template <
   typename FuncIter, typename Functor = std::iter_value_t<FuncIter>,
   typename Result = std::invoke_result_t<Functor>>
 aw_task_many<Result, 0, FuncIter, size_t>
-spawn_many(FuncIter FunctorIterator, size_t FunctorCount)
+spawn_many(FuncIter&& FunctorIterator, size_t FunctorCount)
   requires(
     std::is_invocable_r_v<Result, Functor> && (!requires {
       typename Functor::result_type;
@@ -134,7 +144,7 @@ spawn_many(FuncIter FunctorIterator, size_t FunctorCount)
   )
 {
   return aw_task_many<Result, 0, FuncIter, size_t>(
-    FunctorIterator, FunctorCount, 0
+    std::forward<FuncIter>(FunctorIterator), FunctorCount, 0
   );
 }
 
@@ -157,7 +167,7 @@ template <
   typename Functor = std::iter_value_t<FuncIter>,
   typename Result = std::invoke_result_t<Functor>>
 aw_task_many<Result, MaxCount, FuncIter, FuncIter>
-spawn_many(FuncIter Begin, FuncIter End)
+spawn_many(FuncIter&& Begin, FuncIter&& End)
   requires(
     std::is_invocable_r_v<Result, Functor> && (!requires {
       typename Functor::result_type;
@@ -165,7 +175,8 @@ spawn_many(FuncIter Begin, FuncIter End)
   )
 {
   return aw_task_many<Result, MaxCount, FuncIter, FuncIter>(
-    Begin, End, std::numeric_limits<size_t>::max()
+    std::forward<FuncIter>(Begin), std::forward<FuncIter>(End),
+    std::numeric_limits<size_t>::max()
   );
 }
 
@@ -182,14 +193,16 @@ template <
   typename FuncIter, typename Functor = std::iter_value_t<FuncIter>,
   typename Result = std::invoke_result_t<Functor>>
 aw_task_many<Result, 0, FuncIter, FuncIter>
-spawn_many(FuncIter Begin, FuncIter End, size_t MaxCount)
+spawn_many(FuncIter&& Begin, FuncIter&& End, size_t MaxCount)
   requires(
     std::is_invocable_r_v<Result, Functor> && (!requires {
       typename Functor::result_type;
     } || !std::is_convertible_v<Functor, task<typename Functor::result_type>>)
   )
 {
-  return aw_task_many<Result, 0, FuncIter, FuncIter>(Begin, End, MaxCount);
+  return aw_task_many<Result, 0, FuncIter, FuncIter>(
+    std::forward<FuncIter>(Begin), std::forward<FuncIter>(End), MaxCount
+  );
 }
 
 template <typename Result, size_t Count> class aw_task_many_impl {

--- a/include/tmc/spawn_many.hpp
+++ b/include/tmc/spawn_many.hpp
@@ -22,17 +22,16 @@ class aw_task_many;
 /// `TaskIter` must be an iterator type that implements `operator*()` and
 /// `TaskIter& operator++()`.
 ///
-/// Submits `Count` items to the executor.
+/// Submits items in range [Begin, Begin + Count) to the executor.
 template <
   size_t Count, typename TaskIter,
   typename Result = typename std::iter_value_t<TaskIter>::result_type>
-aw_task_many<Result, Count, TaskIter, size_t> spawn_many(TaskIter&& TaskIterator
-)
+aw_task_many<Result, Count, TaskIter, size_t> spawn_many(TaskIter&& Begin)
   requires(std::is_convertible_v<std::iter_value_t<TaskIter>, task<Result>>)
 {
   static_assert(Count != 0);
   return aw_task_many<Result, Count, TaskIter, size_t>(
-    std::forward<TaskIter>(TaskIterator), 0, 0
+    std::forward<TaskIter>(Begin), 0, 0
   );
 }
 
@@ -41,16 +40,16 @@ aw_task_many<Result, Count, TaskIter, size_t> spawn_many(TaskIter&& TaskIterator
 /// `TaskIter& operator++()`.
 /// `TaskCount` must be non-zero.
 ///
-/// Submits `TaskCount` items to the executor.
+/// Submits items in range [Begin, Begin + TaskCount) to the executor.
 template <
   typename TaskIter,
   typename Result = typename std::iter_value_t<TaskIter>::result_type>
 aw_task_many<Result, 0, TaskIter, size_t>
-spawn_many(TaskIter&& TaskIterator, size_t TaskCount)
+spawn_many(TaskIter&& Begin, size_t TaskCount)
   requires(std::is_convertible_v<std::iter_value_t<TaskIter>, task<Result>>)
 {
   return aw_task_many<Result, 0, TaskIter, size_t>(
-    std::forward<TaskIter>(TaskIterator), TaskCount, 0
+    std::forward<TaskIter>(Begin), TaskCount, 0
   );
 }
 
@@ -63,10 +62,12 @@ spawn_many(TaskIter&& TaskIterator, size_t TaskCount)
 /// iterator. If the iterator produces less than `MaxCount` tasks, elements in
 /// the return array beyond the number of results actually produced by the
 /// iterator will be default-initialized.
+/// Submits items in range [Begin, min(Begin + MaxCount, End)) to the executor.
 ///
 /// - If `MaxCount` is zero/not provided, the return type will be a right-sized
 /// `std::vector<Result>` with size and capacity equal to the number of tasks
 /// produced by the iterator.
+/// Submits items in range [Begin, End) to the executor.
 template <
   size_t MaxCount = 0, typename TaskIter,
   typename Result = typename std::iter_value_t<TaskIter>::result_type>
@@ -88,6 +89,8 @@ spawn_many(TaskIter&& Begin, TaskIter&& End)
 /// - The iterator may produce less than `MaxCount` tasks.
 /// - The return type will be a right-sized `std::vector<Result>` with size and
 /// capacity equal to the number of tasks consumed from the iterator.
+///
+/// Submits items in range [Begin, min(Begin + MaxCount, End)) to the executor.
 template <
   typename TaskIter,
   typename Result = typename std::iter_value_t<TaskIter>::result_type>
@@ -106,7 +109,7 @@ spawn_many(TaskIter&& Begin, TaskIter&& End, size_t MaxCount)
 /// `FuncIter` must be an iterator type that implements `operator*()` and
 /// `FuncIter& operator++()`.
 ///
-/// Submits `Count` items to the executor.
+/// Submits items in range [Begin, Begin + Count) to the executor.
 template <
   size_t Count, typename FuncIter,
   typename Functor = std::iter_value_t<FuncIter>,
@@ -131,7 +134,7 @@ spawn_many(FuncIter&& FunctorIterator)
 /// `FuncIter& operator++()`.
 /// `FunctorCount` must be non-zero.
 ///
-/// Submits `FunctorCount` items to the executor.
+/// Submits items in range [Begin, Begin + FunctorCount) to the executor.
 template <
   typename FuncIter, typename Functor = std::iter_value_t<FuncIter>,
   typename Result = std::invoke_result_t<Functor>>
@@ -158,10 +161,13 @@ spawn_many(FuncIter&& FunctorIterator, size_t FunctorCount)
 /// iterator. If the iterator produces less than `MaxCount` tasks, elements in
 /// the return array beyond the number of results actually produced by the
 /// iterator will be default-initialized.
+/// Submits items in range [Begin, min(Begin + MaxCount, End)) to the executor.
 ///
 /// - If `MaxCount` is zero/not provided, the return type will be a right-sized
 /// `std::vector<Result>` with size and capacity equal to the number of tasks
 /// produced by the iterator.
+/// Submits items in range [Begin, End) to the executor.
+///
 template <
   size_t MaxCount = 0, typename FuncIter,
   typename Functor = std::iter_value_t<FuncIter>,
@@ -189,6 +195,8 @@ spawn_many(FuncIter&& Begin, FuncIter&& End)
 /// - The iterator may produce less than `MaxCount` tasks.
 /// - The return type will be a right-sized `std::vector<Result>` with size and
 /// capacity equal to the number of tasks consumed from the iterator.
+///
+/// Submits items in range [Begin, min(Begin + MaxCount, End)) to the executor.
 template <
   typename FuncIter, typename Functor = std::iter_value_t<FuncIter>,
   typename Result = std::invoke_result_t<Functor>>

--- a/include/tmc/spawn_many.hpp
+++ b/include/tmc/spawn_many.hpp
@@ -267,10 +267,18 @@ public:
       : symmetric_task{nullptr}, continuation_executor{ContinuationExecutor},
         done_count{0} {
     TaskArray taskArr;
-    if constexpr (Count == 0 && requires(TaskIter a, TaskIter b) { a - b; }) {
-      // Caller didn't specify capacity to preallocate, but we can calculate it
-      result_arr.resize(End - Begin);
-      taskArr.resize(End - Begin);
+    if constexpr (Count == 0) {
+      if constexpr (requires(TaskIter a, TaskIter b) { a - b; }) {
+        // Caller didn't specify capacity to preallocate, but we can calculate
+        size_t iterSize = static_cast<size_t>(End - Begin);
+        if (MaxCount < iterSize) {
+          taskArr.resize(MaxCount);
+          result_arr.resize(MaxCount);
+        } else {
+          taskArr.resize(iterSize);
+          result_arr.resize(iterSize);
+        }
+      }
     }
 
     size_t taskCount = 0;
@@ -464,9 +472,16 @@ template <size_t Count> class aw_task_many_impl<void, Count> {
       : symmetric_task{nullptr}, continuation_executor{ContinuationExecutor},
         done_count{0} {
     TaskArray taskArr;
-    if constexpr (Count == 0 && requires(TaskIter a, TaskIter b) { a - b; }) {
-      // Caller didn't specify capacity to preallocate, but we can calculate it
-      taskArr.resize(End - Begin);
+    if constexpr (Count == 0) {
+      if constexpr (requires(TaskIter a, TaskIter b) { a - b; }) {
+        // Caller didn't specify capacity to preallocate, but we can calculate
+        size_t iterSize = static_cast<size_t>(End - Begin);
+        if (MaxCount < iterSize) {
+          taskArr.resize(MaxCount);
+        } else {
+          taskArr.resize(iterSize);
+        }
+      }
     }
 
     size_t taskCount = 0;

--- a/include/tmc/spawn_many.hpp
+++ b/include/tmc/spawn_many.hpp
@@ -261,7 +261,7 @@ public:
     );
 
     if (postCount != 0) {
-      Executor->post_bulk(taskArr.data(), Prio, postCount);
+      Executor->post_bulk(taskArr.data(), postCount, Prio);
     }
   }
 
@@ -360,7 +360,7 @@ public:
     );
 
     if (postCount != 0) {
-      Executor->post_bulk(taskArr.data(), Prio, postCount);
+      Executor->post_bulk(taskArr.data(), postCount, Prio);
     }
   }
 
@@ -458,7 +458,7 @@ template <size_t Count> class aw_task_many_impl<void, Count> {
     );
 
     if (postCount != 0) {
-      Executor->post_bulk(taskArr.data(), Prio, postCount);
+      Executor->post_bulk(taskArr.data(), postCount, Prio);
     }
   }
 
@@ -543,7 +543,7 @@ template <size_t Count> class aw_task_many_impl<void, Count> {
     );
 
     if (postCount != 0) {
-      Executor->post_bulk(taskArr.data(), Prio, postCount);
+      Executor->post_bulk(taskArr.data(), postCount, Prio);
     }
   }
 
@@ -693,7 +693,7 @@ public:
         taskArr[i] = detail::into_task(std::move(*iter));
         ++iter;
       }
-      executor->post_bulk(taskArr.data(), prio, size);
+      executor->post_bulk(taskArr.data(), size, prio);
     } else {
       size_t taskCount = 0;
       if constexpr (Count == 0 && requires(IterEnd a, IterBegin b) { a - b; }) {
@@ -733,7 +733,7 @@ public:
       }
 
       if (taskCount != 0) {
-        executor->post_bulk(taskArr.data(), prio, taskCount);
+        executor->post_bulk(taskArr.data(), taskCount, prio);
       }
     }
   }

--- a/include/tmc/sync.hpp
+++ b/include/tmc/sync.hpp
@@ -151,7 +151,7 @@ std::future<void> post_bulk_waitable(
         return t;
       }
     ),
-    Priority, Count
+    Count, Priority
   );
   return sharedState->promise.get_future();
 }
@@ -199,7 +199,7 @@ std::future<void> post_bulk_waitable(
         }(*iter, sharedState);
       }
     ),
-    Priority, Count
+    Count, Priority
   );
 #else
   Executor.post_bulk(
@@ -215,7 +215,7 @@ std::future<void> post_bulk_waitable(
         };
       }
     ),
-    Priority, Count
+    Count, Priority
   );
 #endif
   return sharedState->promise.get_future();
@@ -230,14 +230,14 @@ std::future<void> post_bulk_waitable(
 template <typename E, typename Iter>
 void post_bulk(E& Executor, Iter&& Begin, size_t Count, size_t Priority) {
   if constexpr (std::is_convertible_v<std::iter_value_t<Iter>, work_item>) {
-    Executor.post_bulk(std::forward<Iter>(Begin), Priority, Count);
+    Executor.post_bulk(std::forward<Iter>(Begin), Count, Priority);
   } else {
     Executor.post_bulk(
       tmc::iter_adapter(
         std::forward<Iter>(Begin),
         [](Iter& it) -> work_item { return detail::into_work_item(*it); }
       ),
-      Priority, Count
+      Count, Priority
     );
   }
 }
@@ -247,14 +247,14 @@ void post_bulk(E& Executor, Iter&& Begin, Iter&& End, size_t Priority) {
   if constexpr (requires(Iter a, Iter b) { a - b; }) {
     size_t Count = End - Begin;
     if constexpr (std::is_convertible_v<std::iter_value_t<Iter>, work_item>) {
-      Executor.post_bulk(std::forward<Iter>(Begin), Priority, Count);
+      Executor.post_bulk(std::forward<Iter>(Begin), Count, Priority);
     } else {
       Executor.post_bulk(
         tmc::iter_adapter(
           std::forward<Iter>(Begin),
           [](Iter& it) -> work_item { return detail::into_work_item(*it); }
         ),
-        Priority, Count
+        Count, Priority
       );
     }
   } else {
@@ -263,7 +263,7 @@ void post_bulk(E& Executor, Iter&& Begin, Iter&& End, size_t Priority) {
       tasks.emplace_back(detail::into_work_item(*Begin));
       ++Begin;
     }
-    Executor.post_bulk(tasks.begin(), Priority, tasks.size());
+    Executor.post_bulk(tasks.begin(), tasks.size(), Priority);
   }
 }
 

--- a/include/tmc/sync.hpp
+++ b/include/tmc/sync.hpp
@@ -8,7 +8,6 @@
 // expected behavior of std::future / std::promise, although it does come at a
 // small performance penalty.
 
-#include "tmc/spawn_many.hpp"
 #include "tmc/task.hpp"
 #include "tmc/utils.hpp"
 
@@ -16,6 +15,7 @@
 #include <coroutine>
 #include <future>
 #include <memory>
+#include <vector>
 
 namespace tmc {
 

--- a/include/tmc/sync.hpp
+++ b/include/tmc/sync.hpp
@@ -8,8 +8,10 @@
 // expected behavior of std::future / std::promise, although it does come at a
 // small performance penalty.
 
+#include "tmc/spawn_many.hpp"
 #include "tmc/task.hpp"
 #include "tmc/utils.hpp"
+
 #include <atomic>
 #include <coroutine>
 #include <future>
@@ -217,6 +219,20 @@ std::future<void> post_bulk_waitable(
   );
 #endif
   return sharedState->promise.get_future();
+}
+
+/// Reads `Count` items from `TasksOrFuncs` and submits them for execution
+/// on `Executor` at priority `Priority`. `Count` must be non-zero.
+/// `TasksOrFuncs` must be an iterator type that implements `operator*()`
+/// and `It& operator++()`.
+/// The type of the items in `TasksOrFuncs` must be `task<void>` or a type
+/// implementing `void operator()`.
+template <typename E, typename Iter>
+void post_bulk(E& Executor, Iter TasksOrFuncs, size_t Priority, size_t Count) {
+  spawn_many(TasksOrFuncs, Count)
+    .run_on(Executor)
+    .with_priority(Priority)
+    .detach();
 }
 
 } // namespace tmc

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -474,15 +474,4 @@ void post(E& Executor, F&& Func, size_t Priority)
   Executor.post(static_cast<F&&>(Func), Priority);
 }
 #endif
-
-/// Reads `Count` items from `WorkItemIterator` and submits them for execution
-/// on `Executor` at priority `Priority`. `Count` must be non-zero.
-/// `WorkItemIterator` must be an iterator type that implements `operator*()`
-/// and `It& operator++()`.
-template <typename E, typename Iter>
-void post_bulk(
-  E& Executor, Iter WorkItemIterator, size_t Priority, size_t Count
-) {
-  Executor.post_bulk(WorkItemIterator, Priority, Count);
-}
 } // namespace tmc

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -395,7 +395,7 @@ task<void> into_task(Original FuncVoid) {
 /// Result-returning types are not supported.
 
 template <typename Original, typename Result = Original::result_type>
-  requires(std::is_convertible_v<Original, task<Result>>)
+  requires(std::is_void_v<Result> && std::is_convertible_v<Original, task<Result>>)
 work_item into_work_item(Original&& Task) {
   return std::coroutine_handle<>(static_cast<Original&&>(Task));
 }

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -391,6 +391,28 @@ task<void> into_task(Original FuncVoid) {
   co_return;
 }
 
+/// Makes a work_item from a task<void> or a void(void) functor.
+/// Result-returning types are not supported.
+
+template <typename Original, typename Result = Original::result_type>
+  requires(std::is_convertible_v<Original, task<Result>>)
+work_item into_work_item(Original&& Task) {
+  return std::coroutine_handle<>(static_cast<Original&&>(Task));
+}
+
+template <typename Original, typename Result = std::invoke_result_t<Original>>
+  requires(std::is_void_v<Result> && !is_instance_of_v<std::decay_t<Original>, task>)
+work_item into_work_item(Original&& FuncVoid) {
+#if TMC_WORK_ITEM_IS(CORO)
+  return std::coroutine_handle<>([](Original f) -> task<void> {
+    f();
+    co_return;
+  }(static_cast<Original&&>(FuncVoid)));
+#else
+  return FuncVoid;
+#endif
+}
+
 } // namespace detail
 
 template <typename Result> class aw_task {

--- a/include/tmc/utils.hpp
+++ b/include/tmc/utils.hpp
@@ -13,7 +13,7 @@ template <typename It, typename Transformer> class iter_adapter {
   It it;
 
 public:
-  using value_type = std::invoke_result_t<Transformer, It>;
+  using value_type = std::invoke_result_t<Transformer, It&>;
   template <typename Iter_, typename Transformer_>
   iter_adapter(Iter_&& Iterator, Transformer_&& TransformFunc)
       : func(static_cast<Transformer_&&>(TransformFunc)),


### PR DESCRIPTION
- Templatize `tmc::post_bulk()` so that it supports Begin/End or Begin/Count, and can support a variety of input types. It now works similarly to `tmc::spawn_many().detach()`, but from an external thread.
- Add perfect forwarding in several task submission functions
- Fix spawn_many().detach()
- Rework requires-clauses in terms of cleaner shared concepts to disambiguate tasks and functions
- Various doc comments cleanups

### Breaking changes
All functions that previously took (..., size_t Priority, size_t Count) now take (..., size_t Count, size_t Priority). This is so that new iterator overloads that take (Begin, End, Priority) can have the same parameter order as (Begin, Count, Priority).