### PR TITLE
Priority checks cleanup

### DIFF
--- a/include/tmc/aw_resume_on.hpp
+++ b/include/tmc/aw_resume_on.hpp
@@ -20,8 +20,8 @@ public:
   /// Resume immediately if outer is already running on the requested executor,
   /// at the requested priority.
   inline bool await_ready() const noexcept {
-    return executor == detail::this_thread::executor &&
-           prio == detail::this_thread::this_task.prio;
+    return detail::this_thread::exec_is(executor) &&
+           detail::this_thread::prio_is(prio);
   }
 
   /// Post the outer task to the requested executor.

--- a/include/tmc/aw_resume_on.hpp
+++ b/include/tmc/aw_resume_on.hpp
@@ -20,8 +20,8 @@ public:
   /// Resume immediately if outer is already running on the requested executor,
   /// at the requested priority.
   inline bool await_ready() const noexcept {
-    return detail::this_thread::executor == executor &&
-           detail::this_thread::this_task.prio == prio;
+    return executor == detail::this_thread::executor &&
+           prio == detail::this_thread::this_task.prio;
   }
 
   /// Post the outer task to the requested executor.

--- a/include/tmc/detail/aw_run_early.hpp
+++ b/include/tmc/detail/aw_run_early.hpp
@@ -69,7 +69,7 @@ public:
     }
     // Resume if remaining <= 0 (worker already finished)
     if (continuation_executor == nullptr ||
-        continuation_executor == detail::this_thread::executor) {
+        detail::this_thread::exec_is(continuation_executor)) {
       return false;
     } else {
       // Need to resume on a different executor
@@ -137,7 +137,7 @@ public:
     }
     // Resume if remaining <= 0 (worker already finished)
     if (continuation_executor == nullptr ||
-        continuation_executor == detail::this_thread::executor) {
+        detail::this_thread::exec_is(continuation_executor)) {
       return false;
     } else {
       // Need to resume on a different executor

--- a/include/tmc/detail/coro_functor.hpp
+++ b/include/tmc/detail/coro_functor.hpp
@@ -118,7 +118,7 @@ public:
   /// operator() is called.
   template <typename T>
   coro_functor(T* Functor) noexcept
-    requires(!std::is_same_v<std::remove_reference_t<T>, coro_functor> && !std::is_convertible_v<T, std::coroutine_handle<>>)
+    requires(!std::is_same_v<std::remove_cvref_t<T>, coro_functor> && !std::is_convertible_v<T, std::coroutine_handle<>>)
   {
     uintptr_t funcAddr = reinterpret_cast<
       uintptr_t>(&cast_call_or_nothing<std::remove_reference_t<T>>);
@@ -136,7 +136,7 @@ public:
   /// new allocation owned by the coro_functor.
   template <typename T>
   coro_functor(const T& Functor) noexcept
-    requires(!std::is_same_v<std::remove_reference_t<T>, coro_functor> && !std::is_convertible_v<T, std::coroutine_handle<>> && std::is_copy_constructible_v<T>)
+    requires(!std::is_same_v<std::remove_cvref_t<T>, coro_functor> && !std::is_convertible_v<T, std::coroutine_handle<>> && std::is_copy_constructible_v<T>)
   {
     uintptr_t funcAddr = reinterpret_cast<
       uintptr_t>(&cast_call_or_delete<std::remove_reference_t<T>>);
@@ -152,7 +152,7 @@ public:
     requires( // prevent lvalues from choosing this overload
               // https://stackoverflow.com/a/46936145/100443
         !std::is_reference_v<T> &&
-        !std::is_same_v<std::remove_reference_t<T>, coro_functor> &&
+        !std::is_same_v<std::remove_cvref_t<T>, coro_functor> &&
         !std::is_convertible_v<T, std::coroutine_handle<>>)
   {
     uintptr_t funcAddr = reinterpret_cast<

--- a/include/tmc/detail/coro_functor32.hpp
+++ b/include/tmc/detail/coro_functor32.hpp
@@ -115,7 +115,7 @@ public:
   // is called.
   template <typename T>
   coro_functor32(T* Functor) noexcept
-    requires(!std::is_same_v<std::remove_reference_t<T>, coro_functor32> && !std::is_convertible_v<T, std::coroutine_handle<>>)
+    requires(!std::is_same_v<std::remove_cvref_t<T>, coro_functor32> && !std::is_convertible_v<T, std::coroutine_handle<>>)
   {
     uintptr_t funcAddr =
       reinterpret_cast<uintptr_t>(&cast_call<std::remove_reference_t<T>>);
@@ -134,7 +134,7 @@ public:
   // new allocation owned by this object.
   template <typename T>
   coro_functor32(const T& Functor) noexcept
-    requires(!std::is_same_v<std::remove_reference_t<T>, coro_functor32> && !std::is_convertible_v<T, std::coroutine_handle<>> && std::is_copy_constructible_v<T>)
+    requires(!std::is_same_v<std::remove_cvref_t<T>, coro_functor32> && !std::is_convertible_v<T, std::coroutine_handle<>> && std::is_copy_constructible_v<T>)
   {
     uintptr_t funcAddr =
       reinterpret_cast<uintptr_t>(&cast_call<std::remove_reference_t<T>>);
@@ -151,7 +151,7 @@ public:
     requires( // prevent lvalues from choosing this overload
               // https://stackoverflow.com/a/46936145/100443
         !std::is_reference_v<T> &&
-        !std::is_same_v<std::remove_reference_t<T>, coro_functor32> &&
+        !std::is_same_v<std::remove_cvref_t<T>, coro_functor32> &&
         !std::is_convertible_v<T, std::coroutine_handle<>>)
   {
     uintptr_t funcAddr =

--- a/include/tmc/detail/ex_braid.ipp
+++ b/include/tmc/detail/ex_braid.ipp
@@ -72,7 +72,7 @@ ex_braid::ex_braid(detail::type_erased_executor* Parent)
 ex_braid::ex_braid() : ex_braid(detail::this_thread::executor) {}
 
 ex_braid::~ex_braid() {
-  if (detail::this_thread::executor == &type_erased_this) {
+  if (detail::this_thread::exec_is(&type_erased_this)) {
     // we are inside of run_one_func() inside of try_run_loop(); we already have
     // the lock
     thread_exit_context();
@@ -95,10 +95,10 @@ ex_braid::~ex_braid() {
 std::coroutine_handle<>
 ex_braid::task_enter_context(std::coroutine_handle<> Outer, size_t Priority) {
   queue.enqueue(std::move(Outer));
-  if (detail::this_thread::executor == &type_erased_this) {
+  if (detail::this_thread::exec_is(&type_erased_this)) {
     // we are already inside of try_run_loop() - don't need to do anything
     return std::noop_coroutine();
-  } else if (detail::this_thread::executor == parent_executor) {
+  } else if (detail::this_thread::exec_is(parent_executor)) {
     // rather than posting to exec, we can just run the queue directly
     return try_run_loop(lock, destroyed_by_this_thread);
   } else {

--- a/include/tmc/detail/ex_cpu.ipp
+++ b/include/tmc/detail/ex_cpu.ipp
@@ -591,7 +591,7 @@ ex_cpu::~ex_cpu() { teardown(); }
 
 std::coroutine_handle<>
 ex_cpu::task_enter_context(std::coroutine_handle<> Outer, size_t Priority) {
-  if (detail::this_thread::executor == &type_erased_this) {
+  if (detail::this_thread::exec_is(&type_erased_this)) {
     return Outer;
   } else {
     post(std::move(Outer), Priority);

--- a/include/tmc/detail/test.hpp
+++ b/include/tmc/detail/test.hpp
@@ -21,7 +21,7 @@ inline size_t wait_for_all_threads_to_sleep(ex_cpu& CpuExecutor) {
   size_t waitCount = 0;
 
   int runThreads = 0;
-  if (detail::this_thread::executor == CpuExecutor.type_erased()) {
+  if (detail::this_thread::exec_is(CpuExecutor.type_erased())) {
     // if this function is being called from an executor thread, we will never
     // see ALL threads sleeping - at least this one will always be running
     runThreads = 1;

--- a/include/tmc/detail/thread_locals.hpp
+++ b/include/tmc/detail/thread_locals.hpp
@@ -81,6 +81,12 @@ namespace this_thread { // namespace reserved for thread_local variables
 inline constinit thread_local type_erased_executor* executor = nullptr;
 inline constinit thread_local running_task_data this_task = {0, &never_yield};
 inline constinit thread_local void* producers = nullptr;
+inline bool exec_is(type_erased_executor const* const Executor) {
+  return Executor == executor;
+}
+inline bool prio_is(size_t const Priority) {
+  return Priority == this_task.prio;
+}
 } // namespace this_thread
 } // namespace detail
 } // namespace tmc

--- a/include/tmc/spawn_func.hpp
+++ b/include/tmc/spawn_func.hpp
@@ -49,7 +49,7 @@ public:
       [this, Outer]() {
         result = wrapped();
         if (continuation_executor == nullptr ||
-            continuation_executor == detail::this_thread::executor) {
+            detail::this_thread::exec_is(continuation_executor)) {
           Outer.resume();
         } else {
           continuation_executor->post(Outer, prio);
@@ -101,7 +101,7 @@ public:
       [this, Outer]() {
         wrapped();
         if (continuation_executor == nullptr ||
-            continuation_executor == detail::this_thread::executor) {
+            detail::this_thread::exec_is(continuation_executor)) {
           Outer.resume();
         } else {
           continuation_executor->post(Outer, prio);

--- a/include/tmc/spawn_many.hpp
+++ b/include/tmc/spawn_many.hpp
@@ -638,11 +638,8 @@ public:
     assert(!did_await);
     did_await = true;
 #endif
-    bool doSymmetricTransfer =
-      executor == detail::this_thread::executor &&
-      prio <= detail::this_thread::this_task.yield_priority->load(
-                std::memory_order_relaxed
-              );
+    bool doSymmetricTransfer = executor == detail::this_thread::executor &&
+                               prio == detail::this_thread::this_task.prio;
     if constexpr (std::is_convertible_v<IterEnd, size_t>) {
       // "Sentinel" is actually a count
       return aw_task_many_impl<Result, Count>(

--- a/include/tmc/spawn_many.hpp
+++ b/include/tmc/spawn_many.hpp
@@ -643,7 +643,7 @@ public:
       prio <= detail::this_thread::this_task.yield_priority->load(
                 std::memory_order_relaxed
               );
-    if constexpr (!std::is_same_v<IterBegin, IterEnd>) {
+    if constexpr (std::is_convertible_v<IterEnd, size_t>) {
       // "Sentinel" is actually a count
       return aw_task_many_impl<Result, Count>(
         std::move(iter), std::move(sentinel), executor, continuation_executor,
@@ -671,7 +671,7 @@ public:
       Count == 0, std::vector<work_item>, std::array<work_item, Count>>;
     TaskArray taskArr;
 
-    if constexpr (!std::is_same_v<IterBegin, IterEnd>) {
+    if constexpr (std::is_convertible_v<IterEnd, size_t>) {
       // "Sentinel" is actually a count
       if constexpr (Count == 0) {
         taskArr.resize(sentinel);

--- a/include/tmc/spawn_many.hpp
+++ b/include/tmc/spawn_many.hpp
@@ -382,7 +382,7 @@ public:
         next = std::noop_coroutine();
       } else { // Resume if remaining <= 0 (tasks already finished)
         if (continuation_executor == nullptr ||
-            continuation_executor == detail::this_thread::executor) {
+            detail::this_thread::exec_is(continuation_executor)) {
           next = Outer;
         } else {
           // Need to resume on a different executor
@@ -564,7 +564,7 @@ public:
         next = std::noop_coroutine();
       } else { // Resume if remaining <= 0 (tasks already finished)
         if (continuation_executor == nullptr ||
-            continuation_executor == detail::this_thread::executor) {
+            detail::this_thread::exec_is(continuation_executor)) {
           next = Outer;
         } else {
           // Need to resume on a different executor
@@ -638,8 +638,8 @@ public:
     assert(!did_await);
     did_await = true;
 #endif
-    bool doSymmetricTransfer = executor == detail::this_thread::executor &&
-                               prio == detail::this_thread::this_task.prio;
+    bool doSymmetricTransfer = detail::this_thread::exec_is(executor) &&
+                               detail::this_thread::prio_is(prio);
     if constexpr (std::is_convertible_v<IterEnd, size_t>) {
       // "Sentinel" is actually a count
       return aw_task_many_impl<Result, Count>(


### PR DESCRIPTION
- Require priority match exactly for symmetric transfer in spawn_many. This prevents the symmetric transfer task from getting out of sync with other submitted tasks, when there are higher priority tasks already waiting.
- Cleanup some std::is_same_v checks to be less fragile
- Add detail::this_thread::exec_is() and detail::this_thread::prio_is() functions