### PR TITLE
Add `tmc::external::set_default_executor()` option to be used for integrating with external threads

### DIFF
--- a/include/tmc/all_headers.hpp
+++ b/include/tmc/all_headers.hpp
@@ -11,6 +11,7 @@
 #include "tmc/aw_yield.hpp"     // IWYU pragma: export
 #include "tmc/ex_braid.hpp"     // IWYU pragma: export
 #include "tmc/ex_cpu.hpp"       // IWYU pragma: export
+#include "tmc/external.hpp"     // IWYU pragma: export
 #include "tmc/spawn_func.hpp"   // IWYU pragma: export
 #include "tmc/spawn_many.hpp"   // IWYU pragma: export
 #include "tmc/spawn_task.hpp"   // IWYU pragma: export

--- a/include/tmc/aw_resume_on.hpp
+++ b/include/tmc/aw_resume_on.hpp
@@ -33,6 +33,7 @@ public:
   /// Post the outer task to the requested executor.
   TMC_FORCE_INLINE inline void await_suspend(std::coroutine_handle<> Outer
   ) const noexcept {
+    // executor check not needed, this function is explicit
     executor->post(std::move(Outer), prio);
   }
 
@@ -112,7 +113,7 @@ public:
 
   /// Post this task to the continuation executor.
   TMC_FORCE_INLINE inline void await_suspend(std::coroutine_handle<> Outer) {
-    continuation_executor->post(std::move(Outer), prio);
+    detail::post_checked(continuation_executor, std::move(Outer), prio);
   }
 
   /// Restores the original priority.

--- a/include/tmc/aw_yield.hpp
+++ b/include/tmc/aw_yield.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "tmc/detail/thread_locals.hpp"
+
 #include <coroutine>
 
 namespace tmc {

--- a/include/tmc/aw_yield.hpp
+++ b/include/tmc/aw_yield.hpp
@@ -29,8 +29,9 @@ public:
   /// task can run.
   TMC_FORCE_INLINE inline void await_suspend(std::coroutine_handle<> Outer
   ) const noexcept {
-    detail::this_thread::executor->post(
-      std::move(Outer), detail::this_thread::this_task.prio
+    detail::post_checked(
+      detail::this_thread::executor, std::move(Outer),
+      detail::this_thread::this_task.prio
     );
   }
 
@@ -54,8 +55,9 @@ public:
   /// task can run.
   TMC_FORCE_INLINE inline void await_suspend(std::coroutine_handle<> Outer
   ) const noexcept {
-    detail::this_thread::executor->post(
-      std::move(Outer), detail::this_thread::this_task.prio
+    detail::post_checked(
+      detail::this_thread::executor, std::move(Outer),
+      detail::this_thread::this_task.prio
     );
   }
 
@@ -101,8 +103,9 @@ public:
   /// task can run.
   TMC_FORCE_INLINE inline void await_suspend(std::coroutine_handle<> Outer
   ) const noexcept {
-    detail::this_thread::executor->post(
-      std::move(Outer), detail::this_thread::this_task.prio
+    detail::post_checked(
+      detail::this_thread::executor, std::move(Outer),
+      detail::this_thread::this_task.prio
     );
   }
 
@@ -148,8 +151,9 @@ public:
   /// task can run.
   TMC_FORCE_INLINE inline void await_suspend(std::coroutine_handle<> Outer
   ) const noexcept {
-    detail::this_thread::executor->post(
-      std::move(Outer), detail::this_thread::this_task.prio
+    detail::post_checked(
+      detail::this_thread::executor, std::move(Outer),
+      detail::this_thread::this_task.prio
     );
   }
 

--- a/include/tmc/detail/aw_run_early.hpp
+++ b/include/tmc/detail/aw_run_early.hpp
@@ -53,7 +53,7 @@ template <typename Result> class aw_run_early_impl {
     p.done_count = &done_count;
     // TODO fence maybe not required if there's one inside the queue?
     std::atomic_thread_fence(std::memory_order_release);
-    Executor->post(std::move(Task), Priority);
+    detail::post_checked(Executor, std::move(Task), Priority);
   }
 
 public:
@@ -79,8 +79,9 @@ public:
       return false;
     } else {
       // Need to resume on a different executor
-      continuation_executor->post(
-        std::move(Outer), detail::this_thread::this_task.prio
+      detail::post_checked(
+        continuation_executor, std::move(Outer),
+        detail::this_thread::this_task.prio
       );
       return true;
     }
@@ -122,7 +123,7 @@ template <> class aw_run_early_impl<void> {
     p.done_count = &done_count;
     // TODO fence maybe not required if there's one inside the queue?
     std::atomic_thread_fence(std::memory_order_release);
-    Executor->post(std::move(Task), Priority);
+    detail::post_checked(Executor, std::move(Task), Priority);
   }
 
 public:
@@ -147,8 +148,9 @@ public:
       return false;
     } else {
       // Need to resume on a different executor
-      continuation_executor->post(
-        std::move(Outer), detail::this_thread::this_task.prio
+      detail::post_checked(
+        continuation_executor, std::move(Outer),
+        detail::this_thread::this_task.prio
       );
       return true;
     }

--- a/include/tmc/detail/aw_run_early.hpp
+++ b/include/tmc/detail/aw_run_early.hpp
@@ -8,6 +8,7 @@
 #include "tmc/detail/mixins.hpp"
 #include "tmc/detail/thread_locals.hpp"
 #include "tmc/task.hpp"
+
 #include <cassert>
 #include <coroutine>
 

--- a/include/tmc/detail/ex_braid.ipp
+++ b/include/tmc/detail/ex_braid.ipp
@@ -6,6 +6,7 @@
 // Implementation definition file for tmc::ex_braid. This will be included
 // anywhere TMC_IMPL is defined. If you prefer to manually separate compilation
 // units, you can instead include this file directly in a CPP file.
+
 #include "tmc/detail/thread_locals.hpp"
 #include "tmc/ex_braid.hpp"
 

--- a/include/tmc/detail/ex_braid.ipp
+++ b/include/tmc/detail/ex_braid.ipp
@@ -6,6 +6,7 @@
 // Implementation definition file for tmc::ex_braid. This will be included
 // anywhere TMC_IMPL is defined. If you prefer to manually separate compilation
 // units, you can instead include this file directly in a CPP file.
+#include "tmc/detail/thread_locals.hpp"
 #include "tmc/ex_braid.hpp"
 
 namespace tmc {
@@ -62,6 +63,7 @@ void ex_braid::post(work_item&& Item, size_t Priority) {
   // If someone already has the lock, we don't need to post, as they will see
   // this item in queue.
   if (!lock->is_locked()) {
+    // executor check not needed, it happened in braid constructor
     parent_executor->post(
       std::coroutine_handle<>(try_run_loop(lock, destroyed_by_this_thread)),
       Priority
@@ -72,7 +74,11 @@ void ex_braid::post(work_item&& Item, size_t Priority) {
 ex_braid::ex_braid(detail::type_erased_executor* Parent)
     : queue(32), lock{std::make_shared<tiny_lock>()},
       destroyed_by_this_thread{new bool(false)}, type_erased_this(this),
-      parent_executor(Parent) {}
+      parent_executor(Parent) {
+  if (Parent == nullptr) {
+    parent_executor = detail::g_ex_default;
+  }
+}
 
 ex_braid::ex_braid() : ex_braid(detail::this_thread::executor) {}
 
@@ -111,6 +117,7 @@ ex_braid::task_enter_context(std::coroutine_handle<> Outer, size_t Priority) {
     if (!lock->is_locked()) {
       // post try_run_loop to braid's parent executor
       // (don't allow braids to migrate across thread pools)
+      // executor check not needed, it happened in braid constructor
       parent_executor->post(
         std::coroutine_handle<>(try_run_loop(lock, destroyed_by_this_thread)),
         Priority

--- a/include/tmc/detail/ex_cpu.ipp
+++ b/include/tmc/detail/ex_cpu.ipp
@@ -6,6 +6,7 @@
 // Implementation definition file for tmc::ex_cpu. This will be included
 // anywhere TMC_IMPL is defined. If you prefer to manually separate compilation
 // units, you can instead include this file directly in a CPP file.
+
 #include "tmc/detail/qu_lockfree.hpp"
 #include "tmc/detail/thread_layout.hpp"
 #include "tmc/ex_cpu.hpp"

--- a/include/tmc/detail/mixins.hpp
+++ b/include/tmc/detail/mixins.hpp
@@ -7,6 +7,7 @@
 
 #include "tmc/detail/concepts.hpp"
 #include "tmc/detail/thread_locals.hpp"
+
 namespace tmc {
 namespace detail {
 // These mixins provide the `run_on`, `resume_on`, and `with_priority` methods

--- a/include/tmc/detail/thread_locals.hpp
+++ b/include/tmc/detail/thread_locals.hpp
@@ -50,6 +50,9 @@ using work_item = tmc::coro_functor32;
 namespace tmc {
 namespace detail {
 class type_erased_executor;
+
+// The default executor that is used by post_checked / post_bulk_checked
+// when the current (non-TMC) thread's executor == nullptr.
 inline constinit type_erased_executor* g_ex_default = nullptr;
 
 class type_erased_executor {
@@ -98,6 +101,7 @@ inline bool prio_is(size_t const Priority) {
 }
 
 } // namespace this_thread
+
 inline void post_checked(
   detail::type_erased_executor* executor, work_item&& Item, size_t Priority
 ) {
@@ -115,6 +119,7 @@ inline void post_bulk_checked(
   }
   executor->post_bulk(Items, Count, Priority);
 }
+
 } // namespace detail
 } // namespace tmc
 

--- a/include/tmc/detail/thread_locals.hpp
+++ b/include/tmc/detail/thread_locals.hpp
@@ -5,8 +5,6 @@
 
 #pragma once
 
-#include "tmc/detail/concepts.hpp"
-
 #include <atomic>
 #include <limits>
 
@@ -53,28 +51,6 @@ namespace tmc {
 namespace detail {
 class type_erased_executor;
 inline constinit type_erased_executor* g_ex_default = nullptr;
-/// You only need to set this if you are planning to integrate TMC with external
-/// threads of execution that don't configure
-/// `tmc::detail::this_thread::executor`.
-///
-/// If a TMC function that submits work to the current executor implicitly, such
-/// as `spawn()`, is invoked:
-/// - on a non-TMC thread that has not set `tmc::detail::this_thread::executor`
-/// - without explicitly specifying an executor via `.run_on()` / `.resume_on()`
-///
-/// then that function will use this default executor (instead of deferencing
-/// nullptr and crashing).
-inline void set_default_executor(detail::type_erased_executor* Executor) {
-  g_ex_default = Executor;
-}
-template <detail::TypeErasableExecutor Exec>
-inline void set_default_executor(Exec& Executor) {
-  g_ex_default = Executor.type_erased();
-}
-template <detail::TypeErasableExecutor Exec>
-inline void set_default_executor(Exec* Executor) {
-  g_ex_default = Executor->type_erased();
-}
 
 class type_erased_executor {
 public:

--- a/include/tmc/ex_braid.hpp
+++ b/include/tmc/ex_braid.hpp
@@ -14,6 +14,7 @@
 #include "tmc/detail/thread_locals.hpp"
 #include "tmc/detail/tiny_lock.hpp"
 #include "tmc/task.hpp"
+
 #include <coroutine>
 #include <memory>
 

--- a/include/tmc/ex_braid.hpp
+++ b/include/tmc/ex_braid.hpp
@@ -83,6 +83,7 @@ public:
   void post_bulk(It&& Items, size_t Count, size_t Priority) {
     queue.enqueue_bulk(std::forward<It>(Items), Count);
     if (!lock->is_locked()) {
+      // executor check not needed, it happened in braid constructor
       parent_executor->post(
         try_run_loop(lock, destroyed_by_this_thread), Priority
       );

--- a/include/tmc/ex_cpu.hpp
+++ b/include/tmc/ex_cpu.hpp
@@ -10,16 +10,13 @@
 #else
 #include "tmc/detail/qu_lockfree.hpp"
 #endif
-#include "tmc/task.hpp"
-#ifdef TMC_USE_HWLOC
-#include <hwloc.h>
-#endif
 #include "tmc/aw_resume_on.hpp"
 #include "tmc/detail/thread_layout.hpp"
 #include "tmc/detail/thread_locals.hpp"
 #include "tmc/detail/tiny_vec.hpp"
-#include <atomic>
+#include "tmc/task.hpp"
 
+#include <atomic>
 #if defined(__x86_64__) || defined(_M_AMD64)
 #include <immintrin.h>
 #else
@@ -27,6 +24,9 @@
 #endif
 #include <stop_token>
 #include <thread>
+#ifdef TMC_USE_HWLOC
+#include <hwloc.h>
+#endif
 
 namespace tmc {
 class ex_cpu;

--- a/include/tmc/external.hpp
+++ b/include/tmc/external.hpp
@@ -1,0 +1,84 @@
+// Copyright (c) 2023-2024 Logan McDougall
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+// external.hpp provides functions to simplify safe integration of TMC with
+// external coroutines, awaitables, and executors.
+
+#include "tmc/aw_resume_on.hpp"
+#include "tmc/detail/concepts.hpp" // IWYU pragma: keep
+#include "tmc/detail/thread_locals.hpp"
+#include "tmc/task.hpp"
+
+namespace tmc {
+namespace external {
+/// Saves the current TMC executor and priority level before awaiting the
+/// provided awaitable. After the awaitable completes, returns the awaiting task
+/// back to the saved executor / priority.
+///
+/// Use of this function isn't *strictly* necessary, if you are sure that an
+/// external awaitable won't lasso your task onto a different executor.
+template <typename Result, typename ExternalAwaitable>
+[[nodiscard("You must await the return type of safe_await()"
+)]] tmc::task<Result>
+safe_await(ExternalAwaitable&& Awaitable) {
+  return [](
+           ExternalAwaitable ExAw, tmc::aw_resume_on TakeMeHome
+         ) -> tmc::task<Result> {
+    auto result = co_await ExAw;
+    co_await TakeMeHome;
+    co_return result;
+  }(static_cast<ExternalAwaitable&&>(Awaitable),
+           tmc::resume_on(tmc::detail::this_thread::executor));
+}
+
+/// You only need to set this if you are planning to integrate TMC with external
+/// threads of execution that don't configure
+/// `tmc::detail::this_thread::executor`.
+///
+/// If a TMC function that submits work to the current executor implicitly, such
+/// as `spawn()`, is invoked:
+/// - on a non-TMC thread that has not set `tmc::detail::this_thread::executor`
+/// - without explicitly specifying an executor via `.run_on()` / `.resume_on()`
+///
+/// then that function will use this default executor (instead of deferencing
+/// nullptr and crashing).
+inline void set_default_executor(detail::type_erased_executor* Executor) {
+  detail::g_ex_default = Executor;
+}
+/// You only need to set this if you are planning to integrate TMC with external
+/// threads of execution that don't configure
+/// `tmc::detail::this_thread::executor`.
+///
+/// If a TMC function that submits work to the current executor implicitly, such
+/// as `spawn()`, is invoked:
+/// - on a non-TMC thread that has not set `tmc::detail::this_thread::executor`
+/// - without explicitly specifying an executor via `.run_on()` / `.resume_on()`
+///
+/// then that function will use this default executor (instead of deferencing
+/// nullptr and crashing).
+template <detail::TypeErasableExecutor Exec>
+inline void set_default_executor(Exec& Executor) {
+  detail::g_ex_default = Executor.type_erased();
+}
+/// You only need to set this if you are planning to integrate TMC with external
+/// threads of execution that don't configure
+/// `tmc::detail::this_thread::executor`.
+///
+/// If a TMC function that submits work to the current executor implicitly, such
+/// as `spawn()`, is invoked:
+/// - on a non-TMC thread that has not set `tmc::detail::this_thread::executor`
+/// - without explicitly specifying an executor via `.run_on()` / `.resume_on()`
+///
+/// then that function will use this default executor (instead of deferencing
+/// nullptr and crashing).
+template <detail::TypeErasableExecutor Exec>
+inline void set_default_executor(Exec* Executor) {
+  detail::g_ex_default = Executor->type_erased();
+}
+
+} // namespace external
+} // namespace tmc

--- a/include/tmc/spawn_func.hpp
+++ b/include/tmc/spawn_func.hpp
@@ -9,6 +9,7 @@
 #include "tmc/detail/mixins.hpp"
 #include "tmc/detail/thread_locals.hpp"
 #include "tmc/task.hpp"
+
 #include <cassert>
 #include <coroutine>
 #include <functional>

--- a/include/tmc/spawn_func.hpp
+++ b/include/tmc/spawn_func.hpp
@@ -49,16 +49,17 @@ public:
     p.continuation = Outer.address();
     p.continuation_executor = continuation_executor;
     p.result_ptr = &result;
-    executor->post(std::move(t), prio);
+    detail::post_checked(executor, std::move(t), prio);
 #else
-    executor->post(
+    detail::post_checked(
+      executor,
       [this, Outer]() {
         result = wrapped();
         if (continuation_executor == nullptr ||
             detail::this_thread::exec_is(continuation_executor)) {
           Outer.resume();
         } else {
-          continuation_executor->post(Outer, prio);
+          detail::post_checked(continuation_executor, Outer, prio);
         }
       },
       prio
@@ -101,16 +102,17 @@ public:
     auto& p = t.promise();
     p.continuation = Outer.address();
     p.continuation_executor = continuation_executor;
-    executor->post(std::move(t), prio);
+    detail::post_checked(executor, std::move(t), prio);
 #else
-    executor->post(
+    detail::post_checked(
+      executor,
       [this, Outer]() {
         wrapped();
         if (continuation_executor == nullptr ||
             detail::this_thread::exec_is(continuation_executor)) {
           Outer.resume();
         } else {
-          continuation_executor->post(Outer, prio);
+          detail::post_checked(continuation_executor, Outer, prio);
         }
       },
       prio
@@ -262,9 +264,9 @@ public:
     did_await = true;
 #endif
 #if TMC_WORK_ITEM_IS(CORO)
-    executor->post(detail::into_task(wrapped), prio);
+    detail::post_checked(executor, detail::into_task(wrapped), prio);
 #else
-    executor->post(std::move(wrapped), prio);
+    detail::post_checked(executor, std::move(wrapped), prio);
 #endif
   }
 

--- a/include/tmc/spawn_many.hpp
+++ b/include/tmc/spawn_many.hpp
@@ -9,6 +9,7 @@
 #include "tmc/detail/mixins.hpp"
 #include "tmc/detail/thread_locals.hpp"
 #include "tmc/task.hpp"
+
 #include <array>
 #include <atomic>
 #include <cassert>

--- a/include/tmc/spawn_many.hpp
+++ b/include/tmc/spawn_many.hpp
@@ -260,7 +260,7 @@ public:
     );
 
     if (postCount != 0) {
-      Executor->post_bulk(taskArr.data(), postCount, Prio);
+      detail::post_bulk_checked(Executor, taskArr.data(), postCount, Prio);
     }
   }
 
@@ -360,7 +360,7 @@ public:
     );
 
     if (postCount != 0) {
-      Executor->post_bulk(taskArr.data(), postCount, Prio);
+      detail::post_bulk_checked(Executor, taskArr.data(), postCount, Prio);
     }
   }
 
@@ -392,8 +392,9 @@ public:
           next = Outer;
         } else {
           // Need to resume on a different executor
-          continuation_executor->post(
-            std::move(Outer), detail::this_thread::this_task.prio
+          detail::post_checked(
+            continuation_executor, std::move(Outer),
+            detail::this_thread::this_task.prio
           );
           next = std::noop_coroutine();
         }
@@ -458,7 +459,7 @@ template <size_t Count> class aw_task_many_impl<void, Count> {
     );
 
     if (postCount != 0) {
-      Executor->post_bulk(taskArr.data(), postCount, Prio);
+      detail::post_bulk_checked(Executor, taskArr.data(), postCount, Prio);
     }
   }
 
@@ -542,7 +543,7 @@ template <size_t Count> class aw_task_many_impl<void, Count> {
     );
 
     if (postCount != 0) {
-      Executor->post_bulk(taskArr.data(), postCount, Prio);
+      detail::post_bulk_checked(Executor, taskArr.data(), postCount, Prio);
     }
   }
 
@@ -574,8 +575,9 @@ public:
           next = Outer;
         } else {
           // Need to resume on a different executor
-          continuation_executor->post(
-            std::move(Outer), detail::this_thread::this_task.prio
+          detail::post_checked(
+            continuation_executor, std::move(Outer),
+            detail::this_thread::this_task.prio
           );
           next = std::noop_coroutine();
         }
@@ -689,7 +691,7 @@ public:
         taskArr[i] = detail::into_task(std::move(*iter));
         ++iter;
       }
-      executor->post_bulk(taskArr.data(), size, prio);
+      detail::post_bulk_checked(executor, taskArr.data(), size, prio);
     } else {
       if constexpr (Count == 0 && requires(IterEnd a, IterBegin b) { a - b; }) {
         // Caller didn't specify capacity to preallocate, but we can calculate
@@ -729,7 +731,7 @@ public:
       }
 
       if (taskCount != 0) {
-        executor->post_bulk(taskArr.data(), taskCount, prio);
+        detail::post_bulk_checked(executor, taskArr.data(), taskCount, prio);
       }
     }
   }

--- a/include/tmc/spawn_task.hpp
+++ b/include/tmc/spawn_task.hpp
@@ -10,8 +10,10 @@
 #include "tmc/detail/mixins.hpp"
 #include "tmc/detail/thread_locals.hpp"
 #include "tmc/task.hpp"
+
 #include <cassert>
 #include <coroutine>
+
 namespace tmc {
 
 template <typename Result> class aw_spawned_task_impl;

--- a/include/tmc/spawn_task.hpp
+++ b/include/tmc/spawn_task.hpp
@@ -45,7 +45,7 @@ public:
     p.continuation = Outer.address();
     p.continuation_executor = continuation_executor;
     p.result_ptr = &result;
-    executor->post(std::move(wrapped), prio);
+    detail::post_checked(executor, std::move(wrapped), prio);
   }
 
   /// Returns the value provided by the wrapped task.
@@ -84,7 +84,7 @@ public:
     auto& p = wrapped.promise();
     p.continuation = Outer.address();
     p.continuation_executor = continuation_executor;
-    executor->post(std::move(wrapped), prio);
+    detail::post_checked(executor, std::move(wrapped), prio);
   }
 
   /// Does nothing.
@@ -186,7 +186,7 @@ public:
 #ifndef TMC_TRIVIAL_TASK
     assert(wrapped);
 #endif
-    executor->post(std::move(wrapped), prio);
+    detail::post_checked(executor, std::move(wrapped), prio);
   }
 
 #if !defined(NDEBUG) && !defined(TMC_TRIVIAL_TASK)

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -7,6 +7,7 @@
 
 #include "tmc/detail/concepts.hpp" // IWYU pragma: keep
 #include "tmc/detail/thread_locals.hpp"
+
 #include <atomic>
 #include <cassert>
 #include <coroutine>

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -62,8 +62,9 @@ template <typename Result> struct mt1_continuation_resumer {
             this_thread::exec_is(continuationExecutor)) {
           next = continuation;
         } else {
-          continuationExecutor->post(
-            std::move(continuation), this_thread::this_task.prio
+          detail::post_checked(
+            continuationExecutor, std::move(continuation),
+            this_thread::this_task.prio
           );
           next = std::noop_coroutine();
         }
@@ -90,8 +91,9 @@ template <typename Result> struct mt1_continuation_resumer {
               this_thread::exec_is(continuationExecutor)) {
             next = continuation;
           } else {
-            continuationExecutor->post(
-              std::move(continuation), this_thread::this_task.prio
+            detail::post_checked(
+              continuationExecutor, std::move(continuation),
+              this_thread::this_task.prio
             );
             next = std::noop_coroutine();
           }

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -58,10 +58,11 @@ template <typename Result> struct mt1_continuation_resumer {
       if (continuation) {
         detail::type_erased_executor* continuationExecutor =
           static_cast<detail::type_erased_executor*>(p.continuation_executor);
-        if (p.continuation_executor == nullptr ||
+        if (continuationExecutor == nullptr ||
             this_thread::exec_is(continuationExecutor)) {
           next = continuation;
         } else {
+          // post_checked is redundant with the prior check at the moment
           detail::post_checked(
             continuationExecutor, std::move(continuation),
             this_thread::this_task.prio
@@ -91,6 +92,7 @@ template <typename Result> struct mt1_continuation_resumer {
               this_thread::exec_is(continuationExecutor)) {
             next = continuation;
           } else {
+            // post_checked is redundant with the prior check at the moment
             detail::post_checked(
               continuationExecutor, std::move(continuation),
               this_thread::this_task.prio


### PR DESCRIPTION
By calling `tmc::external::set_default_executor()` somewhere (in main?) you can provide a global default executor that which will be used if the current thread isn't associated with an executor. This means that calling `tmc::spawn()` from an external thread, which would otherwise crash the program, will instead submit the task to the previously-provided default executor.

A more preferable solution would be for users to configure all external threads so that they are TMC-aware and provide a value for `detail::this_thread::executor`, but this is not always viable.

You can also use the existing `tmc::external::safe_await()` to await individual external awaitables, and resume the awaiting task back on the original executor. But this may not cover all use cases.

So this fallback default is provided. It can lead to some slightly unintuitive behavior (see below) but it's better than crashing the program.

```cpp
// in main
tmc::external::set_default_executor(tmc::cpu_executor());

tmc::task<void> something() {
  // I'm on a TMC executor
  co_await external_awaitable();
  // I'm on some external, unknown thread now

  // other_task will run on the default executor (cpu_executor)
  co_await spawn(other_task);
  // I resumed on the default executor as well
}
```

### Breaking Changes
- All utility functions for integrating with external coroutines/awaitables/executors have been moved into `"tmc/external.hpp"` and `namespace tmc::external`
- Renamed `tmc::safe_await_external()` -> `tmc::external::safe_await()`, found in `"tmc/external.hpp"`