### PR TITLE
fix regressions introduced by recent changes

### DIFF
--- a/include/tmc/aw_resume_on.hpp
+++ b/include/tmc/aw_resume_on.hpp
@@ -101,12 +101,12 @@ class aw_ex_scope_exit : tmc::detail::AwaitTagNoGroupAsIs {
 public:
   /// Returns an awaitable that can be co_await'ed to exit the
   /// executor scope. This is idempotent.
-  /// (Not strictly necessary - you can just await aw_ex_scope_exit directly -
-  /// but makes code a bit easier to understand.)
+  /// (Not strictly necessary - you can just `co_await std::move(*this);`
+  /// directly - but makes code a bit easier to understand.)
   [[nodiscard("You must co_await exit() for it to have any "
-              "effect.")]] inline aw_ex_scope_exit&
+              "effect.")]] inline aw_ex_scope_exit&&
   exit() {
-    return *this;
+    return std::move(*this);
   }
 
   /// Always suspends.

--- a/include/tmc/spawn_task_tuple.hpp
+++ b/include/tmc/spawn_task_tuple.hpp
@@ -672,9 +672,7 @@ struct awaitable_traits<aw_spawned_task_tuple_each<Result...>> {
   using self_type = aw_spawned_task_tuple_each<Result...>;
   using awaiter_type = self_type;
 
-  static awaiter_type get_awaiter(self_type&& Awaitable) {
-    return std::forward<self_type>(Awaitable);
-  }
+  static awaiter_type& get_awaiter(self_type& Awaitable) { return Awaitable; }
 };
 
 } // namespace detail

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -442,9 +442,8 @@ template <typename Result> struct task_promise {
   template <typename Awaitable>
   decltype(auto) await_transform(Awaitable&& awaitable) {
     if constexpr (requires {
-                    tmc::detail::get_awaitable_traits<Awaitable>::get_awaiter(
-                      std::forward<Awaitable>(awaitable)
-                    );
+                    // Check whether any function with this name exists
+                    &tmc::detail::get_awaitable_traits<Awaitable>::get_awaiter;
                   }) {
       return tmc::detail::get_awaitable_traits<Awaitable>::get_awaiter(
         std::forward<Awaitable>(awaitable)
@@ -511,9 +510,8 @@ template <> struct task_promise<void> {
   template <typename Awaitable>
   decltype(auto) await_transform(Awaitable&& awaitable) {
     if constexpr (requires {
-                    tmc::detail::get_awaitable_traits<Awaitable>::get_awaiter(
-                      std::forward<Awaitable>(awaitable)
-                    );
+                    // Check whether any function with this name exists
+                    &tmc::detail::get_awaitable_traits<Awaitable>::get_awaiter;
                   }) {
       return tmc::detail::get_awaitable_traits<Awaitable>::get_awaiter(
         std::forward<Awaitable>(awaitable)

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -109,18 +109,18 @@ struct awaitable_customizer_base {
     }
 
     // Common submission and continuation logic
-    if (continuationExecutor != nullptr &&
-        !this_thread::exec_is(continuationExecutor)) {
+    if (finalContinuation == nullptr) {
+      return std::noop_coroutine();
+    } else if (continuationExecutor != nullptr &&
+               !this_thread::exec_is(continuationExecutor)) {
       // post_checked is redundant with the prior check at the moment
       tmc::detail::post_checked(
         continuationExecutor, std::move(finalContinuation), Priority
       );
-      finalContinuation = nullptr;
+      return std::noop_coroutine();
+    } else {
+      return finalContinuation;
     }
-    if (finalContinuation == nullptr) {
-      finalContinuation = std::noop_coroutine();
-    }
-    return finalContinuation;
   }
 };
 


### PR DESCRIPTION
In #18 the `if (continuation)` check was removed from the final part of `mt1_continuation_resumer::await_suspend()`. This is now part of `awaitable_customizer_base::resume_continuation()`. This missing check was allowing null tasks to be submitted to the executor in the case of switching executors.

This is resolved by adding `if (finalContinuation == nullptr)` check.

------------------------------

In #19 the check for the existence of awaitable_traits in await_transform was based on passing `std::forward<Awaitable>(awaitable)` into `get_awaiter()`. If `get_awaiter()` expects an rvalue and the input is an lvalue, this will fail to detect - and the fallback to `safe_wrap` will happen silently.

This is resolved by simply checking for the existence of any function named `get_awaiter`. Now, the user can define an rvalue-taking function and if an lvalue is provided, it will be an error. It is expected that if such a ref-qualified overload is provided, the user doesn't expect this to work with a parameter that doesn't satisfy. If the user wants to support either / or, they can define multiple / templated overloads.

------------------------------

`aw_ex_scope_exit::exit()` was broken after this as it returned an lvalue, but its awaitable_traits::get_awaiter() expected an rvalue. The await_transform bug above was hiding this behavior. It should return an rvalue to satisfy its get_awaiter function. After fixing the await_transform bug, you could no longer directly await the result of `exit()`.

This is resolved by making `exit()` return an rvalue reference.

------------------------------

`aw_spawned_task_tuple_each` had get_awaiter looking for an rvalue, but this particular awaitable should be awaited multiple times. This again was being hidden by the await_transform bug.

This is resolved by making awaitable_traits::get_awaiter specialization for this take and return an lvalue reference. This now matches the specialization for `aw_task_many_each`.