### PR TITLE
Unified executor interface via `tmc::detail::executor_traits`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ It provides:
 - a suite of utility functions for fluently interacting with tasks, awaitables, and executors
 
 ### Documentation
-Documentation is available at https://fleetcode.com/oss/tmc/docs/v0.1.0/. As this is library approaches its first major release, this documentation is still under active development... but it's nearly complete.
+https://fleetcode.com/oss/tmc/docs/v0.1.0/
+
+As this is library approaches its first major release, this documentation is still under active development... but it's nearly complete.
 
 ### Examples
 https://github.com/tzcnt/tmc-examples
@@ -30,7 +32,7 @@ In order to reduce compile times, some files have separated declarations and def
 #include "tmc/all_headers.hpp"
 int main() {
   return tmc::async_main(()[] -> tmc::task<int> {
-    // Hello, world!
+    // Hello, async world!
     co_return 0;
   }());
 }
@@ -38,7 +40,7 @@ int main() {
 
 ### Configuration
 TooManyCooks supports the following configuration parameters, supplied as preprocessor definitions:
-- `TMC_USE_HWLOC` (default `OFF`) enables hwloc integration, allowing TMC to automatically create optimized thread layouts and work-stealing groups. This requires that you add the directory containing `hwloc.h` to your include path, and the `hwloc` library path to you your linker path. It is highly recommended to use this.
+- `TMC_USE_HWLOC` (default unset) enables hwloc integration, allowing TMC to automatically create optimized thread layouts and work-stealing groups. This requires that you add the directory containing `hwloc.h` to your include path, and the `hwloc` library path to you your linker path. It is highly recommended to use this.
 - `TMC_PRIORITY_COUNT=` (default unset) allows you to set the number of priority levels at compile-time, rather than at runtime. The main use case for this is to set the value to 1, which will remove all priority-specific code, making things slightly faster.
 - `TMC_WORK_ITEM=` (default `CORO`) controls the type used to store work items in the work stealing queue. Any type can store both a coroutine or a functor, but the performance characteristics are different. There are 4 options:
 
@@ -82,4 +84,4 @@ TooManyCooks has been tested on the following physical devices:
 - Rockchip RK3588S (in a Khadas Edge2)
 
 ### Untested Hardware
-TooManyCooks has not been tested on an M1+ Mac, or any Intel Hybrid (12th gen Core or newer) architecture. These platforms represent unique optimization challenges, and I am interested in purchasing one of these parts, for the right price. Contact me if you want to support the project :)
+TooManyCooks has not been tested on an M1+ Mac, or any Intel Hybrid (12th gen Core or newer) architecture - yet. I have recently purchased both of these machines, so this will be forthcoming.

--- a/include/tmc/aw_resume_on.hpp
+++ b/include/tmc/aw_resume_on.hpp
@@ -178,7 +178,9 @@ public:
   /// Switch this task to the target executor.
   TMC_FORCE_INLINE inline std::coroutine_handle<>
   await_suspend(std::coroutine_handle<> Outer) {
-    return scope_executor.task_enter_context(Outer, prio);
+    return tmc::detail::executor_traits<E>::task_enter_context(
+      scope_executor, Outer, prio
+    );
   }
 
   /// Returns an `aw_ex_scope_exit` with an `exit()` method that can be called

--- a/include/tmc/aw_resume_on.hpp
+++ b/include/tmc/aw_resume_on.hpp
@@ -64,17 +64,15 @@ inline aw_resume_on resume_on(tmc::detail::type_erased_executor* Executor) {
 /// Returns an awaitable that moves this task onto the requested executor. If
 /// this task is already running on the requested executor, the co_await will do
 /// nothing.
-template <tmc::detail::TypeErasableExecutor Exec>
-inline aw_resume_on resume_on(Exec& Executor) {
-  return resume_on(Executor.type_erased());
+template <typename Exec> inline aw_resume_on resume_on(Exec& Executor) {
+  return resume_on(tmc::detail::executor_traits<Exec>::type_erased(Executor));
 }
 
 /// Returns an awaitable that moves this task onto the requested executor. If
 /// this task is already running on the requested executor, the co_await will do
 /// nothing.
-template <tmc::detail::TypeErasableExecutor Exec>
-inline aw_resume_on resume_on(Exec* Executor) {
-  return resume_on(Executor->type_erased());
+template <typename Exec> inline aw_resume_on resume_on(Exec* Executor) {
+  return resume_on(tmc::detail::executor_traits<Exec>::type_erased(*Executor));
 }
 
 /// Equivalent to `resume_on(tmc::current_executor()).with_priority(Priority);`
@@ -134,16 +132,15 @@ public:
 
   /// When awaited, the outer coroutine will be resumed on the provided
   /// executor.
-  template <tmc::detail::TypeErasableExecutor Exec>
-  aw_ex_scope_exit& resume_on(Exec& Executor) {
-    return resume_on(Executor.type_erased());
+  template <typename Exec> aw_ex_scope_exit& resume_on(Exec& Executor) {
+    return resume_on(tmc::detail::executor_traits<Exec>::type_erased(Executor));
   }
 
   /// When awaited, the outer coroutine will be resumed on the provided
   /// executor.
-  template <tmc::detail::TypeErasableExecutor Exec>
-  aw_ex_scope_exit& resume_on(Exec* Executor) {
-    return resume_on(Executor->type_erased());
+  template <typename Exec> aw_ex_scope_exit& resume_on(Exec* Executor) {
+    return resume_on(tmc::detail::executor_traits<Exec>::type_erased(*Executor)
+    );
   }
 
   /// When awaited, the outer coroutine will be resumed with the provided

--- a/include/tmc/detail/concepts.hpp
+++ b/include/tmc/detail/concepts.hpp
@@ -9,8 +9,6 @@
 
 namespace tmc {
 namespace detail {
-template <typename E>
-concept TypeErasableExecutor = requires(E e) { e.type_erased(); };
 
 struct AwaitTagNoGroupAsIs {};
 
@@ -152,5 +150,8 @@ static void set_flags(Awaitable& YourAwaitable, uint64_t Flags);
 */
 template <typename Awaitable>
 using get_awaitable_traits = awaitable_traits<std::remove_cvref_t<Awaitable>>;
+
+template <typename Executor> struct executor_traits;
+
 } // namespace detail
 } // namespace tmc

--- a/include/tmc/detail/ex_braid.ipp
+++ b/include/tmc/detail/ex_braid.ipp
@@ -131,4 +131,31 @@ ex_braid::task_enter_context(std::coroutine_handle<> Outer, size_t Priority) {
   }
 }
 
+namespace detail {
+
+void executor_traits<tmc::ex_braid>::post(
+  tmc::ex_braid& ex, tmc::work_item&& Item, size_t Priority
+) {
+  ex.post(std::move(Item), Priority);
+}
+
+template <typename It>
+void executor_traits<tmc::ex_braid>::post_bulk(
+  tmc::ex_braid& ex, It&& Items, size_t Count, size_t Priority
+) {
+  ex.post_bulk(std::forward<It>(Items), Count, Priority);
+}
+
+tmc::detail::type_erased_executor*
+executor_traits<tmc::ex_braid>::type_erased(tmc::ex_braid& ex) {
+  return ex.type_erased();
+}
+
+std::coroutine_handle<> executor_traits<tmc::ex_braid>::task_enter_context(
+  tmc::ex_braid& ex, std::coroutine_handle<> Outer, size_t Priority
+) {
+  return ex.task_enter_context(Outer, Priority);
+}
+
+} // namespace detail
 } // namespace tmc

--- a/include/tmc/detail/ex_cpu.ipp
+++ b/include/tmc/detail/ex_cpu.ipp
@@ -605,6 +605,31 @@ ex_cpu::task_enter_context(std::coroutine_handle<> Outer, size_t Priority) {
 }
 
 namespace detail {
+
+void executor_traits<tmc::ex_cpu>::post(
+  tmc::ex_cpu& ex, tmc::work_item&& Item, size_t Priority
+) {
+  ex.post(std::move(Item), Priority);
+}
+
+template <typename It>
+void executor_traits<tmc::ex_cpu>::post_bulk(
+  tmc::ex_cpu& ex, It&& Items, size_t Count, size_t Priority
+) {
+  ex.post_bulk(std::forward<It>(Items), Count, Priority);
+}
+
+tmc::detail::type_erased_executor*
+executor_traits<tmc::ex_cpu>::type_erased(tmc::ex_cpu& ex) {
+  return ex.type_erased();
+}
+
+std::coroutine_handle<> executor_traits<tmc::ex_cpu>::task_enter_context(
+  tmc::ex_cpu& ex, std::coroutine_handle<> Outer, size_t Priority
+) {
+  return ex.task_enter_context(Outer, Priority);
+}
+
 tmc::task<void> client_main_awaiter(
   tmc::task<int> ClientMainTask, std::atomic<int>* ExitCode_out
 ) {

--- a/include/tmc/detail/mixins.hpp
+++ b/include/tmc/detail/mixins.hpp
@@ -22,15 +22,15 @@ public:
     return static_cast<Derived&>(*this);
   }
   /// The wrapped task will run on the provided executor.
-  template <tmc::detail::TypeErasableExecutor Exec>
-  [[nodiscard]] Derived& run_on(Exec& Executor) & {
-    static_cast<Derived*>(this)->executor = Executor.type_erased();
+  template <typename Exec> [[nodiscard]] Derived& run_on(Exec& Executor) & {
+    static_cast<Derived*>(this)->executor =
+      tmc::detail::executor_traits<Exec>::type_erased(Executor);
     return static_cast<Derived&>(*this);
   }
   /// The wrapped task will run on the provided executor.
-  template <tmc::detail::TypeErasableExecutor Exec>
-  [[nodiscard]] Derived& run_on(Exec* Executor) & {
-    static_cast<Derived*>(this)->executor = Executor->type_erased();
+  template <typename Exec> [[nodiscard]] Derived& run_on(Exec* Executor) & {
+    static_cast<Derived*>(this)->executor =
+      tmc::detail::executor_traits<Exec>::type_erased(*Executor);
     return static_cast<Derived&>(*this);
   }
 
@@ -41,15 +41,15 @@ public:
     return static_cast<Derived&&>(*this);
   }
   /// The wrapped task will run on the provided executor.
-  template <tmc::detail::TypeErasableExecutor Exec>
-  [[nodiscard]] Derived&& run_on(Exec& Executor) && {
-    static_cast<Derived*>(this)->executor = Executor.type_erased();
+  template <typename Exec> [[nodiscard]] Derived&& run_on(Exec& Executor) && {
+    static_cast<Derived*>(this)->executor =
+      tmc::detail::executor_traits<Exec>::type_erased(Executor);
     return static_cast<Derived&&>(*this);
   }
   /// The wrapped task will run on the provided executor.
-  template <tmc::detail::TypeErasableExecutor Exec>
-  [[nodiscard]] Derived&& run_on(Exec* Executor) && {
-    static_cast<Derived*>(this)->executor = Executor->type_erased();
+  template <typename Exec> [[nodiscard]] Derived&& run_on(Exec* Executor) && {
+    static_cast<Derived*>(this)->executor =
+      tmc::detail::executor_traits<Exec>::type_erased(*Executor);
     return static_cast<Derived&&>(*this);
   }
 };
@@ -63,16 +63,15 @@ public:
     return static_cast<Derived&>(*this);
   }
   /// The wrapped task will run on the provided executor.
-  template <tmc::detail::TypeErasableExecutor Exec>
-  [[nodiscard]] Derived& resume_on(Exec& Executor) & {
-    static_cast<Derived*>(this)->continuation_executor = Executor.type_erased();
+  template <typename Exec> [[nodiscard]] Derived& resume_on(Exec& Executor) & {
+    static_cast<Derived*>(this)->continuation_executor =
+      tmc::detail::executor_traits<Exec>::type_erased(Executor);
     return static_cast<Derived&>(*this);
   }
   /// The wrapped task will run on the provided executor.
-  template <tmc::detail::TypeErasableExecutor Exec>
-  [[nodiscard]] Derived& resume_on(Exec* Executor) & {
+  template <typename Exec> [[nodiscard]] Derived& resume_on(Exec* Executor) & {
     static_cast<Derived*>(this)->continuation_executor =
-      Executor->type_erased();
+      tmc::detail::executor_traits<Exec>::type_erased(*Executor);
     return static_cast<Derived&>(*this);
   }
 
@@ -83,16 +82,17 @@ public:
     return static_cast<Derived&&>(*this);
   }
   /// The wrapped task will run on the provided executor.
-  template <tmc::detail::TypeErasableExecutor Exec>
+  template <typename Exec>
   [[nodiscard]] Derived&& resume_on(Exec& Executor) && {
-    static_cast<Derived*>(this)->continuation_executor = Executor.type_erased();
+    static_cast<Derived*>(this)->continuation_executor =
+      tmc::detail::executor_traits<Exec>::type_erased(Executor);
     return static_cast<Derived&&>(*this);
   }
   /// The wrapped task will run on the provided executor.
-  template <tmc::detail::TypeErasableExecutor Exec>
+  template <typename Exec>
   [[nodiscard]] Derived&& resume_on(Exec* Executor) && {
     static_cast<Derived*>(this)->continuation_executor =
-      Executor->type_erased();
+      tmc::detail::executor_traits<Exec>::type_erased(*Executor);
     return static_cast<Derived&&>(*this);
   }
 };

--- a/include/tmc/detail/thread_locals.hpp
+++ b/include/tmc/detail/thread_locals.hpp
@@ -70,6 +70,11 @@ public:
     s_post_bulk(executor, Items, Count, Priority);
   }
 
+  // A default constructor is offered so that other executors can initialize
+  // this with their own function pointers.
+  type_erased_executor() {}
+
+  // This constructor is used by TMC executors.
   template <typename T> type_erased_executor(T* Executor) {
     executor = Executor;
     s_post = [](void* Erased, work_item&& Item, size_t Priority) {

--- a/include/tmc/ex_braid.hpp
+++ b/include/tmc/ex_braid.hpp
@@ -97,8 +97,6 @@ public:
     }
   }
 
-  /// Implements `tmc::TypeErasableExecutor` concept, but unlikely to be needed
-  /// directly by users.
   inline tmc::detail::type_erased_executor* type_erased() {
     return &type_erased_this;
   }

--- a/include/tmc/ex_braid.hpp
+++ b/include/tmc/ex_braid.hpp
@@ -21,6 +21,7 @@
 namespace tmc {
 class ex_braid {
   friend class aw_ex_scope_enter<ex_braid>;
+  friend tmc::detail::executor_traits<ex_braid>;
 
 #ifdef TMC_USE_MUTEXQ
   using task_queue_t = tmc::detail::MutexQueue<work_item>;
@@ -134,6 +135,21 @@ private:
 //   }
 // };
 
+namespace detail {
+template <> struct executor_traits<tmc::ex_braid> {
+  static void post(tmc::ex_braid& ex, tmc::work_item&& Item, size_t Priority);
+
+  template <typename It>
+  static void
+  post_bulk(tmc::ex_braid& ex, It&& Items, size_t Count, size_t Priority);
+
+  static tmc::detail::type_erased_executor* type_erased(tmc::ex_braid& ex);
+
+  static std::coroutine_handle<> task_enter_context(
+    tmc::ex_braid& ex, std::coroutine_handle<> Outer, size_t Priority
+  );
+};
+} // namespace detail
 } // namespace tmc
 
 #ifdef TMC_IMPL

--- a/include/tmc/ex_braid.hpp
+++ b/include/tmc/ex_braid.hpp
@@ -111,7 +111,8 @@ public:
 
   /// Construct a braid with the specified executor as its parent.
   template <typename Executor>
-  ex_braid(Executor& Parent) : ex_braid(Parent.type_erased()) {}
+  ex_braid(Executor& Parent)
+      : ex_braid(tmc::detail::executor_traits<Executor>::type_erased(Parent)) {}
   ~ex_braid();
 
 private:

--- a/include/tmc/ex_cpu.hpp
+++ b/include/tmc/ex_cpu.hpp
@@ -90,6 +90,7 @@ class ex_cpu {
   );
 
   friend class aw_ex_scope_enter<ex_cpu>;
+  friend tmc::detail::executor_traits<ex_cpu>;
   friend size_t test::wait_for_all_threads_to_sleep(ex_cpu& Executor);
   std::coroutine_handle<>
   task_enter_context(std::coroutine_handle<> Outer, size_t Priority);
@@ -178,6 +179,20 @@ public:
 };
 
 namespace detail {
+template <> struct executor_traits<tmc::ex_cpu> {
+  static void post(tmc::ex_cpu& ex, tmc::work_item&& Item, size_t Priority);
+
+  template <typename It>
+  static void
+  post_bulk(tmc::ex_cpu& ex, It&& Items, size_t Count, size_t Priority);
+
+  static tmc::detail::type_erased_executor* type_erased(tmc::ex_cpu& ex);
+
+  static std::coroutine_handle<> task_enter_context(
+    tmc::ex_cpu& ex, std::coroutine_handle<> Outer, size_t Priority
+  );
+};
+
 inline ex_cpu g_ex_cpu;
 } // namespace detail
 

--- a/include/tmc/ex_cpu.hpp
+++ b/include/tmc/ex_cpu.hpp
@@ -160,8 +160,6 @@ public:
   /// `tmc::post()` free function template.
   void post(work_item&& Item, size_t Priority);
 
-  /// Implements `tmc::TypeErasableExecutor` concept, but unlikely to be needed
-  /// directly by users.
   tmc::detail::type_erased_executor* type_erased();
 
   /// Submits `count` items to the executor. `It` is expected to be an iterator

--- a/include/tmc/external.hpp
+++ b/include/tmc/external.hpp
@@ -41,10 +41,10 @@ inline void set_default_executor(tmc::detail::type_erased_executor* Executor) {
 ///
 /// then that function will use this default executor (instead of deferencing
 /// nullptr and crashing).
-template <tmc::detail::TypeErasableExecutor Exec>
-inline void set_default_executor(Exec& Executor) {
+template <typename Exec> inline void set_default_executor(Exec& Executor) {
   tmc::detail::g_ex_default.store(
-    Executor.type_erased(), std::memory_order_release
+    tmc::detail::executor_traits<Exec>::type_erased(Executor),
+    std::memory_order_release
   );
 }
 /// You only need to set this if you are planning to integrate TMC with external
@@ -58,10 +58,10 @@ inline void set_default_executor(Exec& Executor) {
 ///
 /// then that function will use this default executor (instead of deferencing
 /// nullptr and crashing).
-template <tmc::detail::TypeErasableExecutor Exec>
-inline void set_default_executor(Exec* Executor) {
+template <typename Exec> inline void set_default_executor(Exec* Executor) {
   tmc::detail::g_ex_default.store(
-    Executor->type_erased(), std::memory_order_release
+    tmc::detail::executor_traits<Exec>::type_erased(*Executor),
+    std::memory_order_release
   );
 }
 

--- a/include/tmc/sync.hpp
+++ b/include/tmc/sync.hpp
@@ -151,7 +151,8 @@ post_bulk_waitable(E& Executor, TaskIter&& Begin, size_t Count, size_t Priority)
     sharedState->continuation_executor = Executor;
   }
 
-  Executor.post_bulk(
+  tmc::detail::executor_traits<E>::post_bulk(
+    Executor,
     iter_adapter(
       std::forward<TaskIter>(Begin),
       [sharedState](TaskIter iter) mutable -> task<void> {
@@ -196,7 +197,8 @@ post_bulk_waitable(E& Executor, FuncIter&& Begin, size_t Count, size_t Priority)
   std::shared_ptr<BulkSyncState> sharedState =
     std::make_shared<BulkSyncState>(std::promise<void>(), Count - 1);
 #if TMC_WORK_ITEM_IS(CORO)
-  Executor.post_bulk(
+  tmc::detail::executor_traits<E>::post_bulk(
+    Executor,
     iter_adapter(
       std::forward<FuncIter>(Begin),
       [sharedState](FuncIter iter) mutable -> std::coroutine_handle<> {
@@ -215,7 +217,8 @@ post_bulk_waitable(E& Executor, FuncIter&& Begin, size_t Count, size_t Priority)
     Count, Priority
   );
 #else
-  Executor.post_bulk(
+  tmc::detail::executor_traits<E>::post_bulk(
+    Executor,
     iter_adapter(
       std::forward<FuncIter>(Begin),
       [sharedState](FuncIter iter) mutable -> auto {
@@ -247,9 +250,12 @@ void post_bulk(E& Executor, Iter&& Begin, size_t Count, size_t Priority)
   requires(tmc::detail::is_task_void_v<TaskOrFunc> || tmc::detail::is_func_void_v<TaskOrFunc>)
 {
   if constexpr (std::is_convertible_v<TaskOrFunc, work_item>) {
-    Executor.post_bulk(std::forward<Iter>(Begin), Count, Priority);
+    tmc::detail::executor_traits<E>::post_bulk(
+      Executor, std::forward<Iter>(Begin), Count, Priority
+    );
   } else {
-    Executor.post_bulk(
+    tmc::detail::executor_traits<E>::post_bulk(
+      Executor,
       tmc::iter_adapter(
         std::forward<Iter>(Begin),
         [](Iter& it) -> work_item { return tmc::detail::into_work_item(*it); }
@@ -273,9 +279,12 @@ void post_bulk(E& Executor, Iter&& Begin, Iter&& End, size_t Priority)
   if constexpr (requires(Iter a, Iter b) { a - b; }) {
     size_t Count = End - Begin;
     if constexpr (std::is_convertible_v<TaskOrFunc, work_item>) {
-      Executor.post_bulk(std::forward<Iter>(Begin), Count, Priority);
+      tmc::detail::executor_traits<E>::post_bulk(
+        Executor, std::forward<Iter>(Begin), Count, Priority
+      );
     } else {
-      Executor.post_bulk(
+      tmc::detail::executor_traits<E>::post_bulk(
+        Executor,
         tmc::iter_adapter(
           std::forward<Iter>(Begin),
           [](Iter& it) -> work_item { return tmc::detail::into_work_item(*it); }
@@ -289,7 +298,9 @@ void post_bulk(E& Executor, Iter&& Begin, Iter&& End, size_t Priority)
       tasks.emplace_back(tmc::detail::into_work_item(*Begin));
       ++Begin;
     }
-    Executor.post_bulk(tasks.begin(), tasks.size(), Priority);
+    tmc::detail::executor_traits<E>::post_bulk(
+      Executor, tasks.begin(), tasks.size(), Priority
+    );
   }
 }
 

--- a/include/tmc/sync.hpp
+++ b/include/tmc/sync.hpp
@@ -145,8 +145,11 @@ post_bulk_waitable(E& Executor, TaskIter&& Begin, size_t Count, size_t Priority)
     State->promise.set_value();
     co_return;
   }(sharedState);
-  if constexpr (requires { Executor.type_erased(); }) {
-    sharedState->continuation_executor = Executor.type_erased();
+  if constexpr (requires {
+                  tmc::detail::executor_traits<E>::type_erased(Executor);
+                }) {
+    sharedState->continuation_executor =
+      tmc::detail::executor_traits<E>::type_erased(Executor);
   } else {
     sharedState->continuation_executor = Executor;
   }

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -949,10 +949,13 @@ void post(E& Executor, TaskOrFunc&& Work, size_t Priority)
   requires(tmc::detail::is_task_void_v<TaskOrFunc> || tmc::detail::is_func_void_v<TaskOrFunc>)
 {
   if constexpr (std::is_convertible_v<TaskOrFunc, work_item>) {
-    Executor.post(work_item(static_cast<TaskOrFunc&&>(Work)), Priority);
+    tmc::detail::executor_traits<E>::post_bulk(
+      Executor, work_item(static_cast<TaskOrFunc&&>(Work)), Priority
+    );
   } else {
-    Executor.post(
-      tmc::detail::into_work_item(static_cast<TaskOrFunc&&>(Work)), Priority
+    tmc::detail::executor_traits<E>::post_bulk(
+      Executor, tmc::detail::into_work_item(static_cast<TaskOrFunc&&>(Work)),
+      Priority
     );
   }
 }

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -951,11 +951,11 @@ void post(E& Executor, TaskOrFunc&& Work, size_t Priority)
   requires(tmc::detail::is_task_void_v<TaskOrFunc> || tmc::detail::is_func_void_v<TaskOrFunc>)
 {
   if constexpr (std::is_convertible_v<TaskOrFunc, work_item>) {
-    tmc::detail::executor_traits<E>::post_bulk(
+    tmc::detail::executor_traits<E>::post(
       Executor, work_item(static_cast<TaskOrFunc&&>(Work)), Priority
     );
   } else {
-    tmc::detail::executor_traits<E>::post_bulk(
+    tmc::detail::executor_traits<E>::post(
       Executor, tmc::detail::into_work_item(static_cast<TaskOrFunc&&>(Work)),
       Priority
     );

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -202,19 +202,20 @@ template <typename Result> struct task {
   }
   /// When this task completes, the awaiting coroutine will be resumed
   /// on the provided executor.
-  template <tmc::detail::TypeErasableExecutor Exec>
+  template <typename Exec>
   [[nodiscard("You must submit or co_await task for execution. Failure to "
               "do so will result in a memory leak.")]] task&
   resume_on(Exec& Executor) & {
-    return resume_on(Executor.type_erased());
+    return resume_on(tmc::detail::executor_traits<Exec>::type_erased(Executor));
   }
   /// When this task completes, the awaiting coroutine will be resumed
   /// on the provided executor.
-  template <tmc::detail::TypeErasableExecutor Exec>
+  template <typename Exec>
   [[nodiscard("You must submit or co_await task for execution. Failure to "
               "do so will result in a memory leak.")]] task&
   resume_on(Exec* Executor) & {
-    return resume_on(Executor->type_erased());
+    return resume_on(tmc::detail::executor_traits<Exec>::type_erased(*Executor)
+    );
   }
 
   /// When this task completes, the awaiting coroutine will be resumed
@@ -227,19 +228,20 @@ template <typename Result> struct task {
   }
   /// When this task completes, the awaiting coroutine will be resumed
   /// on the provided executor.
-  template <tmc::detail::TypeErasableExecutor Exec>
+  template <typename Exec>
   [[nodiscard("You must submit or co_await task for execution. Failure to "
               "do so will result in a memory leak.")]] task&&
   resume_on(Exec& Executor) && {
-    return resume_on(Executor.type_erased());
+    return resume_on(tmc::detail::executor_traits<Exec>::type_erased(Executor));
   }
   /// When this task completes, the awaiting coroutine will be resumed
   /// on the provided executor.
-  template <tmc::detail::TypeErasableExecutor Exec>
+  template <typename Exec>
   [[nodiscard("You must submit or co_await task for execution. Failure to "
               "do so will result in a memory leak.")]] task&&
   resume_on(Exec* Executor) && {
-    return resume_on(Executor->type_erased());
+    return resume_on(tmc::detail::executor_traits<Exec>::type_erased(*Executor)
+    );
   }
 
   inline task() noexcept : handle(nullptr) {}


### PR DESCRIPTION
This replaces the `TypeErasableExecutor` concept with the `tmc::detail::executor_traits`  implementation. Unlike awaitable_traits, there is no default implementation. This must be provided for the following functions to work with an executor:

- post() / post_bulk() / post_waitable() / post_bulk_waitable()
- run_on() / resume_on()
- enter() / exit()

An implementation has been provided for `ex_cpu`, `ex_braid`, and `ex_asio`.