### PR TITLE
Don't rethrow exceptions in unhandled_exception()

### DIFF
--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -12,6 +12,7 @@
 #include <atomic>
 #include <cassert>
 #include <coroutine>
+#include <exception>
 #include <new>
 #include <type_traits>
 
@@ -432,10 +433,7 @@ template <typename Result> struct task_promise {
   task<Result> get_return_object() noexcept {
     return {task<Result>::from_promise(*this)};
   }
-  void unhandled_exception() {
-    throw;
-    // exc = std::current_exception();
-  }
+  void unhandled_exception() { std::terminate(); }
 
   template <typename RV> void return_value(RV&& Value) {
     *customizer.result_ptr = static_cast<RV&&>(Value);
@@ -502,10 +500,7 @@ template <> struct task_promise<void> {
   task<void> get_return_object() noexcept {
     return {task<void>::from_promise(*this)};
   }
-  [[noreturn]] void unhandled_exception() {
-    throw;
-    // exc = std::current_exception();
-  }
+  void unhandled_exception() { std::terminate(); }
 
   void return_void() {}
 
@@ -543,10 +538,7 @@ template <typename Result> struct wrapper_task_promise {
   wrapper_task<Result> get_return_object() noexcept {
     return {wrapper_task<Result>::from_promise(*this)};
   }
-  void unhandled_exception() {
-    throw;
-    // exc = std::current_exception();
-  }
+  void unhandled_exception() { std::terminate(); }
 
   template <typename RV> void return_value(RV&& Value) {
     *customizer.result_ptr = static_cast<RV&&>(Value);
@@ -595,10 +587,7 @@ template <> struct wrapper_task_promise<void> {
   wrapper_task<void> get_return_object() noexcept {
     return {wrapper_task<void>::from_promise(*this)};
   }
-  [[noreturn]] void unhandled_exception() {
-    throw;
-    // exc = std::current_exception();
-  }
+  void unhandled_exception() { std::terminate(); }
 
   void return_void() {}
 };


### PR DESCRIPTION
Currently the library doesn't have any way of handling the rethrown exceptions. I believe they would be thrown in the executor runloop scope, not in the awaiting coroutine scope. Since the runloop doesn't have any exception handling, this would result in termination anyway.

In order to make them thrown in the awaiting coroutine scope where the caller can handle them, they would need to be stored in the result struct and thrown in await_resume(). Implementing this properly will be an exercise for another day.

I don't personally care for exceptions, so supporting this behavior is not high priority at this time. Now we can also turn on `-fno-exceptions` and get slightly better performance.