### PR TITLE
Resolve compilation issues on Windows/MSVC

### DIFF
--- a/include/tmc/detail/concepts.hpp
+++ b/include/tmc/detail/concepts.hpp
@@ -74,7 +74,7 @@ template <typename Awaitable> struct awaitable_traits {
   // If this doesn't behave as expected, you should specialize awaitable_traits
   // instead.
   using result_type =
-    tmc::detail::unknown_awaitable_traits<Awaitable>::result_type;
+    typename tmc::detail::unknown_awaitable_traits<Awaitable>::result_type;
 };
 
 // Details on how to specialize awaitable_traits:
@@ -84,7 +84,7 @@ template <typename Awaitable> struct awaitable_traits {
 
 // Define the result type of `co_await YourAwaitable;`
 // This should be a value type, not a reference type.
-using result_type = (result type of `co_await YourAwaitable;`);
+using result_type = typename (result type of `co_await YourAwaitable;`);
 
 // ## Declarations controlling the behavior when awaited directly in a tmc::task
 
@@ -150,6 +150,10 @@ static void set_flags(Awaitable& YourAwaitable, uint64_t Flags);
 */
 template <typename Awaitable>
 using get_awaitable_traits = awaitable_traits<std::remove_cvref_t<Awaitable>>;
+
+template <typename Awaitable>
+using awaitable_result_t =
+  typename awaitable_traits<std::remove_cvref_t<Awaitable>>::result_type;
 
 template <typename Executor> struct executor_traits;
 

--- a/include/tmc/detail/ex_cpu.ipp
+++ b/include/tmc/detail/ex_cpu.ipp
@@ -375,8 +375,8 @@ void ex_cpu::init() {
   std::atomic<int> initThreadsBarrier(static_cast<int>(thread_count()));
   std::atomic_thread_fence(std::memory_order_seq_cst);
   size_t slot = 0;
-  size_t groupStart = 0;
 #ifdef TMC_USE_HWLOC
+  size_t groupStart = 0;
   // copy elements of groupedCores into thread lambda capture
   // that will go out of scope at the end of this function
   tmc::detail::ThreadSetupData tdata;

--- a/include/tmc/detail/ex_cpu.ipp
+++ b/include/tmc/detail/ex_cpu.ipp
@@ -33,8 +33,10 @@ void ex_cpu::notify_n(size_t Count, size_t Priority) {
     // if available threads can take all tasks, no need to interrupt
     if (sleepingThreadCount < Count && workingThreadCount != 0) {
       size_t interruptCount = 0;
-      size_t interruptMax =
-        std::min(workingThreadCount, Count - sleepingThreadCount);
+      size_t interruptMax = Count - sleepingThreadCount;
+      if (workingThreadCount < interruptMax) {
+        interruptMax = workingThreadCount;
+      }
       for (size_t prio = PRIORITY_COUNT - 1; prio > Priority; --prio) {
         uint64_t set =
           task_stopper_bitsets[prio].load(std::memory_order_acquire);

--- a/include/tmc/detail/qu_lockfree.hpp
+++ b/include/tmc/detail/qu_lockfree.hpp
@@ -31,12 +31,15 @@
 #endif
 #endif
 
-#if defined(_MSC_VER) && (!defined(_HAS_CXX17) || !_HAS_CXX17)
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4146 4293 4307 4309 4706)
+#if (!defined(_HAS_CXX17) || !_HAS_CXX17)
 // VS2019 with /W4 warns about constant conditional expressions but unless
 // /std=c++17 or higher does not support `if constexpr`, so we have no choice
 // but to simply disable the warning
-#pragma warning(push)
 #pragma warning(disable : 4127) // conditional expression is constant
+#endif
 #endif
 
 #if defined(__APPLE__)
@@ -853,16 +856,9 @@ public:
 
   static constexpr size_t BLOCK_EMPTY_ELEM_SIZE =
     PRODUCER_BLOCK_SIZE < 64 ? PRODUCER_BLOCK_SIZE : 64;
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4146 4293)
-#endif
   static constexpr uint64_t BLOCK_EMPTY_MASK =
     PRODUCER_BLOCK_SIZE < 64 ? (1ULL << Traits::PRODUCER_BLOCK_SIZE) - 1ULL
                              : -1ULL;
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
   static constexpr size_t BLOCK_EMPTY_ARRAY_SIZE =
     PRODUCER_BLOCK_SIZE < 64 ? 1 : (PRODUCER_BLOCK_SIZE / 64);
   // Each emptyFlags element is a 64-bitmask. 8 of these (512bits) make up a
@@ -888,12 +884,6 @@ public:
       static_cast<std::uint32_t>(
         Traits::EXPLICIT_CONSUMER_CONSUMPTION_QUOTA_BEFORE_ROTATE
       );
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4307) // + integral constant overflow (that's what the
-                                // ternary expression is for!)
-#pragma warning(disable : 4309) // static_cast: Truncation of constant value
-#endif
   static constexpr size_t MAX_SUBQUEUE_SIZE =
     (details::const_numeric_max<size_t>::value -
        static_cast<size_t>(Traits::MAX_SUBQUEUE_SIZE) <
@@ -901,9 +891,6 @@ public:
       ? details::const_numeric_max<size_t>::value
       : ((static_cast<size_t>(Traits::MAX_SUBQUEUE_SIZE) + (BLOCK_MASK)) /
          PRODUCER_BLOCK_SIZE * PRODUCER_BLOCK_SIZE);
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
   static_assert(
     !std::numeric_limits<size_t>::is_signed && std::is_integral<size_t>::value,
@@ -3464,10 +3451,6 @@ private:
       return true;
     }
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4706) // assignment within conditional expression
-#endif
     template <AllocationMode allocMode, typename It>
     bool enqueue_bulk(It itemFirst, size_t count) {
       // First, we need to make sure we have enough room to enqueue all of the
@@ -3666,9 +3649,6 @@ private:
       this->tailIndex.store(newTailIndex, std::memory_order_release);
       return true;
     }
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
     template <typename It> size_t dequeue_bulk(It& itemFirst, size_t max) {
       auto tail = this->tailIndex.load(std::memory_order_relaxed);
@@ -4771,7 +4751,7 @@ inline void swap(
 
 } // namespace tmc::queue
 
-#if defined(_MSC_VER) && (!defined(_HAS_CXX17) || !_HAS_CXX17)
+#if defined(_MSC_VER)
 #pragma warning(pop)
 #endif
 

--- a/include/tmc/detail/thread_locals.hpp
+++ b/include/tmc/detail/thread_locals.hpp
@@ -126,9 +126,26 @@ inline void post_bulk_checked(
 } // namespace tmc
 
 #if defined(_MSC_VER)
+
+#ifdef __has_cpp_attribute
+
+#if __has_cpp_attribute(msvc::forceinline)
 #define TMC_FORCE_INLINE [[msvc::forceinline]]
+#else
+#define TMC_FORCE_INLINE
+#endif
+
+#if __has_cpp_attribute(msvc::no_unique_address)
 #define TMC_NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
 #else
+#define TMC_NO_UNIQUE_ADDRESS
+#endif
+
+#else // not __has_cpp_attribute
+#define TMC_FORCE_INLINE [[msvc::forceinline]]
+#define TMC_NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
+#endif
+#else // not _MSC_VER
 #define TMC_FORCE_INLINE __attribute__((always_inline))
 #define TMC_NO_UNIQUE_ADDRESS [[no_unique_address]]
 #endif

--- a/include/tmc/detail/thread_locals.hpp
+++ b/include/tmc/detail/thread_locals.hpp
@@ -125,7 +125,7 @@ inline void post_bulk_checked(
 } // namespace detail
 } // namespace tmc
 
-#if defined(_MSC_VER) && !defined(__clang__)
+#if defined(_MSC_VER)
 #define TMC_FORCE_INLINE [[msvc::forceinline]]
 #define TMC_NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
 #else

--- a/include/tmc/spawn_many.hpp
+++ b/include/tmc/spawn_many.hpp
@@ -39,7 +39,7 @@ class aw_task_many;
 template <
   size_t Count, typename AwaitableIter,
   typename Awaitable = std::iter_value_t<AwaitableIter>,
-  typename Result = tmc::detail::get_awaitable_traits<Awaitable>::result_type>
+  typename Result = tmc::detail::awaitable_result_t<Awaitable>>
 aw_task_many<Result, Count, AwaitableIter, size_t, false>
 spawn_many(AwaitableIter&& Begin) {
   static_assert(Count != 0);
@@ -60,7 +60,7 @@ spawn_many(AwaitableIter&& Begin) {
 /// Submits items in range [Begin, Begin + TaskCount) to the executor.
 template <
   typename AwaitableIter, typename Awaitable = std::iter_value_t<AwaitableIter>,
-  typename Result = tmc::detail::get_awaitable_traits<Awaitable>::result_type>
+  typename Result = tmc::detail::awaitable_result_t<Awaitable>>
 aw_task_many<Result, 0, AwaitableIter, size_t, false>
 spawn_many(AwaitableIter&& Begin, size_t TaskCount) {
   return aw_task_many<Result, 0, AwaitableIter, size_t, false>(
@@ -90,7 +90,7 @@ spawn_many(AwaitableIter&& Begin, size_t TaskCount) {
 template <
   size_t MaxCount = 0, typename AwaitableIter,
   typename Awaitable = std::iter_value_t<AwaitableIter>,
-  typename Result = tmc::detail::get_awaitable_traits<Awaitable>::result_type>
+  typename Result = tmc::detail::awaitable_result_t<Awaitable>>
 aw_task_many<Result, MaxCount, AwaitableIter, AwaitableIter, false>
 spawn_many(AwaitableIter&& Begin, AwaitableIter&& End) {
   return aw_task_many<Result, MaxCount, AwaitableIter, AwaitableIter, false>(
@@ -115,7 +115,7 @@ spawn_many(AwaitableIter&& Begin, AwaitableIter&& End) {
 /// Submits items in range [Begin, min(Begin + MaxCount, End)) to the executor.
 template <
   typename AwaitableIter, typename Awaitable = std::iter_value_t<AwaitableIter>,
-  typename Result = tmc::detail::get_awaitable_traits<Awaitable>::result_type>
+  typename Result = tmc::detail::awaitable_result_t<Awaitable>>
 aw_task_many<Result, 0, AwaitableIter, AwaitableIter, false>
 spawn_many(AwaitableIter&& Begin, AwaitableIter&& End, size_t MaxCount) {
   return aw_task_many<Result, 0, AwaitableIter, AwaitableIter, false>(

--- a/include/tmc/spawn_many.hpp
+++ b/include/tmc/spawn_many.hpp
@@ -406,7 +406,10 @@ public:
       }
       if constexpr (requires(TaskIter a, TaskIter b) { a - b; }) {
         // Caller didn't specify capacity to preallocate, but we can calculate
-        size = std::min(size, static_cast<size_t>(End - Begin));
+        size_t iterSize = static_cast<size_t>(End - Begin);
+        if (iterSize < size) {
+          size = iterSize;
+        }
         if constexpr (!std::is_void_v<Result>) {
           result_arr.resize(size);
         }
@@ -435,7 +438,10 @@ public:
         // ASYNC_INITIATE types may possibly not be stored in a vector or
         // array (no default/copy constructor). Try to sidestep this by
         // initiating them individually.
-        size_t actualSize = std::min(size, static_cast<size_t>(End - Begin));
+        size_t actualSize = static_cast<size_t>(End - Begin);
+        if (size < actualSize) {
+          actualSize = size;
+        }
         set_done_count(actualSize);
         while (Begin != End && taskCount < actualSize) {
           auto t = std::move(*Begin);

--- a/include/tmc/spawn_task.hpp
+++ b/include/tmc/spawn_task.hpp
@@ -19,7 +19,7 @@ namespace tmc {
 /// `tmc::spawn()`.
 template <
   typename Awaitable,
-  typename Result = tmc::detail::get_awaitable_traits<Awaitable>::result_type>
+  typename Result = tmc::detail::awaitable_result_t<Awaitable>>
 class aw_spawned_task;
 
 /// A wrapper that converts lazy task(s) to eager task(s),
@@ -30,7 +30,7 @@ class aw_spawned_task;
 /// `Result` is the type of a single result value.
 template <
   typename Awaitable,
-  typename Result = tmc::detail::get_awaitable_traits<Awaitable>::result_type>
+  typename Result = tmc::detail::awaitable_result_t<Awaitable>>
 class [[nodiscard("You must co_await aw_run_early. "
                   "It is not safe to destroy aw_run_early without first "
                   "awaiting it.")]] aw_run_early_impl;
@@ -188,7 +188,7 @@ using aw_run_early =
 
 template <
   typename Awaitable,
-  typename Result = tmc::detail::get_awaitable_traits<Awaitable>::result_type>
+  typename Result = tmc::detail::awaitable_result_t<Awaitable>>
 class aw_spawned_task_impl;
 
 template <typename Awaitable, typename Result> class aw_spawned_task_impl {

--- a/include/tmc/spawn_tuple.hpp
+++ b/include/tmc/spawn_tuple.hpp
@@ -34,7 +34,7 @@ template <> struct last_type<> {
   using type = void;
 };
 
-template <typename... T> using last_type_t = last_type<T...>::type;
+template <typename... T> using last_type_t = typename last_type<T...>::type;
 
 // Create 2 instantiations of the Variadic, one where all of the types
 // satisfy the predicate, and one where none of the types satisfy the predicate.
@@ -528,11 +528,7 @@ public:
   /// Initiates the wrapped operations immediately. They cannot be awaited
   /// afterward. Precondition: Every wrapped operation must return void.
   void detach()
-    requires(
-      std::is_void_v<
-        typename tmc::detail::get_awaitable_traits<Awaitable>::result_type> &&
-      ...
-    )
+    requires(std::is_void_v<tmc::detail::awaitable_result_t<Awaitable>> && ...)
   {
     if constexpr (Count == 0) {
       return;

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -401,8 +401,7 @@ namespace detail {
 /// awaitable, we are restored to the original TMC executor and priority.
 template <
   typename Awaitable,
-  typename Result =
-    typename tmc::detail::get_awaitable_traits<Awaitable>::result_type>
+  typename Result = tmc::detail::awaitable_result_t<Awaitable>>
 [[nodiscard("You must await the return type of safe_wrap()"
 )]] tmc::wrapper_task<Result>
 safe_wrap(Awaitable&& awaitable) {
@@ -759,7 +758,7 @@ template <typename T> struct task_result_t_impl {
   using type = not_found;
 };
 template <HasTaskResult T> struct task_result_t_impl<T> {
-  using type = T::result_type;
+  using type = typename T::result_type;
 };
 template <typename T>
 using task_result_t = typename task_result_t_impl<T>::type;


### PR DESCRIPTION
Fix issues compiling on Windows with both clang-cl.exe and MSVC. Also fix many warnings.

Some of these fixes are due to clang/gcc accepting non-standard code (such as the typename before dependent type), and some of them are workarounds for MSVC misbehaving.

Removed uses of std::min() because they conflict with min() macro on windows and would require all users of this library to define NOMINMAX which doesn't seem acceptable.