### PR TITLE
Test support & misc cleanup

### DIFF
--- a/include/tmc/detail/ex_cpu.ipp
+++ b/include/tmc/detail/ex_cpu.ipp
@@ -234,6 +234,7 @@ bool ex_cpu::try_run_some(
 }
 
 void ex_cpu::post(work_item&& Item, size_t Priority) {
+  assert(Priority < PRIORITY_COUNT);
   work_queues[Priority].enqueue_ex_cpu(std::move(Item), Priority);
   notify_n(1, Priority);
 }

--- a/include/tmc/detail/ex_cpu.ipp
+++ b/include/tmc/detail/ex_cpu.ipp
@@ -235,7 +235,7 @@ bool ex_cpu::try_run_some(
 
 void ex_cpu::post(work_item&& Item, size_t Priority) {
   work_queues[Priority].enqueue_ex_cpu(std::move(Item), Priority);
-  notify_n(Priority, 1);
+  notify_n(1, Priority);
 }
 
 tmc::detail::type_erased_executor* ex_cpu::type_erased() {

--- a/include/tmc/detail/ex_cpu.ipp
+++ b/include/tmc/detail/ex_cpu.ipp
@@ -290,64 +290,19 @@ void ex_cpu::init() {
   hwloc_topology_init(&topology);
   hwloc_topology_load(topology);
   auto groupedCores = tmc::detail::group_cores_by_l3c(topology);
-  bool lasso = true;
-  size_t totalThreadCount = 0;
-  size_t coreCount = 0;
-  for (size_t i = 0; i < groupedCores.size(); ++i) {
-    coreCount += groupedCores[i].group_size;
-  }
-  if (init_params == nullptr || (init_params->thread_count == 0 &&
-                                 init_params->thread_occupancy >= -0.0001f &&
-                                 init_params->thread_occupancy <= 0.0001f)) {
-    totalThreadCount = coreCount;
-  } else {
-    if (init_params->thread_count != 0) {
-      float occupancy = static_cast<float>(init_params->thread_count) /
-                        static_cast<float>(coreCount);
-      totalThreadCount = init_params->thread_count;
-      if (occupancy <= 0.5f) {
-        // turn off thread-lasso capability and make everything one group
-        groupedCores.resize(1);
-        groupedCores[0].group_size = init_params->thread_count;
-        lasso = false;
-      } else if (coreCount > init_params->thread_count) {
-        // Evenly reduce the size of groups until we hit the desired thread
-        // count
-        size_t i = groupedCores.size() - 1;
-        while (coreCount > init_params->thread_count) {
-          --groupedCores[i].group_size;
-          --coreCount;
-          if (i == 0) {
-            i = groupedCores.size() - 1;
-          } else {
-            --i;
-          }
-        }
-      } else if (coreCount < init_params->thread_count) {
-        // Evenly increase the size of groups until we hit the desired thread
-        // count
-        size_t i = 0;
-        while (coreCount < init_params->thread_count) {
-          ++groupedCores[i].group_size;
-          ++coreCount;
-          ++i;
-          if (i == groupedCores.size()) {
-            i = 0;
-          }
-        }
-      }
-    } else { // init_params->thread_occupancy != 0
-      for (size_t i = 0; i < groupedCores.size(); ++i) {
-        size_t groupSize = static_cast<size_t>(
-          static_cast<float>(groupedCores[i].group_size) *
-          init_params->thread_occupancy
-        );
-        groupedCores[i].group_size = groupSize;
-        totalThreadCount += groupSize;
-      }
+  bool lasso;
+  tmc::detail::adjust_thread_groups(
+    init_params == nullptr ? 0 : init_params->thread_count,
+    init_params == nullptr ? 0.0f : init_params->thread_occupancy, groupedCores,
+    lasso
+  );
+  {
+    size_t totalThreadCount = 0;
+    for (size_t i = 0; i < groupedCores.size(); ++i) {
+      totalThreadCount += groupedCores[i].group_size;
     }
+    threads.resize(totalThreadCount);
   }
-  threads.resize(totalThreadCount);
 #endif
   assert(thread_count() != 0);
   // limited to 64 threads for now, due to use of uint64_t bitset
@@ -541,6 +496,8 @@ ex_cpu& ex_cpu::set_thread_occupancy(float ThreadOccupancy) {
 
 ex_cpu& ex_cpu::set_thread_count(size_t ThreadCount) {
   assert(!is_initialized);
+  // limited to 64 threads for now, due to use of uint64_t bitset
+  assert(ThreadCount <= 64);
   if (init_params == nullptr) {
     init_params = new InitParams;
   }

--- a/include/tmc/detail/mixins.hpp
+++ b/include/tmc/detail/mixins.hpp
@@ -123,27 +123,7 @@ class rvalue_only_awaitable : private Base, private AwaitTagNoGroupCoAwait {
   using Base::Base;
 
 public:
-#if defined(__clang__) || defined(_MSC_VER)
   Base&& operator co_await() && { return static_cast<Base&&>(*this); }
-#else
-  // GCC isn't able to simply cast the awaitable to the awaiter in-place - it
-  // requires to construct a value of the awaiter type... which is our
-  // non-movable Base. This is a workaround.
-  struct BaseWrapper {
-    Base& base;
-    BaseWrapper(Base& Wrapped) : base(Wrapped) {}
-
-    inline bool await_ready() const noexcept { return base.await_ready(); }
-
-    TMC_FORCE_INLINE inline auto await_suspend(std::coroutine_handle<> Outer
-    ) noexcept {
-      return base.await_suspend(Outer);
-    }
-
-    inline auto await_resume() noexcept { return base.await_resume(); }
-  };
-  BaseWrapper operator co_await() && { return {static_cast<Base&>(*this)}; }
-#endif
 };
 
 } // namespace detail

--- a/include/tmc/detail/thread_layout.hpp
+++ b/include/tmc/detail/thread_layout.hpp
@@ -23,6 +23,14 @@ struct L3CacheSet {
 // https://utcc.utoronto.ca/~cks/space/blog/linux/IntelHyperthreadingSurprise
 std::vector<L3CacheSet> group_cores_by_l3c(hwloc_topology_t& Topology);
 
+// Modifies GroupedCores according to the number of found cores and requested
+// values. Also modifies Lasso to determine whether thread lassoing should be
+// enabled.
+void adjust_thread_groups(
+  size_t RequestedThreadCount, size_t RequestedOccupancy,
+  std::vector<L3CacheSet>& GroupedCores, bool& Lasso
+);
+
 // bind this thread to any of the cores that share l3 cache in this set
 void bind_thread(hwloc_topology_t Topology, hwloc_cpuset_t SharedCores);
 #endif

--- a/include/tmc/detail/thread_locals.hpp
+++ b/include/tmc/detail/thread_locals.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <atomic>
+#include <cassert>
 #include <coroutine>
 #include <limits>
 
@@ -107,6 +108,10 @@ inline void post_checked(
   if (executor == nullptr) {
     executor = g_ex_default.load(std::memory_order_acquire);
   }
+  assert(
+    executor != nullptr && "either submit work from a TMC thread or call "
+                           "set_default_executor() beforehand"
+  );
   executor->post(std::move(Item), Priority);
 }
 inline void post_bulk_checked(
@@ -119,6 +124,10 @@ inline void post_bulk_checked(
   if (executor == nullptr) {
     executor = g_ex_default.load(std::memory_order_acquire);
   }
+  assert(
+    executor != nullptr && "either submit work from a TMC thread or call "
+                           "set_default_executor() beforehand"
+  );
   executor->post_bulk(Items, Count, Priority);
 }
 

--- a/include/tmc/ex_cpu.hpp
+++ b/include/tmc/ex_cpu.hpp
@@ -169,6 +169,7 @@ public:
   /// `tmc::post_bulk()` free function template.
   template <typename It>
   void post_bulk(It&& Items, size_t Count, size_t Priority) {
+    assert(Priority < PRIORITY_COUNT);
     work_queues[Priority].enqueue_bulk_ex_cpu(
       std::forward<It>(Items), Count, Priority
     );

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -276,7 +276,7 @@ template <typename Result> struct task {
 
   /// When this task is destroyed, it should already have been deinitialized.
   /// Either because it was moved-from, or because the coroutine completed.
-  ~task() { assert(!handle); }
+  ~task() { assert(!handle && "you forgot to co_await this task"); }
 #endif
 
   /// Conversion to a std::coroutine_handle<> is move-only


### PR DESCRIPTION
Add some asserts to support the test PR: https://github.com/tzcnt/tmc-examples/pull/15. Refactor the thread layout code. Remove the rvalue_only_awaitable workaround that was previously in place for GCC (version 12). Now GCC 14 is the required version, this workaround is no longer necessary.

The requirement increased from GCC 12 to GCC 14 for incompatibility with a different feature (each()) which fails on GCC 12.