### PR TITLE
Fix sized deleters to support Clang 19

### DIFF
--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -481,6 +481,10 @@ template <typename Result> struct task_promise {
     return ::operator new(n, al);
   }
 
+  static void operator delete(void* ptr, std::size_t n) noexcept {
+    return ::operator delete(ptr, (n + 63) & -64);
+  }
+
 #ifndef __clang__
   // GCC creates a TON of warnings if this is missing with the noexcept new
   static task<Result> get_return_object_on_allocation_failure() { return {}; }

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -475,14 +475,9 @@ template <typename Result> struct task_promise {
     return ::operator new(n);
   }
 
-  static void* operator new(std::size_t n, std::align_val_t al) noexcept {
-    // Don't try to round up the allocation size if there is also a required
-    // alignment. If we end up with size > alignment, that could cause issues.
-    return ::operator new(n, al);
-  }
-
   static void operator delete(void* ptr, std::size_t n) noexcept {
-    return ::operator delete(ptr, (n + 63) & -64);
+    n = (n + 63) & -64;
+    return ::operator delete(ptr, n);
   }
 
 #ifndef __clang__
@@ -546,36 +541,6 @@ template <typename Result> struct wrapper_task_promise {
   template <typename RV> void return_value(RV&& Value) {
     *customizer.result_ptr = static_cast<RV&&>(Value);
   }
-
-#ifdef TMC_CUSTOM_CORO_ALLOC
-  // Round up the coroutine allocation to next 64 bytes.
-  // This reduces false sharing with adjacent coroutines.
-  static void* operator new(std::size_t n) noexcept {
-    // This operator new is noexcept. This means that if the allocation
-    // throws, std::terminate will be called.
-    // I recommend using tcmalloc with TooManyCooks, as it will also directly
-    // crash the program rather than throwing an exception:
-    // https://github.com/google/tcmalloc/blob/master/docs/reference.md#operator-new--operator-new
-
-    // DEBUG - Print the size of the coroutine allocation.
-    // std::printf("task_promise new %zu -> %zu\n", n, (n + 63) & -64);
-    n = (n + 63) & -64;
-    return ::operator new(n);
-  }
-
-  static void* operator new(std::size_t n, std::align_val_t al) noexcept {
-    // Don't try to round up the allocation size if there is also a required
-    // alignment. If we end up with size > alignment, that could cause issues.
-    return ::operator new(n, al);
-  }
-
-#ifndef __clang__
-  // GCC creates a TON of warnings if this is missing with the noexcept new
-  static wrapper_task<Result> get_return_object_on_allocation_failure() {
-    return {};
-  }
-#endif
-#endif
 };
 
 template <> struct wrapper_task_promise<void> {

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -480,6 +480,18 @@ template <typename Result> struct task_promise {
     return ::operator delete(ptr, n);
   }
 
+  // Aligned new/delete is necessary to support -fcoro-aligned-allocation
+  static void* operator new(std::size_t n, std::align_val_t al) noexcept {
+    n = (n + 63) & -64;
+    return ::operator new(n, al);
+  }
+
+  static void
+  operator delete(void* ptr, std::size_t n, std::align_val_t al) noexcept {
+    n = (n + 63) & -64;
+    return ::operator delete(ptr, n, al);
+  }
+
 #ifndef __clang__
   // GCC creates a TON of warnings if this is missing with the noexcept new
   static task<Result> get_return_object_on_allocation_failure() { return {}; }


### PR DESCRIPTION
This PR adds a sized deleter to tmc::task when using TMC_CUSTOM_CORO_ALLOC to enable compatibility with Clang 19, which now enables sized deallocation by default.

Also fill out the sized aligned new/delete which is required to enable `-fcoro-aligned-allocation` on Clang.

Also removed the custom new operator from wrapper_task_promise which doesn't need it for its purposes.

I had not done this in the past because GCC 12 did not support this. For a while I was able to use Clang 18 with the GCC 12 libstdc++, but that is no longer supported with this change; it cannot handle the sized + aligned deleter. So a full upgrade to GCC 14 was necessary.
