### PR TITLE
bugfixes

### DIFF
--- a/include/tmc/detail/qu_lockfree.hpp
+++ b/include/tmc/detail/qu_lockfree.hpp
@@ -1606,14 +1606,11 @@ public:
   bool empty() const {
     // TODO make a producer thread version of this that uses this thread's
     // static iteration order
-    if (dequeueProducerCount != 0) {
-      auto static_producer_count = dequeueProducerCount - 1;
-      ExplicitProducer* producers = staticProducers;
-      for (size_t pidx = 0; pidx < static_producer_count; ++pidx) {
-        ExplicitProducer& prod = producers[pidx];
-        if (prod.size() != 0) {
-          return false;
-        }
+    auto static_producer_count = static_cast<int64_t>(dequeueProducerCount) - 1;
+    for (int64_t pidx = 0; pidx < static_producer_count; ++pidx) {
+      ExplicitProducer& prod = staticProducers[pidx];
+      if (prod.size() != 0) {
+        return false;
       }
     }
 

--- a/include/tmc/detail/qu_lockfree.hpp
+++ b/include/tmc/detail/qu_lockfree.hpp
@@ -1606,17 +1606,17 @@ public:
   bool empty() const {
     // TODO make a producer thread version of this that uses this thread's
     // static iteration order
-    auto static_producer_count = dequeueProducerCount - 1;
-    ExplicitProducer* producers = staticProducers;
-    if (dequeueProducerCount == 0) {
-      return true;
-    }
-    for (size_t pidx = 0; pidx < static_producer_count; ++pidx) {
-      ExplicitProducer& prod = producers[pidx];
-      if (prod.size() != 0) {
-        return false;
+    if (dequeueProducerCount != 0) {
+      auto static_producer_count = dequeueProducerCount - 1;
+      ExplicitProducer* producers = staticProducers;
+      for (size_t pidx = 0; pidx < static_producer_count; ++pidx) {
+        ExplicitProducer& prod = producers[pidx];
+        if (prod.size() != 0) {
+          return false;
+        }
       }
     }
+
     for (auto ptr = producerListTail.load(std::memory_order_seq_cst);
          ptr != nullptr; ptr = ptr->next_prod()) {
       if (ptr->size() != 0) {

--- a/include/tmc/detail/thread_locals.hpp
+++ b/include/tmc/detail/thread_locals.hpp
@@ -10,6 +10,31 @@
 #include <coroutine>
 #include <limits>
 
+#if defined(_MSC_VER)
+
+#ifdef __has_cpp_attribute
+
+#if __has_cpp_attribute(msvc::forceinline)
+#define TMC_FORCE_INLINE [[msvc::forceinline]]
+#else
+#define TMC_FORCE_INLINE
+#endif
+
+#if __has_cpp_attribute(msvc::no_unique_address)
+#define TMC_NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
+#else
+#define TMC_NO_UNIQUE_ADDRESS
+#endif
+
+#else // not __has_cpp_attribute
+#define TMC_FORCE_INLINE [[msvc::forceinline]]
+#define TMC_NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
+#endif
+#else // not _MSC_VER
+#define TMC_FORCE_INLINE __attribute__((always_inline))
+#define TMC_NO_UNIQUE_ADDRESS [[no_unique_address]]
+#endif
+
 // Macro hackery to enable defines TMC_WORK_ITEM=CORO / TMC_WORK_ITEM=FUNC, etc
 #define TMC_WORK_ITEM_CORO 0 // coro will be the default if undefined
 #define TMC_WORK_ITEM_FUNC 1
@@ -43,6 +68,16 @@ using work_item = tmc::coro_functor;
 
 namespace tmc {
 namespace detail {
+
+TMC_FORCE_INLINE inline void memory_barrier() {
+#if defined(__x86_64__) || defined(_M_AMD64) || defined(__i386__)
+  std::atomic<size_t> locker;
+  locker.fetch_add(0, std::memory_order_seq_cst);
+#else
+  std::atomic_thread_fence(std::memory_order_seq_cst);
+#endif
+}
+
 class type_erased_executor;
 
 // The default executor that is used by post_checked / post_bulk_checked
@@ -133,28 +168,3 @@ inline void post_bulk_checked(
 
 } // namespace detail
 } // namespace tmc
-
-#if defined(_MSC_VER)
-
-#ifdef __has_cpp_attribute
-
-#if __has_cpp_attribute(msvc::forceinline)
-#define TMC_FORCE_INLINE [[msvc::forceinline]]
-#else
-#define TMC_FORCE_INLINE
-#endif
-
-#if __has_cpp_attribute(msvc::no_unique_address)
-#define TMC_NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
-#else
-#define TMC_NO_UNIQUE_ADDRESS
-#endif
-
-#else // not __has_cpp_attribute
-#define TMC_FORCE_INLINE [[msvc::forceinline]]
-#define TMC_NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
-#endif
-#else // not _MSC_VER
-#define TMC_FORCE_INLINE __attribute__((always_inline))
-#define TMC_NO_UNIQUE_ADDRESS [[no_unique_address]]
-#endif

--- a/include/tmc/spawn_many.hpp
+++ b/include/tmc/spawn_many.hpp
@@ -1139,8 +1139,11 @@ template <
 struct awaitable_traits<
   aw_task_many<Result, Count, IterBegin, IterEnd, IsFunc>> {
   static constexpr configure_mode mode = WRAPPER;
-
-  using result_type = Result;
+  using result_type = std::conditional_t<
+    std::is_void_v<Result>, void,
+    std::conditional_t<
+      Count == 0, std::vector<tmc::detail::result_storage_t<Result>>,
+      std::array<tmc::detail::result_storage_t<Result>, Count>>>;
   using self_type = aw_task_many<Result, Count, IterBegin, IterEnd, IsFunc>;
   using awaiter_type = aw_task_many_impl<Result, Count, false, IsFunc>;
 

--- a/include/tmc/spawn_many.hpp
+++ b/include/tmc/spawn_many.hpp
@@ -827,6 +827,13 @@ public:
     }
   }
 #endif
+
+  // Not movable or copyable due to awaitables being initiated in constructor,
+  // and having pointers to this.
+  aw_task_many_impl& operator=(const aw_task_many_impl& other) = delete;
+  aw_task_many_impl(const aw_task_many_impl& other) = delete;
+  aw_task_many_impl& operator=(const aw_task_many_impl&& other) = delete;
+  aw_task_many_impl(const aw_task_many_impl&& other) = delete;
 };
 
 template <typename Result, size_t Count, bool IsFunc>

--- a/include/tmc/spawn_task.hpp
+++ b/include/tmc/spawn_task.hpp
@@ -362,15 +362,16 @@ public:
 
 namespace detail {
 
-template <typename Result> struct awaitable_traits<aw_spawned_task<Result>> {
+template <typename Awaitable, typename Result>
+struct awaitable_traits<aw_spawned_task<Awaitable, Result>> {
   static constexpr configure_mode mode = WRAPPER;
 
   using result_type = Result;
-  using self_type = aw_spawned_task<Result>;
-  using awaiter_type = aw_spawned_task_impl<Result>;
+  using self_type = aw_spawned_task<Awaitable, Result>;
+  using awaiter_type = aw_spawned_task_impl<Awaitable, Result>;
 
-  static awaiter_type get_awaiter(self_type&& Awaitable) {
-    return std::forward<self_type>(Awaitable).operator co_await();
+  static awaiter_type get_awaiter(self_type&& awaitable) {
+    return std::forward<self_type>(awaitable).operator co_await();
   }
 };
 

--- a/include/tmc/spawn_tuple.hpp
+++ b/include/tmc/spawn_tuple.hpp
@@ -426,6 +426,15 @@ public:
     }
   }
 #endif
+
+  // Not movable or copyable due to awaitables being initiated in constructor,
+  // and having pointers to this.
+  aw_spawned_task_tuple_impl& operator=(const aw_spawned_task_tuple_impl& other
+  ) = delete;
+  aw_spawned_task_tuple_impl(const aw_spawned_task_tuple_impl& other) = delete;
+  aw_spawned_task_tuple_impl& operator=(const aw_spawned_task_tuple_impl&& other
+  ) = delete;
+  aw_spawned_task_tuple_impl(const aw_spawned_task_tuple_impl&& other) = delete;
 };
 
 template <typename... Result>

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -440,6 +440,11 @@ template <typename Result> struct task_promise {
 
   template <typename Awaitable>
   decltype(auto) await_transform(Awaitable&& awaitable) {
+#ifdef TMC_TESTING
+    return tmc::detail::get_awaitable_traits<Awaitable>::get_awaiter(
+      std::forward<Awaitable>(awaitable)
+    );
+#else
     if constexpr (requires {
                     // Check whether any function with this name exists
                     &tmc::detail::get_awaitable_traits<Awaitable>::get_awaiter;
@@ -457,6 +462,7 @@ template <typename Result> struct task_promise {
       // specialize tmc::detail::awaitable_traits for it yourself.
       return tmc::detail::safe_wrap(std::forward<Awaitable>(awaitable));
     }
+#endif
   }
 
 #ifdef TMC_CUSTOM_CORO_ALLOC
@@ -516,6 +522,11 @@ template <> struct task_promise<void> {
 
   template <typename Awaitable>
   decltype(auto) await_transform(Awaitable&& awaitable) {
+#ifdef TMC_TESTING
+    return tmc::detail::get_awaitable_traits<Awaitable>::get_awaiter(
+      std::forward<Awaitable>(awaitable)
+    );
+#else
     if constexpr (requires {
                     // Check whether any function with this name exists
                     &tmc::detail::get_awaitable_traits<Awaitable>::get_awaiter;
@@ -533,6 +544,7 @@ template <> struct task_promise<void> {
       // specialize tmc::detail::awaitable_traits for it yourself.
       return tmc::detail::safe_wrap(std::forward<Awaitable>(awaitable));
     }
+#endif
   }
 };
 

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -440,7 +440,7 @@ template <typename Result> struct task_promise {
 
   template <typename Awaitable>
   decltype(auto) await_transform(Awaitable&& awaitable) {
-#ifdef TMC_TESTING
+#ifdef TMC_NO_UNKNOWN_AWAITABLES
     return tmc::detail::get_awaitable_traits<Awaitable>::get_awaiter(
       std::forward<Awaitable>(awaitable)
     );
@@ -522,7 +522,7 @@ template <> struct task_promise<void> {
 
   template <typename Awaitable>
   decltype(auto) await_transform(Awaitable&& awaitable) {
-#ifdef TMC_TESTING
+#ifdef TMC_NO_UNKNOWN_AWAITABLES
     return tmc::detail::get_awaitable_traits<Awaitable>::get_awaiter(
       std::forward<Awaitable>(awaitable)
     );


### PR DESCRIPTION
Detected during automated test development:
- qu_lockfree empty() function would skip implicit producer checks. This would only cause extra sleep/wake cycles of threads.
- A race condition between submitting work to ex_braid and the runloop finding that task, when running the check to skip submitting a runloop task to the parent executor. A memory barrier is needed in both places.
- As part of the prior fix, all task submission functions to ex_braid call post_runloop_task() which also now includes the check for the braid being the current executor. This will reduce overhead in situations where a task running on a braid is spawn()ing work - now it can skip the creation of the runloop task.
- spawn_many() and spawn() awaitables had incorrectly defined result types when composed inside of other spawn() functions. This did not affect regular direct awaits from coroutines.
- The copy and move constructors of the spawn_many() and spawn_tuple() _impl types (those returned by .run_early()) are now deleted, as these types must remain pinned in memory until they are awaited.

------------

Added TMC_NO_UNKNOWN_AWAITABLES compile option. When defined, tmc::detail::get_awaitable_traits<Awaitable>::get_awaiter must be defined for all awaitables. This is primarily for testing that all TMC awaitable traits are able to be resolved, but it may be useful for others development (to do the same check).