### PR TITLE
Implement spawn_func().run_early() / GH Actions branches improvement

### DIFF
--- a/.github/workflows/arm64-macos-clang.yml
+++ b/.github/workflows/arm64-macos-clang.yml
@@ -8,17 +8,33 @@ on:
 
 env:
   PRESET: clang-macos-debug
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
 jobs:
-  build:
+  build-and-test:
     runs-on: macos-15
     steps:
     - uses: actions/checkout@v4
       with:
         repository: tzcnt/tmc-examples
         ref: main
+    - name: branch-examples
+      continue-on-error: true
+      run: git checkout ${{env.BRANCH_NAME}}
+    - name: submodule-clone
+      run: >
+        cd submodules
+        && git clone https://github.com/tzcnt/TooManyCooks.git
+        && git clone https://github.com/tzcnt/tmc-asio.git
+    # If a branch with the same name exists in the dependency repos, use that. Otherwise, use main.
+    - name: submodule-branch-TMC
+      # continue-on-error: true # this should never fail if triggered from TMC workflow
+      run: cd submodules/TooManyCooks && git checkout ${{env.BRANCH_NAME}}
+    - name: submodule-branch-tmc-asio
+      continue-on-error: true
+      run: cd submodules/tmc-asio && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" --preset ${{env.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON --preset ${{env.PRESET}} .
     - name: build
       run: cmake --build ./build/${{env.PRESET}} --parallel $(sysctl -n hw.logicalcpu) --target all
     - name: run tests

--- a/.github/workflows/x64-linux-clang.yml
+++ b/.github/workflows/x64-linux-clang.yml
@@ -8,17 +8,33 @@ on:
 
 env:
   PRESET: clang-linux-debug
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
 jobs:
-  build:
+  build-and-test:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
       with:
         repository: tzcnt/tmc-examples
         ref: main
+    - name: branch-examples
+      continue-on-error: true
+      run: git checkout ${{env.BRANCH_NAME}}
+    - name: submodule-clone
+      run: >
+        cd submodules
+        && git clone https://github.com/tzcnt/TooManyCooks.git
+        && git clone https://github.com/tzcnt/tmc-asio.git
+    # If a branch with the same name exists in the dependency repos, use that. Otherwise, use main.
+    - name: submodule-branch-TMC
+      # continue-on-error: true # this should never fail if triggered from TMC workflow
+      run: cd submodules/TooManyCooks && git checkout ${{env.BRANCH_NAME}}
+    - name: submodule-branch-tmc-asio
+      continue-on-error: true
+      run: cd submodules/tmc-asio && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" --preset ${{env.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON --preset ${{env.PRESET}} .
     - name: build
       run: cmake --build ./build/${{env.PRESET}} --parallel $(nproc) --target all
     - name: run tests

--- a/.github/workflows/x64-linux-gcc.yml
+++ b/.github/workflows/x64-linux-gcc.yml
@@ -8,17 +8,33 @@ on:
 
 env:
   PRESET: gcc-linux-debug
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
 jobs:
-  build:
+  build-and-test:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
       with:
         repository: tzcnt/tmc-examples
         ref: main
+    - name: branch-examples
+      continue-on-error: true
+      run: git checkout ${{env.BRANCH_NAME}}
+    - name: submodule-clone
+      run: >
+        cd submodules
+        && git clone https://github.com/tzcnt/TooManyCooks.git
+        && git clone https://github.com/tzcnt/tmc-asio.git
+    # If a branch with the same name exists in the dependency repos, use that. Otherwise, use main.
+    - name: submodule-branch-TMC
+      # continue-on-error: true # this should never fail if triggered from TMC workflow
+      run: cd submodules/TooManyCooks && git checkout ${{env.BRANCH_NAME}}
+    - name: submodule-branch-tmc-asio
+      continue-on-error: true
+      run: cd submodules/tmc-asio && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" --preset ${{env.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON --preset ${{env.PRESET}} .
     - name: build
       run: cmake --build ./build/${{env.PRESET}} --parallel $(nproc) --target all
     - name: run tests

--- a/.github/workflows/x64-windows-clang-cl.yml
+++ b/.github/workflows/x64-windows-clang-cl.yml
@@ -8,18 +8,34 @@ on:
 
 env:
   PRESET: clang-win-debug
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
 jobs:
-  build:
+  build-and-test:
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
       with:
         repository: tzcnt/tmc-examples
         ref: main
+    - name: branch-examples
+      continue-on-error: true
+      run: git checkout ${{env.BRANCH_NAME}}
+    - name: submodule-clone
+      run: >
+        cd submodules
+        && git clone https://github.com/tzcnt/TooManyCooks.git
+        && git clone https://github.com/tzcnt/tmc-asio.git
+    # If a branch with the same name exists in the dependency repos, use that. Otherwise, use main.
+    - name: submodule-branch-TMC
+      # continue-on-error: true # this should never fail if triggered from TMC workflow
+      run: cd submodules/TooManyCooks && git checkout ${{env.BRANCH_NAME}}
+    - name: submodule-branch-tmc-asio
+      continue-on-error: true
+      run: cd submodules/tmc-asio && git checkout ${{env.BRANCH_NAME}}
     - uses: ilammy/msvc-dev-cmd@v1
     - name: configure
-      run: cmake -G "Ninja" --preset ${{env.PRESET}} .
+      run: cmake -G "Ninja" -DTMC_AS_SUBMODULE=ON --preset ${{env.PRESET}} .
     - name: build
       run: cmake --build ./build/${{env.PRESET}} --target all
     - name: run tests

--- a/include/tmc/spawn_task.hpp
+++ b/include/tmc/spawn_task.hpp
@@ -68,8 +68,6 @@ public:
   /// executor, and waits for it to complete.
   TMC_FORCE_INLINE inline bool await_suspend(std::coroutine_handle<> Outer
   ) noexcept {
-    // For unknown reasons, it doesn't work to start with done_count at 0,
-    // Then increment here and check before storing continuation...
     continuation = Outer;
     auto remaining = done_count.fetch_sub(1, std::memory_order_acq_rel);
     // Worker was already posted.
@@ -143,8 +141,6 @@ public:
   /// executor, and waits for it to complete.
   TMC_FORCE_INLINE inline bool await_suspend(std::coroutine_handle<> Outer
   ) noexcept {
-    // For unknown reasons, it doesn't work to start with done_count at 0,
-    // Then increment here and check before storing continuation...
     continuation = Outer;
     auto remaining = done_count.fetch_sub(1, std::memory_order_acq_rel);
     // Worker was already posted.


### PR DESCRIPTION
Implement the missing customizer run_early() for spawn_func()

Update GH Actions workflow to use the same branch name from other TMC repos when building tests. This allows concurrent development across repos. If the named branch does not exist, main will be used instead.