### PR TITLE
bugfixes & queue improvements

### DIFF
--- a/.github/workflows/arm64-macos-clang.yml
+++ b/.github/workflows/arm64-macos-clang.yml
@@ -7,12 +7,15 @@ on:
     branches: [ main ]
 
 env:
-  PRESET: clang-macos-debug
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
 jobs:
   build-and-test:
     runs-on: macos-15
+    strategy:
+      matrix:
+        PRESET: [clang-macos-debug, clang-macos-release]
+        WORK_ITEM: [CORO, FUNCORO]
     steps:
     - uses: actions/checkout@v4
       with:
@@ -34,8 +37,8 @@ jobs:
       continue-on-error: true
       run: cd submodules/tmc-asio && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON --preset ${{env.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} --preset ${{matrix.PRESET}} .
     - name: build
-      run: cmake --build ./build/${{env.PRESET}} --parallel $(sysctl -n hw.logicalcpu) --target all
+      run: cmake --build ./build/${{matrix.PRESET}} --parallel $(sysctl -n hw.logicalcpu) --target all
     - name: run tests
-      run: ./build/${{env.PRESET}}/tests/tests
+      run: ./build/${{matrix.PRESET}}/tests/tests

--- a/.github/workflows/arm64-macos-clang.yml
+++ b/.github/workflows/arm64-macos-clang.yml
@@ -37,7 +37,7 @@ jobs:
       continue-on-error: true
       run: cd submodules/tmc-asio && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DCMD_FLAGS='-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}}' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(sysctl -n hw.logicalcpu) --target all
     - name: run tests

--- a/.github/workflows/arm64-macos-clang.yml
+++ b/.github/workflows/arm64-macos-clang.yml
@@ -23,7 +23,7 @@ jobs:
         ref: main
     - name: branch-examples
       continue-on-error: true
-      run: git checkout ${{env.BRANCH_NAME}}
+      run: git fetch && git checkout -b ${{env.BRANCH_NAME}} origin/${{env.BRANCH_NAME}}
     - name: submodule-clone
       run: >
         cd submodules
@@ -32,10 +32,10 @@ jobs:
     # If a branch with the same name exists in the dependency repos, use that. Otherwise, use main.
     - name: submodule-branch-TMC
       # continue-on-error: true # this should never fail if triggered from TMC workflow
-      run: cd submodules/TooManyCooks && git checkout ${{env.BRANCH_NAME}}
+      run: cd submodules/TooManyCooks && git fetch && git checkout -b ${{env.BRANCH_NAME}} origin/${{env.BRANCH_NAME}}
     - name: submodule-branch-tmc-asio
       continue-on-error: true
-      run: cd submodules/tmc-asio && git checkout ${{env.BRANCH_NAME}}
+      run: cd submodules/tmc-asio && git fetch && git checkout -b ${{env.BRANCH_NAME}} origin/${{env.BRANCH_NAME}}
     - name: configure
       run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DCMD_FLAGS='-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}}' --preset ${{matrix.PRESET}} .
     - name: build

--- a/.github/workflows/x64-linux-clang.yml
+++ b/.github/workflows/x64-linux-clang.yml
@@ -7,12 +7,15 @@ on:
     branches: [ main ]
 
 env:
-  PRESET: clang-linux-debug
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        PRESET: [clang-linux-debug, clang-linux-release]
+        WORK_ITEM: [CORO, FUNCORO]
     steps:
     - uses: actions/checkout@v4
       with:
@@ -34,8 +37,8 @@ jobs:
       continue-on-error: true
       run: cd submodules/tmc-asio && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON --preset ${{env.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} --preset ${{matrix.PRESET}} .
     - name: build
-      run: cmake --build ./build/${{env.PRESET}} --parallel $(nproc) --target all
+      run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests
-      run: ./build/${{env.PRESET}}/tests/tests
+      run: ./build/${{matrix.PRESET}}/tests/tests

--- a/.github/workflows/x64-linux-clang.yml
+++ b/.github/workflows/x64-linux-clang.yml
@@ -37,7 +37,7 @@ jobs:
       continue-on-error: true
       run: cd submodules/tmc-asio && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DCMD_FLAGS='-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}}' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests

--- a/.github/workflows/x64-linux-clang.yml
+++ b/.github/workflows/x64-linux-clang.yml
@@ -23,7 +23,7 @@ jobs:
         ref: main
     - name: branch-examples
       continue-on-error: true
-      run: git checkout ${{env.BRANCH_NAME}}
+      run: git fetch && git checkout -b ${{env.BRANCH_NAME}} origin/${{env.BRANCH_NAME}}
     - name: submodule-clone
       run: >
         cd submodules
@@ -32,10 +32,10 @@ jobs:
     # If a branch with the same name exists in the dependency repos, use that. Otherwise, use main.
     - name: submodule-branch-TMC
       # continue-on-error: true # this should never fail if triggered from TMC workflow
-      run: cd submodules/TooManyCooks && git checkout ${{env.BRANCH_NAME}}
+      run: cd submodules/TooManyCooks && git fetch && git checkout -b ${{env.BRANCH_NAME}} origin/${{env.BRANCH_NAME}}
     - name: submodule-branch-tmc-asio
       continue-on-error: true
-      run: cd submodules/tmc-asio && git checkout ${{env.BRANCH_NAME}}
+      run: cd submodules/tmc-asio && git fetch && git checkout -b ${{env.BRANCH_NAME}} origin/${{env.BRANCH_NAME}}
     - name: configure
       run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DCMD_FLAGS='-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}}' --preset ${{matrix.PRESET}} .
     - name: build

--- a/.github/workflows/x64-linux-gcc.yml
+++ b/.github/workflows/x64-linux-gcc.yml
@@ -7,12 +7,15 @@ on:
     branches: [ main ]
 
 env:
-  PRESET: gcc-linux-debug
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        PRESET: [gcc-linux-debug, gcc-linux-release]
+        WORK_ITEM: [CORO, FUNCORO]
     steps:
     - uses: actions/checkout@v4
       with:
@@ -34,8 +37,8 @@ jobs:
       continue-on-error: true
       run: cd submodules/tmc-asio && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON --preset ${{env.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} --preset ${{matrix.PRESET}} .
     - name: build
-      run: cmake --build ./build/${{env.PRESET}} --parallel $(nproc) --target all
+      run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests
-      run: ./build/${{env.PRESET}}/tests/tests
+      run: ./build/${{matrix.PRESET}}/tests/tests

--- a/.github/workflows/x64-linux-gcc.yml
+++ b/.github/workflows/x64-linux-gcc.yml
@@ -37,7 +37,7 @@ jobs:
       continue-on-error: true
       run: cd submodules/tmc-asio && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DCMD_FLAGS='-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}}' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests

--- a/.github/workflows/x64-linux-gcc.yml
+++ b/.github/workflows/x64-linux-gcc.yml
@@ -23,7 +23,7 @@ jobs:
         ref: main
     - name: branch-examples
       continue-on-error: true
-      run: git checkout ${{env.BRANCH_NAME}}
+      run: git fetch && git checkout -b ${{env.BRANCH_NAME}} origin/${{env.BRANCH_NAME}}
     - name: submodule-clone
       run: >
         cd submodules
@@ -32,10 +32,10 @@ jobs:
     # If a branch with the same name exists in the dependency repos, use that. Otherwise, use main.
     - name: submodule-branch-TMC
       # continue-on-error: true # this should never fail if triggered from TMC workflow
-      run: cd submodules/TooManyCooks && git checkout ${{env.BRANCH_NAME}}
+      run: cd submodules/TooManyCooks && git fetch && git checkout -b ${{env.BRANCH_NAME}} origin/${{env.BRANCH_NAME}}
     - name: submodule-branch-tmc-asio
       continue-on-error: true
-      run: cd submodules/tmc-asio && git checkout ${{env.BRANCH_NAME}}
+      run: cd submodules/tmc-asio && git fetch && git checkout -b ${{env.BRANCH_NAME}} origin/${{env.BRANCH_NAME}}
     - name: configure
       run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DCMD_FLAGS='-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}}' --preset ${{matrix.PRESET}} .
     - name: build

--- a/.github/workflows/x64-windows-clang-cl.yml
+++ b/.github/workflows/x64-windows-clang-cl.yml
@@ -7,12 +7,15 @@ on:
     branches: [ main ]
 
 env:
-  PRESET: clang-win-debug
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
 jobs:
   build-and-test:
     runs-on: windows-latest
+    strategy:
+      matrix:
+        PRESET: [clang-win-debug, clang-win-release]
+        WORK_ITEM: [CORO, FUNCORO]
     steps:
     - uses: actions/checkout@v4
       with:
@@ -35,8 +38,8 @@ jobs:
       run: cd submodules/tmc-asio && git checkout ${{env.BRANCH_NAME}}
     - uses: ilammy/msvc-dev-cmd@v1
     - name: configure
-      run: cmake -G "Ninja" -DTMC_AS_SUBMODULE=ON --preset ${{env.PRESET}} .
+      run: cmake -G "Ninja" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} --preset ${{matrix.PRESET}} .
     - name: build
-      run: cmake --build ./build/${{env.PRESET}} --target all
+      run: cmake --build ./build/${{matrix.PRESET}} --target all
     - name: run tests
-      run: ./build/${{env.PRESET}}/tests/tests.exe
+      run: ./build/${{matrix.PRESET}}/tests/tests.exe

--- a/.github/workflows/x64-windows-clang-cl.yml
+++ b/.github/workflows/x64-windows-clang-cl.yml
@@ -23,7 +23,7 @@ jobs:
         ref: main
     - name: branch-examples
       continue-on-error: true
-      run: git checkout ${{env.BRANCH_NAME}}
+      run: git fetch && git checkout -b ${{env.BRANCH_NAME}} origin/${{env.BRANCH_NAME}}
     - name: submodule-clone
       run: >
         cd submodules
@@ -32,10 +32,10 @@ jobs:
     # If a branch with the same name exists in the dependency repos, use that. Otherwise, use main.
     - name: submodule-branch-TMC
       # continue-on-error: true # this should never fail if triggered from TMC workflow
-      run: cd submodules/TooManyCooks && git checkout ${{env.BRANCH_NAME}}
+      run: cd submodules/TooManyCooks && git fetch && git checkout -b ${{env.BRANCH_NAME}} origin/${{env.BRANCH_NAME}}
     - name: submodule-branch-tmc-asio
       continue-on-error: true
-      run: cd submodules/tmc-asio && git checkout ${{env.BRANCH_NAME}}
+      run: cd submodules/tmc-asio && git fetch && git checkout -b ${{env.BRANCH_NAME}} origin/${{env.BRANCH_NAME}}
     - uses: ilammy/msvc-dev-cmd@v1
     - name: configure
       run: cmake -G "Ninja" -DTMC_AS_SUBMODULE=ON -DCMD_FLAGS='-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}}' --preset ${{matrix.PRESET}} .

--- a/.github/workflows/x64-windows-clang-cl.yml
+++ b/.github/workflows/x64-windows-clang-cl.yml
@@ -38,7 +38,7 @@ jobs:
       run: cd submodules/tmc-asio && git checkout ${{env.BRANCH_NAME}}
     - uses: ilammy/msvc-dev-cmd@v1
     - name: configure
-      run: cmake -G "Ninja" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} --preset ${{matrix.PRESET}} .
+      run: cmake -G "Ninja" -DTMC_AS_SUBMODULE=ON -DCMD_FLAGS='-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}}' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --target all
     - name: run tests

--- a/include/tmc/detail/coro_functor.hpp
+++ b/include/tmc/detail/coro_functor.hpp
@@ -154,16 +154,9 @@ public:
 #endif
   }
 
-  inline coro_functor(const coro_functor& Other) noexcept {
-    func = Other.func;
-    obj = Other.obj;
-  }
-
-  inline coro_functor& operator=(const coro_functor& Other) noexcept {
-    func = Other.func;
-    obj = Other.obj;
-    return *this;
-  }
+  /// Not copy-constructible. Holds an owning pointer to the functor object.
+  inline coro_functor(const coro_functor& Other) = delete;
+  inline coro_functor& operator=(const coro_functor& Other) = delete;
 
   inline coro_functor(coro_functor&& Other) noexcept {
     func = Other.func;

--- a/include/tmc/detail/qu_lockfree.hpp
+++ b/include/tmc/detail/qu_lockfree.hpp
@@ -1,3 +1,6 @@
+// last upstream patch: 2025-01-26
+// https://github.com/cameron314/concurrentqueue/commit/0d54c6794510018f42b1b987f55c313dd1358320
+
 // Copyright (c) 2013-2020, Cameron Desrochers
 // Copyright (c) 2023-2025 Logan McDougall
 //

--- a/include/tmc/detail/qu_lockfree.hpp
+++ b/include/tmc/detail/qu_lockfree.hpp
@@ -2663,18 +2663,20 @@ public:
     bool MOODYCAMEL_NO_TSAN enqueue_bulk(It itemFirst, size_t count) {
       static constexpr bool HasMoveConstructor =
         requires { new (static_cast<T*>(nullptr)) T(std::move(*itemFirst)); };
-      static constexpr bool HasNoexceptMoveConstructor = requires {
-        MOODYCAMEL_NOEXCEPT_CTOR(new (static_cast<T*>(nullptr))
-                                   T(std::move(*itemFirst)));
-      };
+      static constexpr bool HasNoexceptMoveConstructor =
+        HasMoveConstructor && requires {
+          MOODYCAMEL_NOEXCEPT_CTOR(new (static_cast<T*>(nullptr))
+                                     T(std::move(*itemFirst)));
+        };
 
       static constexpr bool HasCopyConstructor = requires {
         new (static_cast<T*>(nullptr)) T(details::nomove(*itemFirst));
       };
-      static constexpr bool HasNoexceptCopyConstructor = requires {
-        requires MOODYCAMEL_NOEXCEPT_CTOR(new (static_cast<T*>(nullptr))
-                                            T(details::nomove(*itemFirst)));
-      };
+      static constexpr bool HasNoexceptCopyConstructor =
+        HasCopyConstructor && requires {
+          requires MOODYCAMEL_NOEXCEPT_CTOR(new (static_cast<T*>(nullptr))
+                                              T(details::nomove(*itemFirst)));
+        };
 
       // Prefer constructors in this order:
       // 1. Noexcept move constructor
@@ -2686,8 +2688,7 @@ public:
       // available because we may have to revert if there's an
       // exception.
       static constexpr bool UseMoveConstructor =
-        HasMoveConstructor &&
-        (HasNoexceptMoveConstructor || !HasCopyConstructor);
+        HasNoexceptMoveConstructor || !HasCopyConstructor;
 
       static constexpr bool IsConstructorNoexcept =
         HasNoexceptMoveConstructor || HasNoexceptCopyConstructor;
@@ -3415,18 +3416,20 @@ private:
     bool enqueue_bulk(It itemFirst, size_t count) {
       static constexpr bool HasMoveConstructor =
         requires { new (static_cast<T*>(nullptr)) T(std::move(*itemFirst)); };
-      static constexpr bool HasNoexceptMoveConstructor = requires {
-        MOODYCAMEL_NOEXCEPT_CTOR(new (static_cast<T*>(nullptr))
-                                   T(std::move(*itemFirst)));
-      };
+      static constexpr bool HasNoexceptMoveConstructor =
+        HasMoveConstructor && requires {
+          MOODYCAMEL_NOEXCEPT_CTOR(new (static_cast<T*>(nullptr))
+                                     T(std::move(*itemFirst)));
+        };
 
       static constexpr bool HasCopyConstructor = requires {
         new (static_cast<T*>(nullptr)) T(details::nomove(*itemFirst));
       };
-      static constexpr bool HasNoexceptCopyConstructor = requires {
-        requires MOODYCAMEL_NOEXCEPT_CTOR(new (static_cast<T*>(nullptr))
-                                            T(details::nomove(*itemFirst)));
-      };
+      static constexpr bool HasNoexceptCopyConstructor =
+        HasCopyConstructor && requires {
+          requires MOODYCAMEL_NOEXCEPT_CTOR(new (static_cast<T*>(nullptr))
+                                              T(details::nomove(*itemFirst)));
+        };
 
       // Prefer constructors in this order:
       // 1. Noexcept move constructor
@@ -3438,8 +3441,7 @@ private:
       // available because we may have to revert if there's an
       // exception.
       static constexpr bool UseMoveConstructor =
-        HasMoveConstructor &&
-        (HasNoexceptMoveConstructor || !HasCopyConstructor);
+        HasNoexceptMoveConstructor || !HasCopyConstructor;
 
       static constexpr bool IsConstructorNoexcept =
         HasNoexceptMoveConstructor || HasNoexceptCopyConstructor;

--- a/include/tmc/detail/qu_lockfree.hpp
+++ b/include/tmc/detail/qu_lockfree.hpp
@@ -1738,8 +1738,7 @@ private:
         auto refs = head->freeListRefs.load(std::memory_order_relaxed);
         if ((refs & REFS_MASK) == 0 ||
             !head->freeListRefs.compare_exchange_strong(
-              refs, refs + 1, std::memory_order_acquire,
-              std::memory_order_relaxed
+              refs, refs + 1, std::memory_order_acquire
             )) {
           head = freeListHead.load(std::memory_order_acquire);
           continue;
@@ -1809,7 +1808,7 @@ private:
           // Hmm, the add failed, but we can only try again when the refcount
           // goes back to zero
           if (node->freeListRefs.fetch_add(
-                SHOULD_BE_ON_FREELIST - 1, std::memory_order_release
+                SHOULD_BE_ON_FREELIST - 1, std::memory_order_acq_rel
               ) == 1) {
             continue;
           }
@@ -1910,7 +1909,7 @@ private:
       } else {
         // Increment counter
         auto prevVal =
-          elementsCompletelyDequeued.fetch_add(1, std::memory_order_release);
+          elementsCompletelyDequeued.fetch_add(1, std::memory_order_acq_rel);
         assert(prevVal < PRODUCER_BLOCK_SIZE);
         return prevVal == BLOCK_MASK;
       }
@@ -1970,7 +1969,7 @@ private:
       } else {
         // Increment counter
         auto prevVal = elementsCompletelyDequeued.fetch_add(
-          count, std::memory_order_release
+          count, std::memory_order_acq_rel
         );
         assert(prevVal + count <= PRODUCER_BLOCK_SIZE);
         return prevVal + count == PRODUCER_BLOCK_SIZE;

--- a/include/tmc/spawn_func.hpp
+++ b/include/tmc/spawn_func.hpp
@@ -315,9 +315,10 @@ public:
 
   aw_spawned_func(const aw_spawned_func&) = delete;
   aw_spawned_func& operator=(const aw_spawned_func&) = delete;
-  aw_spawned_func(aw_spawned_func&& Other) {
-    wrapped = std::move(Other.wrapped);
-    prio = Other.prio;
+  aw_spawned_func(aw_spawned_func&& Other)
+      : wrapped(std::move(Other.wrapped)), executor(std::move(Other.executor)),
+        continuation_executor(std::move(Other.continuation_executor)),
+        prio(Other.prio) {
 #ifndef NDEBUG
     is_empty = Other.is_empty;
     Other.is_empty = true;
@@ -325,6 +326,8 @@ public:
   }
   aw_spawned_func& operator=(aw_spawned_func&& Other) {
     wrapped = std::move(Other.wrapped);
+    executor = std::move(Other.executor);
+    continuation_executor = std::move(Other.continuation_executor);
     prio = Other.prio;
 #ifndef NDEBUG
     is_empty = Other.is_empty;

--- a/include/tmc/spawn_many.hpp
+++ b/include/tmc/spawn_many.hpp
@@ -1001,7 +1001,7 @@ public:
                           tmc::detail::TMC_TASK ||
                         tmc::detail::get_awaitable_traits<Awaitable>::mode ==
                           tmc::detail::COROUTINE) {
-            if (IsFunc) {
+            if constexpr (IsFunc) {
               taskArr[i] = tmc::detail::into_task(std::move(*iter));
             } else {
               taskArr[i] = std::move(*iter);
@@ -1034,7 +1034,7 @@ public:
                             tmc::detail::TMC_TASK ||
                           tmc::detail::get_awaitable_traits<Awaitable>::mode ==
                             tmc::detail::COROUTINE) {
-              if (IsFunc) {
+              if constexpr (IsFunc) {
                 taskArr[taskCount] = tmc::detail::into_task(std::move(*iter));
               } else {
                 taskArr[taskCount] = std::move(*iter);
@@ -1052,7 +1052,7 @@ public:
                             tmc::detail::TMC_TASK ||
                           tmc::detail::get_awaitable_traits<Awaitable>::mode ==
                             tmc::detail::COROUTINE) {
-              if (IsFunc) {
+              if constexpr (IsFunc) {
                 taskArr.emplace_back(tmc::detail::into_task(std::move(*iter)));
               } else {
                 taskArr.emplace_back(std::move(*iter));


### PR DESCRIPTION
Additional fixes to spawn_func and spawn_func_many.

Delete coro_functor copy constructor, as it uniquely owns a resource. Update ex_asio (https://github.com/tzcnt/tmc-asio/pull/8) and qu_lockfree to support non-copyable types.

All tests now pass with TMC_WORK_ITEM=FUNCORO 🎉. Setup GH Actions job matrix to build with that config, as well as Release builds with TMC_TRIVIAL_TASK.

Cleaned up some legacy cruft (I'm not supporting VS2015) and merged upstream queue fixes https://github.com/cameron314/concurrentqueue/commit/e74b07d5878a10689f1999d0c3ab1aae4127f881 and https://github.com/cameron314/concurrentqueue/commit/0d54c6794510018f42b1b987f55c313dd1358320