### PR TITLE
32-bit support

### DIFF
--- a/.github/workflows/arm64-macos-clang.yml
+++ b/.github/workflows/arm64-macos-clang.yml
@@ -37,7 +37,7 @@ jobs:
       continue-on-error: true
       run: cd submodules/tmc-asio && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DCMD_FLAGS='-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}}' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DCMD_COMPILE_FLAGS='-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}}' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(sysctl -n hw.logicalcpu) --target all
     - name: run tests

--- a/.github/workflows/x64-linux-clang.yml
+++ b/.github/workflows/x64-linux-clang.yml
@@ -37,7 +37,7 @@ jobs:
       continue-on-error: true
       run: cd submodules/tmc-asio && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DCMD_FLAGS='-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}}' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DCMD_COMPILE_FLAGS='-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}}' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests

--- a/.github/workflows/x64-linux-gcc.yml
+++ b/.github/workflows/x64-linux-gcc.yml
@@ -37,7 +37,7 @@ jobs:
       continue-on-error: true
       run: cd submodules/tmc-asio && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DCMD_FLAGS='-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}}' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DCMD_COMPILE_FLAGS='-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}}' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests

--- a/.github/workflows/x64-windows-clang-cl.yml
+++ b/.github/workflows/x64-windows-clang-cl.yml
@@ -38,7 +38,7 @@ jobs:
       run: cd submodules/tmc-asio && git fetch && git checkout ${{env.BRANCH_NAME}}
     - uses: ilammy/msvc-dev-cmd@v1
     - name: configure
-      run: cmake -G "Ninja" -DTMC_AS_SUBMODULE=ON -DCMD_FLAGS='-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}}' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Ninja" -DTMC_AS_SUBMODULE=ON -DCMD_COMPILE_FLAGS='-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}}' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --target all
     - name: run tests

--- a/.github/workflows/x86-linux-clang.yml
+++ b/.github/workflows/x86-linux-clang.yml
@@ -1,0 +1,46 @@
+name: x86-linux-clang
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        PRESET: [clang-linux-debug]
+        WORK_ITEM: [CORO]
+    steps:
+    - name: install-32bit-libs
+      run: sudo apt-get update && sudo apt install gcc-14-multilib g++-14-multilib
+    - uses: actions/checkout@v4
+      with:
+        repository: tzcnt/tmc-examples
+        ref: main
+    - name: branch-examples
+      continue-on-error: true
+      run: git fetch && git checkout ${{env.BRANCH_NAME}}
+    - name: submodule-clone
+      run: >
+        cd submodules
+        && git clone https://github.com/tzcnt/TooManyCooks.git
+        && git clone https://github.com/tzcnt/tmc-asio.git
+    # If a branch with the same name exists in the dependency repos, use that. Otherwise, use main.
+    - name: submodule-branch-TMC
+      # continue-on-error: true # this should never fail if triggered from TMC workflow
+      run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
+    - name: submodule-branch-tmc-asio
+      continue-on-error: true
+      run: cd submodules/tmc-asio && git fetch && git checkout ${{env.BRANCH_NAME}}
+    - name: configure
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DCMD_COMPILE_FLAGS='-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}};-m32' -DCMD_LINK_FLAGS='-m32' --preset ${{matrix.PRESET}} .
+    - name: build
+      run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
+    - name: run tests
+      run: ./build/${{matrix.PRESET}}/tests/tests

--- a/.github/workflows/x86-linux-gcc.yml
+++ b/.github/workflows/x86-linux-gcc.yml
@@ -1,0 +1,46 @@
+name: x86-linux-gcc
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        PRESET: [gcc-linux-debug]
+        WORK_ITEM: [CORO]
+    steps:
+    - name: install-32bit-libs
+      run: sudo apt-get update && sudo apt install gcc-14-multilib g++-14-multilib
+    - uses: actions/checkout@v4
+      with:
+        repository: tzcnt/tmc-examples
+        ref: main
+    - name: branch-examples
+      continue-on-error: true
+      run: git fetch && git checkout ${{env.BRANCH_NAME}}
+    - name: submodule-clone
+      run: >
+        cd submodules
+        && git clone https://github.com/tzcnt/TooManyCooks.git
+        && git clone https://github.com/tzcnt/tmc-asio.git
+    # If a branch with the same name exists in the dependency repos, use that. Otherwise, use main.
+    - name: submodule-branch-TMC
+      # continue-on-error: true # this should never fail if triggered from TMC workflow
+      run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
+    - name: submodule-branch-tmc-asio
+      continue-on-error: true
+      run: cd submodules/tmc-asio && git fetch && git checkout ${{env.BRANCH_NAME}}
+    - name: configure
+      run: cmake -G "Unix Makefiles" -DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14 -DTMC_AS_SUBMODULE=ON -DCMD_COMPILE_FLAGS='-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}};-m32' -DCMD_LINK_FLAGS='-m32' --preset ${{matrix.PRESET}} .
+    - name: build
+      run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
+    - name: run tests
+      run: ./build/${{matrix.PRESET}}/tests/tests

--- a/include/tmc/aw_resume_on.hpp
+++ b/include/tmc/aw_resume_on.hpp
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "tmc/detail/compat.hpp"
 #include "tmc/detail/concepts.hpp" // IWYU pragma: keep
 #include "tmc/detail/thread_locals.hpp"
 

--- a/include/tmc/aw_yield.hpp
+++ b/include/tmc/aw_yield.hpp
@@ -83,13 +83,13 @@ class [[nodiscard(
   "You must co_await aw_yield_counter_dynamic for it to have any "
   "effect."
 )]] aw_yield_counter_dynamic : tmc::detail::AwaitTagNoGroupAsIs {
-  int64_t count;
-  int64_t n;
+  ssize_t count;
+  ssize_t n;
 
 public:
   /// It is recommended to call `check_yield_counter_dynamic()` instead of using
   /// this constructor directly.
-  aw_yield_counter_dynamic(int64_t N) : count(0), n(N) {}
+  aw_yield_counter_dynamic(ssize_t N) : count(0), n(N) {}
 
   /// Every `N` calls to `co_await`, this will check yield_requested() and
   /// suspend if that returns true.
@@ -125,15 +125,15 @@ public:
 /// `yield_requested()` and yields if that returns true. The counterpart
 /// function `check_yield_counter()` allows setting `N` as a template parameter.
 inline aw_yield_counter_dynamic check_yield_counter_dynamic(size_t N) {
-  return aw_yield_counter_dynamic(static_cast<int64_t>(N));
+  return aw_yield_counter_dynamic(static_cast<ssize_t>(N));
 }
 
 /// The awaitable type returned by `tmc::check_yield_counter()`.
-template <int64_t N>
+template <ssize_t N>
 class [[nodiscard("You must co_await aw_yield_counter for it to have any "
                   "effect.")]] aw_yield_counter
     : tmc::detail::AwaitTagNoGroupAsIs {
-  int64_t count;
+  ssize_t count;
 
 public:
   /// It is recommended to call `check_yield_counter()` instead of using
@@ -174,7 +174,7 @@ public:
 /// `yield_requested()` and yields if that returns true.
 /// The counterpart function `check_yield_counter_dynamic()` allows passing `N`
 /// as a runtime parameter.
-template <int64_t N> inline aw_yield_counter<N> check_yield_counter() {
+template <ssize_t N> inline aw_yield_counter<N> check_yield_counter() {
   return aw_yield_counter<N>();
 }
 

--- a/include/tmc/aw_yield.hpp
+++ b/include/tmc/aw_yield.hpp
@@ -83,13 +83,13 @@ class [[nodiscard(
   "You must co_await aw_yield_counter_dynamic for it to have any "
   "effect."
 )]] aw_yield_counter_dynamic : tmc::detail::AwaitTagNoGroupAsIs {
-  ssize_t count;
-  ssize_t n;
+  ptrdiff_t count;
+  ptrdiff_t n;
 
 public:
   /// It is recommended to call `check_yield_counter_dynamic()` instead of using
   /// this constructor directly.
-  aw_yield_counter_dynamic(ssize_t N) : count(0), n(N) {}
+  aw_yield_counter_dynamic(ptrdiff_t N) : count(0), n(N) {}
 
   /// Every `N` calls to `co_await`, this will check yield_requested() and
   /// suspend if that returns true.
@@ -125,15 +125,15 @@ public:
 /// `yield_requested()` and yields if that returns true. The counterpart
 /// function `check_yield_counter()` allows setting `N` as a template parameter.
 inline aw_yield_counter_dynamic check_yield_counter_dynamic(size_t N) {
-  return aw_yield_counter_dynamic(static_cast<ssize_t>(N));
+  return aw_yield_counter_dynamic(static_cast<ptrdiff_t>(N));
 }
 
 /// The awaitable type returned by `tmc::check_yield_counter()`.
-template <ssize_t N>
+template <ptrdiff_t N>
 class [[nodiscard("You must co_await aw_yield_counter for it to have any "
                   "effect.")]] aw_yield_counter
     : tmc::detail::AwaitTagNoGroupAsIs {
-  ssize_t count;
+  ptrdiff_t count;
 
 public:
   /// It is recommended to call `check_yield_counter()` instead of using
@@ -174,7 +174,7 @@ public:
 /// `yield_requested()` and yields if that returns true.
 /// The counterpart function `check_yield_counter_dynamic()` allows passing `N`
 /// as a runtime parameter.
-template <ssize_t N> inline aw_yield_counter<N> check_yield_counter() {
+template <ptrdiff_t N> inline aw_yield_counter<N> check_yield_counter() {
   return aw_yield_counter<N>();
 }
 

--- a/include/tmc/aw_yield.hpp
+++ b/include/tmc/aw_yield.hpp
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "tmc/detail/compat.hpp"
 #include "tmc/detail/concepts.hpp"
 #include "tmc/detail/thread_locals.hpp"
 

--- a/include/tmc/detail/compat.hpp
+++ b/include/tmc/detail/compat.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <atomic>
+
+#if defined(_MSC_VER)
+
+#ifdef __has_cpp_attribute
+
+#if __has_cpp_attribute(msvc::forceinline)
+#define TMC_FORCE_INLINE [[msvc::forceinline]]
+#else
+#define TMC_FORCE_INLINE
+#endif
+
+#if __has_cpp_attribute(msvc::no_unique_address)
+#define TMC_NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
+#else
+#define TMC_NO_UNIQUE_ADDRESS
+#endif
+
+#else // not __has_cpp_attribute
+#define TMC_FORCE_INLINE [[msvc::forceinline]]
+#define TMC_NO_UNIQUE_ADDRESS [[msvc::no_unique_address]]
+#endif
+#else // not _MSC_VER
+#define TMC_FORCE_INLINE __attribute__((always_inline))
+#define TMC_NO_UNIQUE_ADDRESS [[no_unique_address]]
+#endif
+
+#if defined(__x86_64__) || defined(_M_AMD64) || defined(i386) ||               \
+  defined(__i386__) || defined(__i386) || defined(_M_IX86)
+#include <immintrin.h>
+#define TMC_CPU_X86
+#define TMC_CPU_PAUSE _mm_pause
+#elif defined(__arm__) || defined(_M_ARM) || defined(_M_ARM64) ||              \
+  defined(__aarch64__) || defined(__ARM_ACLE)
+#include <arm_acle.h>
+#define TMC_CPU_ARM
+#define TMC_CPU_PAUSE __yield
+#endif
+
+namespace tmc::detail {
+TMC_FORCE_INLINE inline void memory_barrier() {
+#ifdef TMC_CPU_X86
+  std::atomic<size_t> locker;
+  locker.fetch_add(0, std::memory_order_seq_cst);
+#else
+  std::atomic_thread_fence(std::memory_order_seq_cst);
+#endif
+}
+} // namespace tmc::detail
+
+// `1 << 40` is undefined behavior because the type of `1` defaults to 32-bit
+// `int`. So if we want to left-shift into a 64-bit mask, we need to cast the
+// literal.
+#define TMC_ONE_BIT static_cast<size_t>(1)
+
+#define TMC_ALL_ONES static_cast<size_t>(-1)

--- a/include/tmc/detail/compat.hpp
+++ b/include/tmc/detail/compat.hpp
@@ -50,9 +50,12 @@ TMC_FORCE_INLINE inline void memory_barrier() {
 }
 } // namespace tmc::detail
 
-// `1 << 40` is undefined behavior because the type of `1` defaults to 32-bit
-// `int`. So if we want to left-shift into a 64-bit mask, we need to cast the
-// literal.
+// `1 << 40` is undefined behavior on 64-bit systems because the type of `1`
+// defaults to 32-bit `int`. So if we want to left-shift into a 64-bit mask, we
+// need to cast the literal.
 #define TMC_ONE_BIT static_cast<size_t>(1)
 
 #define TMC_ALL_ONES static_cast<size_t>(-1)
+
+static inline constexpr size_t TMC_PLATFORM_BITS =
+  sizeof(size_t) * 8; // 32 or 64

--- a/include/tmc/detail/concepts.hpp
+++ b/include/tmc/detail/concepts.hpp
@@ -144,7 +144,7 @@ static void set_continuation_executor(Awaitable& YourAwaitable, void* ContExec);
 
 static void set_done_count(Awaitable& YourAwaitable, void* DoneCount);
 
-static void set_flags(Awaitable& YourAwaitable, uint64_t Flags);
+static void set_flags(Awaitable& YourAwaitable, size_t Flags);
 };
 
 */

--- a/include/tmc/detail/coro_functor.hpp
+++ b/include/tmc/detail/coro_functor.hpp
@@ -3,6 +3,12 @@
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+// coro_functor is a lightweight implementation of a move-only functor that can
+// hold either a coroutine, a function pointer, or a function object pointer. It
+// uses pointer tagging to denote the stored type.
+
+// It requires a 64-bit system, as 32-bit systems don't have free address bits.
+
 #pragma once
 
 #include "tmc/detail/compat.hpp"

--- a/include/tmc/detail/coro_functor.hpp
+++ b/include/tmc/detail/coro_functor.hpp
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include "tmc/detail/compat.hpp"
+
 #include <cassert>
 #include <coroutine>
 #include <cstdint>
@@ -14,7 +16,7 @@ namespace tmc {
 class coro_functor {
   // use high bit of pointer for pointer tagging
   // low bit is not safe to use as function addresses may be unaligned
-  static constexpr uintptr_t IS_FUNC_BIT = 1ULL << 60;
+  static constexpr uintptr_t IS_FUNC_BIT = TMC_ONE_BIT << 60;
   static_assert(sizeof(void*) == 8); // requires 64-bit
 
   void* func; // coroutine address or function pointer. tagged via the above bit

--- a/include/tmc/detail/ex_cpu.ipp
+++ b/include/tmc/detail/ex_cpu.ipp
@@ -11,6 +11,8 @@
 #include "tmc/detail/thread_layout.hpp"
 #include "tmc/ex_cpu.hpp"
 
+#include <bit>
+
 namespace tmc {
 void ex_cpu::notify_n(size_t Count, size_t Priority) {
   // TODO set notified threads prev_prod (index 1) to this?

--- a/include/tmc/detail/ex_cpu.ipp
+++ b/include/tmc/detail/ex_cpu.ipp
@@ -13,16 +13,9 @@
 
 namespace tmc {
 void ex_cpu::notify_n(size_t Count, size_t Priority) {
-// TODO set notified threads prev_prod (index 1) to this?
-#ifdef _MSC_VER
-  size_t workingThreadCount = static_cast<size_t>(
-    __popcnt64(working_threads_bitset.load(std::memory_order_acquire))
-  );
-#else
-  size_t workingThreadCount = static_cast<size_t>(
-    __builtin_popcountll(working_threads_bitset.load(std::memory_order_acquire))
-  );
-#endif
+  // TODO set notified threads prev_prod (index 1) to this?
+  size_t workingThreadCount =
+    std::popcount(working_threads_bitset.load(std::memory_order_acquire));
   size_t sleepingThreadCount = thread_count() - workingThreadCount;
 #ifdef TMC_PRIORITY_COUNT
   if constexpr (PRIORITY_COUNT > 1)

--- a/include/tmc/detail/ex_cpu.ipp
+++ b/include/tmc/detail/ex_cpu.ipp
@@ -38,8 +38,7 @@ void ex_cpu::notify_n(size_t Count, size_t Priority) {
         interruptMax = workingThreadCount;
       }
       for (size_t prio = PRIORITY_COUNT - 1; prio > Priority; --prio) {
-        uint64_t set =
-          task_stopper_bitsets[prio].load(std::memory_order_acquire);
+        size_t set = task_stopper_bitsets[prio].load(std::memory_order_acquire);
         while (set != 0) {
 #ifdef _MSC_VER
           size_t slot = static_cast<size_t>(_tzcnt_u64(set));
@@ -267,7 +266,7 @@ void ex_cpu::init() {
   }
   NO_TASK_RUNNING = PRIORITY_COUNT;
 #endif
-  task_stopper_bitsets = new std::atomic<uint64_t>[PRIORITY_COUNT];
+  task_stopper_bitsets = new std::atomic<size_t>[PRIORITY_COUNT];
   work_queues.resize(PRIORITY_COUNT);
   for (size_t i = 0; i < PRIORITY_COUNT; ++i) {
 #ifndef TMC_USE_MUTEXQ
@@ -280,7 +279,7 @@ void ex_cpu::init() {
   if (init_params != nullptr && init_params->thread_count != 0) {
     threads.resize(init_params->thread_count);
   } else {
-    // limited to 64 threads for now, due to use of uint64_t bitset
+    // limited to 64 threads for now, due to use of size_t bitset
     size_t hwconc = std::thread::hardware_concurrency();
     if (hwconc > 64) {
       hwconc = 64;
@@ -307,7 +306,7 @@ void ex_cpu::init() {
   }
 #endif
   assert(thread_count() != 0);
-  // limited to 64 threads for now, due to use of uint64_t bitset
+  // limited to 64 threads for now, due to use of size_t bitset
   assert(thread_count() <= 64);
   thread_states = new ThreadState[thread_count()];
   for (size_t i = 0; i < thread_count(); ++i) {
@@ -498,7 +497,7 @@ ex_cpu& ex_cpu::set_thread_occupancy(float ThreadOccupancy) {
 
 ex_cpu& ex_cpu::set_thread_count(size_t ThreadCount) {
   assert(!is_initialized);
-  // limited to 64 threads for now, due to use of uint64_t bitset
+  // limited to 64 threads for now, due to use of size_t bitset
   assert(ThreadCount <= 64);
   if (init_params == nullptr) {
     init_params = new InitParams;

--- a/include/tmc/detail/ex_cpu.ipp
+++ b/include/tmc/detail/ex_cpu.ipp
@@ -271,10 +271,10 @@ void ex_cpu::init() {
   if (init_params != nullptr && init_params->thread_count != 0) {
     threads.resize(init_params->thread_count);
   } else {
-    // limited to 64 threads for now, due to use of size_t bitset
+    // limited to 32/64 threads for now, due to use of size_t bitset
     size_t hwconc = std::thread::hardware_concurrency();
-    if (hwconc > 64) {
-      hwconc = 64;
+    if (hwconc > TMC_PLATFORM_BITS) {
+      hwconc = TMC_PLATFORM_BITS;
     }
     threads.resize(hwconc);
   }
@@ -298,8 +298,8 @@ void ex_cpu::init() {
   }
 #endif
   assert(thread_count() != 0);
-  // limited to 64 threads for now, due to use of size_t bitset
-  assert(thread_count() <= 64);
+  // limited to 32/64 threads for now, due to use of size_t bitset
+  assert(thread_count() <= TMC_PLATFORM_BITS);
   thread_states = new ThreadState[thread_count()];
   for (size_t i = 0; i < thread_count(); ++i) {
     thread_states[i].yield_priority = NO_TASK_RUNNING;
@@ -490,8 +490,8 @@ ex_cpu& ex_cpu::set_thread_occupancy(float ThreadOccupancy) {
 
 ex_cpu& ex_cpu::set_thread_count(size_t ThreadCount) {
   assert(!is_initialized);
-  // limited to 64 threads for now, due to use of size_t bitset
-  assert(ThreadCount <= 64);
+  // limited to 32/64 threads for now, due to use of size_t bitset
+  assert(ThreadCount <= TMC_PLATFORM_BITS);
   if (init_params == nullptr) {
     init_params = new InitParams;
   }

--- a/include/tmc/detail/ex_cpu.ipp
+++ b/include/tmc/detail/ex_cpu.ipp
@@ -40,11 +40,7 @@ void ex_cpu::notify_n(size_t Count, size_t Priority) {
       for (size_t prio = PRIORITY_COUNT - 1; prio > Priority; --prio) {
         size_t set = task_stopper_bitsets[prio].load(std::memory_order_acquire);
         while (set != 0) {
-#ifdef _MSC_VER
-          size_t slot = static_cast<size_t>(_tzcnt_u64(set));
-#else
-          size_t slot = static_cast<size_t>(__builtin_ctzll(set));
-#endif
+          size_t slot = std::countr_zero(set);
           set = set & ~(1ULL << slot);
           if (thread_states[slot].yield_priority.load(std::memory_order_relaxed
               ) <= Priority) {

--- a/include/tmc/detail/qu_lockfree.hpp
+++ b/include/tmc/detail/qu_lockfree.hpp
@@ -144,7 +144,7 @@ template <> struct thread_id_size<4> {
   typedef std::uint32_t numeric_t;
 };
 template <> struct thread_id_size<8> {
-  typedef std::uint64_t numeric_t;
+  typedef std::size_t numeric_t;
 };
 
 template <> struct thread_id_converter<thread_id_t> {
@@ -359,7 +359,7 @@ struct ConcurrentQueueDefaultTraits {
   // A 64-bit int type is recommended in that case, and in practice will
   // prevent a race condition no matter the usage of the queue. Note that
   // whether the queue is lock-free with a 64-int type depends on the whether
-  // std::atomic<std::uint64_t> is lock-free, which is platform-specific.
+  // std::atomic<std::size_t> is lock-free, which is platform-specific.
   typedef std::size_t index_t;
 
   // Internally, all elements are enqueued and dequeued from multi-element
@@ -480,7 +480,7 @@ template <bool use32> struct _hash_32_or_64 {
   }
 };
 template <> struct _hash_32_or_64<1> {
-  static inline std::uint64_t hash(std::uint64_t h) {
+  static inline std::size_t hash(std::size_t h) {
     h ^= h >> 33;
     h *= 0xff51afd7ed558ccd;
     h ^= h >> 33;
@@ -813,7 +813,7 @@ public:
 
   static constexpr size_t BLOCK_EMPTY_ELEM_SIZE =
     PRODUCER_BLOCK_SIZE < 64 ? PRODUCER_BLOCK_SIZE : 64;
-  static constexpr uint64_t BLOCK_EMPTY_MASK =
+  static constexpr size_t BLOCK_EMPTY_MASK =
     PRODUCER_BLOCK_SIZE < 64 ? (1ULL << Traits::PRODUCER_BLOCK_SIZE) - 1ULL
                              : -1ULL;
   static constexpr size_t BLOCK_EMPTY_ARRAY_SIZE =
@@ -1563,8 +1563,8 @@ public:
   bool empty() const {
     // TODO make a producer thread version of this that uses this thread's
     // static iteration order
-    auto static_producer_count = static_cast<int64_t>(dequeueProducerCount) - 1;
-    for (int64_t pidx = 0; pidx < static_producer_count; ++pidx) {
+    auto static_producer_count = static_cast<ssize_t>(dequeueProducerCount) - 1;
+    for (ssize_t pidx = 0; pidx < static_producer_count; ++pidx) {
       ExplicitProducer& prod = staticProducers[pidx];
       if (prod.size() != 0) {
         return false;
@@ -1902,7 +1902,7 @@ private:
           arrIndex = rawIndex / BLOCK_EMPTY_ELEM_SIZE;
           bitIndex = rawIndex & (BLOCK_EMPTY_ELEM_SIZE - 1);
         }
-        uint64_t bit = 1ULL << bitIndex;
+        size_t bit = 1ULL << bitIndex;
         // Set flag
         assert(
           (emptyFlags[arrIndex].load(std::memory_order_relaxed) & bit) == 0
@@ -1942,7 +1942,7 @@ private:
         auto arrIndex = arrIndexStart;
         auto bitIndex = bitIndexStart;
         if (arrIndex < arrIndexEnd) {
-          uint64_t bits =
+          size_t bits =
             -(1ULL << bitIndex); // set all bits from bitIndex and higher
           assert(
             (emptyFlags[arrIndex].load(std::memory_order_relaxed) & bits) == 0
@@ -1963,7 +1963,7 @@ private:
 
         // End
         assert(arrIndex == arrIndexEnd);
-        uint64_t bits = ((1ULL << count) - 1) << (bitIndexEnd + 1 - count);
+        size_t bits = ((1ULL << count) - 1) << (bitIndexEnd + 1 - count);
         assert(
           (emptyFlags[arrIndex].load(std::memory_order_relaxed) & bits) == 0
         );
@@ -2047,7 +2047,7 @@ private:
     elements;
 
   public:
-    alignas(64) std::atomic<uint64_t> emptyFlags[BLOCK_EMPTY_ARRAY_SIZE];
+    alignas(64) std::atomic<size_t> emptyFlags[BLOCK_EMPTY_ARRAY_SIZE];
     Block* next;
     std::atomic<size_t> elementsCompletelyDequeued;
 

--- a/include/tmc/detail/qu_lockfree.hpp
+++ b/include/tmc/detail/qu_lockfree.hpp
@@ -145,7 +145,7 @@ template <> struct thread_id_size<4> {
   typedef std::uint32_t numeric_t;
 };
 template <> struct thread_id_size<8> {
-  typedef std::size_t numeric_t;
+  typedef std::uint64_t numeric_t;
 };
 
 template <> struct thread_id_converter<thread_id_t> {
@@ -480,7 +480,7 @@ template <bool use32> struct _hash_32_or_64 {
   }
 };
 template <> struct _hash_32_or_64<1> {
-  static inline std::size_t hash(std::size_t h) {
+  static inline std::uint64_t hash(std::uint64_t h) {
     h ^= h >> 33;
     h *= 0xff51afd7ed558ccd;
     h ^= h >> 33;

--- a/include/tmc/detail/qu_lockfree.hpp
+++ b/include/tmc/detail/qu_lockfree.hpp
@@ -465,7 +465,7 @@ struct alignas(64) ConcurrentQueueProducerTypelessBase {
       : next(nullptr), inactive(false), token(nullptr) {}
 };
 
-template <bool use32> struct _hash_32_or_64 {
+template <bool use64> struct _hash_32_or_64 {
   static inline std::uint32_t hash(std::uint32_t h) {
     // MurmurHash3 finalizer -- see
     // https://code.google.com/p/smhasher/source/browse/trunk/MurmurHash3.cpp

--- a/include/tmc/detail/qu_lockfree.hpp
+++ b/include/tmc/detail/qu_lockfree.hpp
@@ -811,17 +811,17 @@ public:
   static constexpr size_t BLOCK_MASK =
     static_cast<size_t>(Traits::PRODUCER_BLOCK_SIZE) - 1;
 
-  static constexpr size_t PLATFORM_BITS = sizeof(size_t) * 8; // 32 or 64
-
   static constexpr size_t BLOCK_EMPTY_ELEM_SIZE =
-    PRODUCER_BLOCK_SIZE < PLATFORM_BITS ? PRODUCER_BLOCK_SIZE : PLATFORM_BITS;
+    PRODUCER_BLOCK_SIZE < TMC_PLATFORM_BITS ? PRODUCER_BLOCK_SIZE
+                                            : TMC_PLATFORM_BITS;
   static constexpr size_t BLOCK_EMPTY_MASK =
-    PRODUCER_BLOCK_SIZE < PLATFORM_BITS
+    PRODUCER_BLOCK_SIZE < TMC_PLATFORM_BITS
       ? (TMC_ONE_BIT << Traits::PRODUCER_BLOCK_SIZE) - 1
       : TMC_ALL_ONES;
   static constexpr size_t BLOCK_EMPTY_ARRAY_SIZE =
-    PRODUCER_BLOCK_SIZE < PLATFORM_BITS ? 1
-                                        : (PRODUCER_BLOCK_SIZE / PLATFORM_BITS);
+    PRODUCER_BLOCK_SIZE < TMC_PLATFORM_BITS
+      ? 1
+      : (PRODUCER_BLOCK_SIZE / TMC_PLATFORM_BITS);
 
   static constexpr size_t PLATFORM_CACHELINE_BYTES = 64;
 
@@ -1938,13 +1938,13 @@ private:
         }
 
         // Middle
-        while (count > PLATFORM_BITS) {
-          assert(count % PLATFORM_BITS == 0);
+        while (count > TMC_PLATFORM_BITS) {
+          assert(count % TMC_PLATFORM_BITS == 0);
           assert(emptyFlags[arrIndex].load(std::memory_order_relaxed) == 0);
           emptyFlags[arrIndex].fetch_or(
             TMC_ALL_ONES, std::memory_order_relaxed
           );
-          count -= PLATFORM_BITS;
+          count -= TMC_PLATFORM_BITS;
           arrIndex++;
         }
 

--- a/include/tmc/detail/qu_lockfree.hpp
+++ b/include/tmc/detail/qu_lockfree.hpp
@@ -1563,8 +1563,9 @@ public:
   bool empty() const {
     // TODO make a producer thread version of this that uses this thread's
     // static iteration order
-    auto static_producer_count = static_cast<ssize_t>(dequeueProducerCount) - 1;
-    for (ssize_t pidx = 0; pidx < static_producer_count; ++pidx) {
+    auto static_producer_count =
+      static_cast<ptrdiff_t>(dequeueProducerCount) - 1;
+    for (ptrdiff_t pidx = 0; pidx < static_producer_count; ++pidx) {
       ExplicitProducer& prod = staticProducers[pidx];
       if (prod.size() != 0) {
         return false;

--- a/include/tmc/detail/test.hpp
+++ b/include/tmc/detail/test.hpp
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "tmc/detail/compat.hpp"
 #include "tmc/detail/thread_locals.hpp"
 #include "tmc/ex_cpu.hpp"
 

--- a/include/tmc/detail/test.hpp
+++ b/include/tmc/detail/test.hpp
@@ -8,11 +8,7 @@
 #include "tmc/detail/thread_locals.hpp"
 #include "tmc/ex_cpu.hpp"
 
-#if defined(__x86_64__) || defined(_M_AMD64)
-#include <immintrin.h>
-#else
-#include <arm_acle.h>
-#endif
+#include <bit>
 
 namespace tmc {
 namespace test {
@@ -32,7 +28,7 @@ inline size_t wait_for_all_threads_to_sleep(ex_cpu& CpuExecutor) {
     runThreads = 1;
   }
 
-  while (__builtin_popcountll(
+  while (std::popcount(
            CpuExecutor.working_threads_bitset.load(std::memory_order_acquire)
          ) > runThreads) {
 
@@ -61,13 +57,7 @@ inline size_t wait_for_all_threads_to_sleep(ex_cpu& CpuExecutor) {
     // once the queue is empty.
 
     for (int i = 0; i < 4; ++i) {
-#if defined(__x86_64__) || defined(_M_AMD64)
-      _mm_pause();
-#endif
-#if defined(__arm__) || defined(_M_ARM) || defined(__aarch64__) ||             \
-  defined(__ARM_ACLE)
-      __yield();
-#endif
+      TMC_CPU_PAUSE();
     }
     // std::this_thread::sleep_for(std::chrono::milliseconds(1));
     ++waitCount;

--- a/include/tmc/detail/thread_layout.ipp
+++ b/include/tmc/detail/thread_layout.ipp
@@ -3,6 +3,7 @@
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include "tmc/detail/compat.hpp"
 #include "tmc/detail/thread_layout.hpp"
 
 #include <vector>
@@ -116,7 +117,7 @@ get_group_iteration_order(size_t GroupCount, size_t StartGroup) {
       if (StartGroup < pathTree[node.lowIdx].max) {
         node = pathTree[node.lowIdx];
       } else {
-        startPath |= (1ULL << depth);
+        startPath |= (TMC_ONE_BIT << depth);
         node = pathTree[node.highIdx];
       }
       ++depth;

--- a/include/tmc/detail/thread_layout.ipp
+++ b/include/tmc/detail/thread_layout.ipp
@@ -190,8 +190,8 @@ void adjust_thread_groups(
   } else {
     threadCount = coreCount;
   }
-  if (threadCount > 64) {
-    threadCount = 64;
+  if (threadCount > TMC_PLATFORM_BITS) {
+    threadCount = TMC_PLATFORM_BITS;
   }
   if (threadCount == 0) {
     threadCount = 1;

--- a/include/tmc/detail/thread_layout.ipp
+++ b/include/tmc/detail/thread_layout.ipp
@@ -43,7 +43,7 @@ static void recursively_subdivide(std::vector<SubdivideNode>& Results) {
 // path structure except for that branch. Keeping the original path structure
 // produces a more balanced work stealing network / matrix.
 static void enumerate_paths(
-  const size_t Path, uint64_t DepthBit,
+  const size_t Path, size_t DepthBit,
   const std::vector<SubdivideNode>& PathTree, const size_t NodeIdx,
   std::vector<size_t>& Results
 ) {
@@ -108,7 +108,7 @@ get_group_iteration_order(size_t GroupCount, size_t StartGroup) {
   // the high bits are padded with 0s (0b0...00010110), which solves the
   // case of a start node on the short (high) side of the tree
 
-  uint64_t startPath = 0;
+  size_t startPath = 0;
   SubdivideNode node = pathTree[0];
   size_t depth = 0;
   {
@@ -253,7 +253,7 @@ void bind_thread(hwloc_topology_t Topology, hwloc_cpuset_t SharedCores) {
     std::vector<unsigned long> bitmapUlongs;
     bitmapUlongs.resize(bitmapSize);
     hwloc_bitmap_to_ulongs(SharedCores, bitmapSize, bitmapUlongs.data());
-    std::vector<uint64_t> bitmaps;
+    std::vector<size_t> bitmaps;
     if constexpr (sizeof(unsigned long) == 8) {
       bitmaps.resize(bitmapUlongs.size());
       for (size_t b = 0; b < bitmapUlongs.size(); ++b) {
@@ -271,7 +271,7 @@ void bind_thread(hwloc_topology_t Topology, hwloc_cpuset_t SharedCores) {
         if (b >= bitmapUlongs.size()) {
           break;
         }
-        bitmaps.back() |= ((static_cast<uint64_t>(bitmapUlongs[b])) << 32);
+        bitmaps.back() |= ((static_cast<size_t>(bitmapUlongs[b])) << 32);
         ++b;
       }
     }

--- a/include/tmc/detail/thread_locals.hpp
+++ b/include/tmc/detail/thread_locals.hpp
@@ -35,6 +35,18 @@
 #define TMC_NO_UNIQUE_ADDRESS [[no_unique_address]]
 #endif
 
+#if defined(__x86_64__) || defined(_M_AMD64) || defined(i386) ||               \
+  defined(__i386__) || defined(__i386) || defined(_M_IX86)
+#include <immintrin.h>
+#define TMC_CPU_X86
+#define TMC_CPU_PAUSE _mm_pause
+#elif defined(__arm__) || defined(_M_ARM) || defined(_M_ARM64) ||              \
+  defined(__aarch64__) || defined(__ARM_ACLE)
+#include <arm_acle.h>
+#define TMC_CPU_ARM
+#define TMC_CPU_PAUSE __yield
+#endif
+
 // Macro hackery to enable defines TMC_WORK_ITEM=CORO / TMC_WORK_ITEM=FUNC, etc
 #define TMC_WORK_ITEM_CORO 0 // coro will be the default if undefined
 #define TMC_WORK_ITEM_FUNC 1
@@ -70,7 +82,7 @@ namespace tmc {
 namespace detail {
 
 TMC_FORCE_INLINE inline void memory_barrier() {
-#if defined(__x86_64__) || defined(_M_AMD64) || defined(__i386__)
+#ifdef TMC_CPU_X86
   std::atomic<size_t> locker;
   locker.fetch_add(0, std::memory_order_seq_cst);
 #else

--- a/include/tmc/detail/tiny_lock.hpp
+++ b/include/tmc/detail/tiny_lock.hpp
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#include "thread_locals.hpp"
+#include "tmc/detail/compat.hpp"
 
 #include <atomic>
 

--- a/include/tmc/detail/tiny_lock.hpp
+++ b/include/tmc/detail/tiny_lock.hpp
@@ -5,12 +5,9 @@
 
 #pragma once
 
+#include "thread_locals.hpp"
+
 #include <atomic>
-#if defined(__x86_64__) || defined(_M_AMD64)
-#include <immintrin.h>
-#else
-#include <arm_acle.h>
-#endif
 
 namespace tmc {
 /// A tiny lock with no syscalls. Used by tmc::ex_braid.
@@ -30,13 +27,7 @@ public:
   inline void spin_lock() {
     while (m_is_locked.test_and_set(std::memory_order_acquire)) {
       while (m_is_locked.test(std::memory_order_relaxed)) {
-#if defined(__x86_64__) || defined(_M_AMD64)
-        _mm_pause();
-#endif
-#if defined(__arm__) || defined(_M_ARM) || defined(__aarch64__) ||             \
-  defined(__ARM_ACLE)
-        __yield();
-#endif
+        TMC_CPU_PAUSE();
       }
     }
   }

--- a/include/tmc/detail/tiny_vec.hpp
+++ b/include/tmc/detail/tiny_vec.hpp
@@ -68,6 +68,5 @@ public:
   ~tiny_vec() { clear(); }
 };
 
-static_assert(sizeof(tiny_vec<int, 8>) == 16);
 } // namespace detail
 } // namespace tmc

--- a/include/tmc/ex_cpu.hpp
+++ b/include/tmc/ex_cpu.hpp
@@ -100,7 +100,8 @@ class ex_cpu {
 public:
   /// Builder func to set the number of threads before calling `init()`.
   /// The default is 0, which will cause `init()` to automatically create 1
-  /// thread per physical core.
+  /// thread per physical core (with hwloc), or create
+  /// std::thread::hardware_concurrency() threads (without hwloc).
   ex_cpu& set_thread_count(size_t ThreadCount);
 #ifdef TMC_USE_HWLOC
   /// Builder func to set the number of threads per core before calling

--- a/include/tmc/ex_cpu.hpp
+++ b/include/tmc/ex_cpu.hpp
@@ -17,11 +17,6 @@
 #include "tmc/task.hpp"
 
 #include <atomic>
-#if defined(__x86_64__) || defined(_M_AMD64)
-#include <immintrin.h>
-#else
-#include <arm_acle.h>
-#endif
 #include <stop_token>
 #include <thread>
 #ifdef TMC_USE_HWLOC

--- a/include/tmc/ex_cpu.hpp
+++ b/include/tmc/ex_cpu.hpp
@@ -58,8 +58,8 @@ class ex_cpu {
 
   std::atomic<int> ready_task_cv; // monotonic counter
   bool is_initialized = false;
-  std::atomic<uint64_t> working_threads_bitset;
-  std::atomic<uint64_t>* task_stopper_bitsets; // array of size PRIORITY_COUNT
+  std::atomic<size_t> working_threads_bitset;
+  std::atomic<size_t>* task_stopper_bitsets; // array of size PRIORITY_COUNT
   // TODO maybe shrink this by 1? we don't need to yield prio 0 tasks
   ThreadState* thread_states; // array of size thread_count()
 

--- a/include/tmc/spawn_func.hpp
+++ b/include/tmc/spawn_func.hpp
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "tmc/detail/compat.hpp"
 #include "tmc/detail/concepts.hpp" // IWYU pragma: keep
 #include "tmc/detail/mixins.hpp"
 #include "tmc/detail/thread_locals.hpp"

--- a/include/tmc/spawn_func.hpp
+++ b/include/tmc/spawn_func.hpp
@@ -101,7 +101,7 @@ public:
 template <typename Result> class aw_spawned_func_run_early_impl {
   std::coroutine_handle<> continuation;
   tmc::detail::type_erased_executor* continuation_executor;
-  std::atomic<ssize_t> done_count;
+  std::atomic<ptrdiff_t> done_count;
 
   struct empty {};
   using ResultStorage = std::conditional_t<

--- a/include/tmc/spawn_func.hpp
+++ b/include/tmc/spawn_func.hpp
@@ -101,7 +101,7 @@ public:
 template <typename Result> class aw_spawned_func_run_early_impl {
   std::coroutine_handle<> continuation;
   tmc::detail::type_erased_executor* continuation_executor;
-  std::atomic<int64_t> done_count;
+  std::atomic<ssize_t> done_count;
 
   struct empty {};
   using ResultStorage = std::conditional_t<

--- a/include/tmc/spawn_many.hpp
+++ b/include/tmc/spawn_many.hpp
@@ -216,13 +216,13 @@ class aw_task_many_impl {
 public:
   union {
     std::coroutine_handle<> symmetric_task;
-    ssize_t remaining_count;
+    ptrdiff_t remaining_count;
   };
   std::coroutine_handle<> continuation;
   tmc::detail::type_erased_executor* continuation_executor;
   union {
-    std::atomic<ssize_t> done_count;
-    std::atomic<ssize_t> sync_flags;
+    std::atomic<ptrdiff_t> done_count;
+    std::atomic<ptrdiff_t> sync_flags;
   };
 
   struct empty {};

--- a/include/tmc/spawn_many.hpp
+++ b/include/tmc/spawn_many.hpp
@@ -784,11 +784,7 @@ public:
     // High bit is set, because we are resuming
     size_t slots = resumeState & ~tmc::detail::task_flags::EACH;
     assert(slots != 0);
-#ifdef _MSC_VER
-    size_t slot = static_cast<size_t>(_tzcnt_u64(slots));
-#else
-    size_t slot = static_cast<size_t>(__builtin_ctzll(slots));
-#endif
+    size_t slot = std::countr_zero(slots);
     --remaining_count;
     sync_flags.fetch_sub(1ULL << slot, std::memory_order_release);
     return slot;

--- a/include/tmc/spawn_many.hpp
+++ b/include/tmc/spawn_many.hpp
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "tmc/detail/compat.hpp"
 #include "tmc/detail/concepts.hpp" // IWYU pragma: keep
 #include "tmc/detail/mixins.hpp"
 #include "tmc/detail/thread_locals.hpp"
@@ -786,7 +787,7 @@ public:
     assert(slots != 0);
     size_t slot = std::countr_zero(slots);
     --remaining_count;
-    sync_flags.fetch_sub(1ULL << slot, std::memory_order_release);
+    sync_flags.fetch_sub(TMC_ONE_BIT << slot, std::memory_order_release);
     return slot;
   }
 

--- a/include/tmc/spawn_many.hpp
+++ b/include/tmc/spawn_many.hpp
@@ -238,10 +238,10 @@ public:
   friend class aw_task_many;
 
   // When each() is called, tasks are synchronized via an atomic bitmask with
-  // only 63 slots for tasks. each() doesn't seem like a good fit for larger
-  // task groups anyway. If you really need more room, please open a GitHub
-  // issue explaining why...
-  static_assert(!IsEach || Count < 64);
+  // only 63 (or 31, on 32-bit) slots for tasks. each() doesn't seem like a good
+  // fit for larger task groups anyway. If you really need more room, please
+  // open a GitHub issue explaining why...
+  static_assert(!IsEach || Count < TMC_PLATFORM_BITS);
 
   // Prepares the work item but does not initiate it.
   template <typename T>
@@ -306,8 +306,8 @@ public:
     } else {
       size = TaskCount;
       if constexpr (IsEach) {
-        if (size > 63) {
-          size = 63;
+        if (size > TMC_PLATFORM_BITS - 1) {
+          size = TMC_PLATFORM_BITS - 1;
         }
       }
       if constexpr (!std::is_void_v<Result>) {
@@ -402,8 +402,8 @@ public:
     } else {
       size = MaxCount;
       if constexpr (IsEach) {
-        if (size > 63) {
-          size = 63;
+        if (size > TMC_PLATFORM_BITS - 1) {
+          size = TMC_PLATFORM_BITS - 1;
         }
       }
       if constexpr (requires(TaskIter a, TaskIter b) { a - b; }) {

--- a/include/tmc/spawn_task.hpp
+++ b/include/tmc/spawn_task.hpp
@@ -38,7 +38,7 @@ class [[nodiscard("You must co_await aw_run_early. "
 template <typename Awaitable, typename Result> class aw_run_early_impl {
   std::coroutine_handle<> continuation;
   tmc::detail::type_erased_executor* continuation_executor;
-  std::atomic<int64_t> done_count;
+  std::atomic<ssize_t> done_count;
   tmc::detail::result_storage_t<Result> result;
 
   using AwaitableTraits = tmc::detail::get_awaitable_traits<Awaitable>;
@@ -114,7 +114,7 @@ public:
 template <typename Awaitable> class aw_run_early_impl<Awaitable, void> {
   std::coroutine_handle<> continuation;
   tmc::detail::type_erased_executor* continuation_executor;
-  std::atomic<int64_t> done_count;
+  std::atomic<ssize_t> done_count;
 
   using AwaitableTraits = tmc::detail::get_awaitable_traits<Awaitable>;
 

--- a/include/tmc/spawn_task.hpp
+++ b/include/tmc/spawn_task.hpp
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "tmc/detail/compat.hpp"
 #include "tmc/detail/concepts.hpp" // IWYU pragma: keep
 #include "tmc/detail/mixins.hpp"
 #include "tmc/detail/thread_locals.hpp"

--- a/include/tmc/spawn_task.hpp
+++ b/include/tmc/spawn_task.hpp
@@ -38,7 +38,7 @@ class [[nodiscard("You must co_await aw_run_early. "
 template <typename Awaitable, typename Result> class aw_run_early_impl {
   std::coroutine_handle<> continuation;
   tmc::detail::type_erased_executor* continuation_executor;
-  std::atomic<ssize_t> done_count;
+  std::atomic<ptrdiff_t> done_count;
   tmc::detail::result_storage_t<Result> result;
 
   using AwaitableTraits = tmc::detail::get_awaitable_traits<Awaitable>;
@@ -114,7 +114,7 @@ public:
 template <typename Awaitable> class aw_run_early_impl<Awaitable, void> {
   std::coroutine_handle<> continuation;
   tmc::detail::type_erased_executor* continuation_executor;
-  std::atomic<ssize_t> done_count;
+  std::atomic<ptrdiff_t> done_count;
 
   using AwaitableTraits = tmc::detail::get_awaitable_traits<Awaitable>;
 

--- a/include/tmc/spawn_tuple.hpp
+++ b/include/tmc/spawn_tuple.hpp
@@ -10,6 +10,7 @@
 #include "tmc/detail/thread_locals.hpp"
 #include "tmc/task.hpp"
 
+#include <bit>
 #include <cassert>
 #include <coroutine>
 #include <tuple>
@@ -389,11 +390,7 @@ public:
     // High bit is set, because we are resuming
     size_t slots = resumeState & ~tmc::detail::task_flags::EACH;
     assert(slots != 0);
-#ifdef _MSC_VER
-    size_t slot = static_cast<size_t>(_tzcnt_u64(slots));
-#else
-    size_t slot = static_cast<size_t>(__builtin_ctzll(slots));
-#endif
+    size_t slot = std::countr_zero(slots);
     --remaining_count;
     sync_flags.fetch_sub(1ULL << slot, std::memory_order_release);
     return slot;

--- a/include/tmc/spawn_tuple.hpp
+++ b/include/tmc/spawn_tuple.hpp
@@ -103,13 +103,13 @@ template <bool IsEach, typename... Awaitable> class aw_spawned_task_tuple_impl {
 
   union {
     std::coroutine_handle<> symmetric_task;
-    int64_t remaining_count;
+    ssize_t remaining_count;
   };
   std::coroutine_handle<> continuation;
   tmc::detail::type_erased_executor* continuation_executor;
   union {
-    std::atomic<int64_t> done_count;
-    std::atomic<uint64_t> sync_flags;
+    std::atomic<ssize_t> done_count;
+    std::atomic<size_t> sync_flags;
   };
 
   template <typename T>
@@ -384,10 +384,10 @@ public:
     if (remaining_count == 0) {
       return end();
     }
-    uint64_t resumeState = sync_flags.load(std::memory_order_acquire);
+    size_t resumeState = sync_flags.load(std::memory_order_acquire);
     assert((resumeState & tmc::detail::task_flags::EACH) != 0);
     // High bit is set, because we are resuming
-    uint64_t slots = resumeState & ~tmc::detail::task_flags::EACH;
+    size_t slots = resumeState & ~tmc::detail::task_flags::EACH;
     assert(slots != 0);
 #ifdef _MSC_VER
     size_t slot = static_cast<size_t>(_tzcnt_u64(slots));

--- a/include/tmc/spawn_tuple.hpp
+++ b/include/tmc/spawn_tuple.hpp
@@ -104,12 +104,12 @@ template <bool IsEach, typename... Awaitable> class aw_spawned_task_tuple_impl {
 
   union {
     std::coroutine_handle<> symmetric_task;
-    ssize_t remaining_count;
+    ptrdiff_t remaining_count;
   };
   std::coroutine_handle<> continuation;
   tmc::detail::type_erased_executor* continuation_executor;
   union {
-    std::atomic<ssize_t> done_count;
+    std::atomic<ptrdiff_t> done_count;
     std::atomic<size_t> sync_flags;
   };
 

--- a/include/tmc/spawn_tuple.hpp
+++ b/include/tmc/spawn_tuple.hpp
@@ -99,6 +99,12 @@ template <typename... Result> class aw_spawned_task_tuple;
 template <bool IsEach, typename... Awaitable> class aw_spawned_task_tuple_impl {
   static constexpr auto Count = sizeof...(Awaitable);
 
+  // When each() is called, tasks are synchronized via an atomic bitmask with
+  // only 63 (or 31, on 32-bit) slots for tasks. each() doesn't seem like a
+  // good fit for larger task groups anyway. If you really need more room,
+  // please open a GitHub issue explaining why...
+  static_assert(!IsEach || Count < TMC_PLATFORM_BITS);
+
   static constexpr size_t WorkItemCount =
     std::tuple_size_v<typename tmc::detail::predicate_partition<
       tmc::detail::treat_as_coroutine, std::tuple, Awaitable...>::true_types>;

--- a/include/tmc/spawn_tuple.hpp
+++ b/include/tmc/spawn_tuple.hpp
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "tmc/detail/compat.hpp"
 #include "tmc/detail/concepts.hpp" // IWYU pragma: keep
 #include "tmc/detail/mixins.hpp"
 #include "tmc/detail/thread_locals.hpp"
@@ -392,7 +393,7 @@ public:
     assert(slots != 0);
     size_t slot = std::countr_zero(slots);
     --remaining_count;
-    sync_flags.fetch_sub(1ULL << slot, std::memory_order_release);
+    sync_flags.fetch_sub(TMC_ONE_BIT << slot, std::memory_order_release);
     return slot;
   }
 

--- a/include/tmc/sync.hpp
+++ b/include/tmc/sync.hpp
@@ -132,7 +132,7 @@ post_bulk_waitable(E& Executor, TaskIter&& Begin, size_t Count, size_t Priority)
 {
   struct BulkSyncState {
     std::promise<void> promise;
-    std::atomic<ssize_t> done_count;
+    std::atomic<ptrdiff_t> done_count;
     std::coroutine_handle<> continuation;
     tmc::detail::type_erased_executor* continuation_executor;
   };
@@ -195,7 +195,7 @@ post_bulk_waitable(E& Executor, FuncIter&& Begin, size_t Count, size_t Priority)
 {
   struct BulkSyncState {
     std::promise<void> promise;
-    std::atomic<ssize_t> done_count;
+    std::atomic<ptrdiff_t> done_count;
   };
   std::shared_ptr<BulkSyncState> sharedState =
     std::make_shared<BulkSyncState>(std::promise<void>(), Count - 1);

--- a/include/tmc/sync.hpp
+++ b/include/tmc/sync.hpp
@@ -132,7 +132,7 @@ post_bulk_waitable(E& Executor, TaskIter&& Begin, size_t Count, size_t Priority)
 {
   struct BulkSyncState {
     std::promise<void> promise;
-    std::atomic<int64_t> done_count;
+    std::atomic<ssize_t> done_count;
     std::coroutine_handle<> continuation;
     tmc::detail::type_erased_executor* continuation_executor;
   };
@@ -195,7 +195,7 @@ post_bulk_waitable(E& Executor, FuncIter&& Begin, size_t Count, size_t Priority)
 {
   struct BulkSyncState {
     std::promise<void> promise;
-    std::atomic<int64_t> done_count;
+    std::atomic<ssize_t> done_count;
   };
   std::shared_ptr<BulkSyncState> sharedState =
     std::make_shared<BulkSyncState>(std::promise<void>(), Count - 1);

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -96,7 +96,7 @@ struct awaitable_customizer_base {
         // task is part of a spawn_many group, or run_early
         // continuation is a std::coroutine_handle<>*
         // continuation_executor is a tmc::detail::type_erased_executor**
-        shouldResume = static_cast<std::atomic<ssize_t>*>(done_count)
+        shouldResume = static_cast<std::atomic<ptrdiff_t>*>(done_count)
                          ->fetch_sub(1, std::memory_order_acq_rel) == 0;
       }
       if (shouldResume) {

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -56,6 +56,8 @@ struct awaitable_customizer_base {
   static_assert(alignof(void*) == alignof(std::coroutine_handle<>));
   static_assert(std::is_trivially_copyable_v<std::coroutine_handle<>>);
   static_assert(std::is_trivially_destructible_v<std::coroutine_handle<>>);
+  static_assert(sizeof(void*) == sizeof(ptrdiff_t));
+  static_assert(sizeof(ptrdiff_t) == sizeof(size_t));
 
   awaitable_customizer_base()
       : continuation{nullptr}, continuation_executor{this_thread::executor},


### PR DESCRIPTION
Support 32-bit processors. No special compile flag is needed; automatically sized types (size_t / ptrdiff_t) are used.

Limitations of 32 bit support are as follows:
- limited to 32 threads
- limited to 31 elements with [spawn_many().each()](https://www.fleetcode.com/oss/tmc/docs/v0.1.0/awaitables/spawn_many.html#each) and [spawn_tuple().each()](https://www.fleetcode.com/oss/tmc/docs/v0.1.0/awaitables/spawn_tuple.html#each)
- [-DTMC_WORK_ITEM=FUNCORO](https://www.fleetcode.com/oss/tmc/docs/v0.1.0/build_flags.html#_CPPv4N3tmc12coro_functorE) is not a valid option as this type depends on pointer tagging and there aren't any free bits in a 32-bit pointer

------------------------

Move all platform / compiler compatibility definitions from `detail/thread_locals.hpp` to `detail/compat.hpp`. Improve cpu type checks (detect i386 / arm32).

Replacements:
- `uint64_t` -> `size_t`
- `int64_t` -> `ptrdiff_t`
- `1ULL` -> `TMC_ONE_BIT`
- `-1ULL` -> `TMC_ALL_ONES`
- `_mm_pause` -> `TMC_CPU_PAUSE`
- `__builtin_popcountll` -> `std::popcount`
- `__builtin_ctzll` -> `std::countr_zero` :'(
- `64` -> `TMC_PLATFORM_BITS`

Removed:
- `ConcurrentQueue::BLOCK_EMPTY_INTERLEAVING` : an old experiment that did not affect performance
- static_assert in tiny_vec : unnecessary

Added:
- static_assert in spawn_tuple().each() : this was missing
- static_assert in task : sizeof(void*) == sizeof(ptrdiff_t) == sizeof(size_t) or else bad things will happen

Add GH Actions for x86-linux with reduced matrix size.