### PR TITLE
Workqueue fixes

### DIFF
--- a/include/tmc/detail/ex_braid.ipp
+++ b/include/tmc/detail/ex_braid.ipp
@@ -37,7 +37,7 @@ tmc::task<void> ex_braid::try_run_loop(
       thread_exit_context();
     }
     ThisBraidLock->unlock();
-    tmc::detail::memory_barrier();
+    tmc::detail::memory_barrier(); // pairs with barrier in post_runloop_task
     // check queue again after unlocking to prevent missing work items
   } while (!queue.empty());
 }
@@ -76,7 +76,8 @@ void ex_braid::post_runloop_task(size_t Priority) {
 
   // This is always called after an enqueue. Make sure that the queue store
   // is globally visible before checking if someone has the lock.
-  tmc::detail::memory_barrier();
+  tmc::detail::memory_barrier(); // pairs with barrier in try_run_loop
+
   // If someone already has the lock, we don't need to post, as they will see
   // this item in queue.
   if (!lock->is_locked()) {

--- a/include/tmc/detail/ex_cpu.ipp
+++ b/include/tmc/detail/ex_cpu.ipp
@@ -16,6 +16,7 @@
 
 namespace tmc {
 void ex_cpu::notify_n(size_t Count, size_t Priority) {
+  tmc::detail::memory_barrier(); // pairs with barrier in try_run_some
   // TODO set notified threads prev_prod (index 1) to this?
   size_t workingThreadCount =
     std::popcount(working_threads_bitset.load(std::memory_order_acquire));
@@ -405,6 +406,8 @@ void ex_cpu::init() {
             // no waiting or in progress work found. wait until a task is
             // ready
             working_threads_bitset.fetch_and(~(TMC_ONE_BIT << slot));
+
+            tmc::detail::memory_barrier(); // pairs with barrier in notify_n
 
 #ifdef TMC_PRIORITY_COUNT
             if constexpr (PRIORITY_COUNT > 1)

--- a/include/tmc/detail/ex_cpu.ipp
+++ b/include/tmc/detail/ex_cpu.ipp
@@ -228,7 +228,11 @@ bool ex_cpu::try_run_some(
 
 void ex_cpu::post(work_item&& Item, size_t Priority) {
   assert(Priority < PRIORITY_COUNT);
-  work_queues[Priority].enqueue_ex_cpu(std::move(Item), Priority);
+  if (tmc::detail::this_thread::executor == &type_erased_this) {
+    work_queues[Priority].enqueue_ex_cpu(std::move(Item), Priority);
+  } else {
+    work_queues[Priority].enqueue(std::move(Item));
+  }
   notify_n(1, Priority);
 }
 

--- a/include/tmc/detail/qu_lockfree.hpp
+++ b/include/tmc/detail/qu_lockfree.hpp
@@ -1120,33 +1120,19 @@ public:
   inline bool enqueue_ex_cpu(T const& item, size_t priority) {
     ExplicitProducer** producers =
       static_cast<ExplicitProducer**>(tmc::detail::this_thread::producers);
-    if (producers != nullptr) {
-      ExplicitProducer* this_thread_prod = static_cast<ExplicitProducer*>(
-        producers[priority * dequeueProducerCount]
+    ExplicitProducer* this_thread_prod =
+      static_cast<ExplicitProducer*>(producers[priority * dequeueProducerCount]
       );
-      return this_thread_prod->template enqueue<CanAlloc>(item);
-    }
-
-    if constexpr (INITIAL_IMPLICIT_PRODUCER_HASH_SIZE == 0) {
-      return false;
-    }
-    return inner_enqueue<CanAlloc>(item);
+    return this_thread_prod->template enqueue<CanAlloc>(item);
   }
 
   inline bool enqueue_ex_cpu(T&& item, size_t priority) {
     ExplicitProducer** producers =
       static_cast<ExplicitProducer**>(tmc::detail::this_thread::producers);
-    if (producers != nullptr) {
-      ExplicitProducer* this_thread_prod = static_cast<ExplicitProducer*>(
-        producers[priority * dequeueProducerCount]
+    ExplicitProducer* this_thread_prod =
+      static_cast<ExplicitProducer*>(producers[priority * dequeueProducerCount]
       );
-      return this_thread_prod->template enqueue<CanAlloc>(static_cast<T&&>(item)
-      );
-    }
-
-    if constexpr (INITIAL_IMPLICIT_PRODUCER_HASH_SIZE == 0)
-      return false;
-    return inner_enqueue<CanAlloc>(static_cast<T&&>(item));
+    return this_thread_prod->template enqueue<CanAlloc>(static_cast<T&&>(item));
   }
 
   // Enqueues a single item (by copying it) using an explicit producer token.

--- a/include/tmc/ex_cpu.hpp
+++ b/include/tmc/ex_cpu.hpp
@@ -166,9 +166,13 @@ public:
   template <typename It>
   void post_bulk(It&& Items, size_t Count, size_t Priority) {
     assert(Priority < PRIORITY_COUNT);
-    work_queues[Priority].enqueue_bulk_ex_cpu(
-      std::forward<It>(Items), Count, Priority
-    );
+    if (tmc::detail::this_thread::executor == &type_erased_this) {
+      work_queues[Priority].enqueue_bulk_ex_cpu(
+        std::forward<It>(Items), Count, Priority
+      );
+    } else {
+      work_queues[Priority].enqueue_bulk(std::forward<It>(Items), Count);
+    }
     notify_n(Count, Priority);
   }
 };


### PR DESCRIPTION
- Properly detect when one ex_cpu cross-posts to another ex_cpu.

- Use a memory barrier to establish a total ordering between enqueuing and dequeuing threads, which prevents lost wakeups:

Thread 1:
Indicates it's going to sleep
-- barrier --
Checks if queue is empty

Thread 2:
Adds item to queue
-- barrier --
Checks if threads are sleeping

This had already been applied in ex_braid but is now also applied in ex_cpu. The performance impact has been observed to be small (~2%).