### PR TITLE
qu_lockfree improvements

### DIFF
--- a/include/tmc/detail/ex_cpu.ipp
+++ b/include/tmc/detail/ex_cpu.ipp
@@ -56,7 +56,7 @@ void ex_cpu::notify_n(
 ) {
   size_t spinningThreads;
   size_t workingThreads;
-  if (ThreadHint != NO_HINT) {
+  if (ThreadHint < thread_count()) {
     size_t* neighbors = wake_nearby_thread_order(ThreadHint);
     size_t groupSize = thread_states[ThreadHint].group_size;
     for (size_t i = 0; i < groupSize; ++i) {
@@ -314,7 +314,7 @@ bool ex_cpu::try_run_some(
 void ex_cpu::post(work_item&& Item, size_t Priority, size_t ThreadHint) {
   assert(Priority < PRIORITY_COUNT);
   bool fromExecThread = tmc::detail::this_thread::executor == &type_erased_this;
-  if (ThreadHint != NO_HINT) {
+  if (ThreadHint < thread_count()) {
     if (thread_states[ThreadHint].inbox->try_push(std::move(Item))) {
       if (ThreadHint != tmc::current_thread_index()) {
         notify_n(1, Priority, ThreadHint, fromExecThread, true);

--- a/include/tmc/ex_cpu.hpp
+++ b/include/tmc/ex_cpu.hpp
@@ -202,7 +202,7 @@ public:
     assert(Priority < PRIORITY_COUNT);
     bool fromExecThread =
       tmc::detail::this_thread::executor == &type_erased_this;
-    if (ThreadHint != NO_HINT) {
+    if (ThreadHint < thread_count()) {
       size_t enqueuedCount =
         thread_states[ThreadHint].inbox->try_push_bulk(Items, Count);
       if (enqueuedCount != 0) {


### PR DESCRIPTION
Fixed a TSan false positive - this also is a minor performance enhancement since it's not necessary to overwrite the same data.

Removed some redundant code in dequeue_lifo - given that we had `assert(block == tailBlock);` at the end, we can work backward from that assumption and remove some unnecessary calculations. Also, replaced atomic operations with no memory order (default seq_cst) with appropriate memory orders.

Overall this yields a nice ~2-3% performance improvement on high load benchmarks. This counteracts the small performance loss introduced by the previous PR (the overhead of checking the usually empty private work queue).