### PR TITLE
add ASan, TSan, UBSan CI workflows

### DIFF
--- a/.github/workflows/x64-linux-clang-asan.yml
+++ b/.github/workflows/x64-linux-clang-asan.yml
@@ -1,4 +1,4 @@
-name: x64-linux-clang-asan
+name: AddressSanitizer
 
 on:
   push:

--- a/.github/workflows/x64-linux-clang-asan.yml
+++ b/.github/workflows/x64-linux-clang-asan.yml
@@ -1,0 +1,44 @@
+name: x64-linux-clang-asan
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        PRESET: [clang-linux-debug]
+        WORK_ITEM: [CORO]
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        repository: tzcnt/tmc-examples
+        ref: main
+    - name: branch-examples
+      continue-on-error: true
+      run: git fetch && git checkout ${{env.BRANCH_NAME}}
+    - name: submodule-clone
+      run: >
+        cd submodules
+        && git clone https://github.com/tzcnt/TooManyCooks.git
+        && git clone https://github.com/tzcnt/tmc-asio.git
+    # If a branch with the same name exists in the dependency repos, use that. Otherwise, use main.
+    - name: submodule-branch-TMC
+      # continue-on-error: true # this should never fail if triggered from TMC workflow
+      run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
+    - name: submodule-branch-tmc-asio
+      continue-on-error: true
+      run: cd submodules/tmc-asio && git fetch && git checkout ${{env.BRANCH_NAME}}
+    - name: configure
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DCMD_COMPILE_FLAGS='-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}};-fsanitize=address' -DCMD_LINK_FLAGS='-fsanitize=address' --preset ${{matrix.PRESET}} .
+    - name: build
+      run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
+    - name: run tests
+      run: ASAN_OPTIONS="detect_leaks=1" ./build/${{matrix.PRESET}}/tests/tests

--- a/.github/workflows/x64-linux-clang-tsan.yml
+++ b/.github/workflows/x64-linux-clang-tsan.yml
@@ -1,4 +1,4 @@
-name: x64-linux-clang-tsan
+name: ThreadSanitizer
 
 on:
   push:

--- a/.github/workflows/x64-linux-clang-tsan.yml
+++ b/.github/workflows/x64-linux-clang-tsan.yml
@@ -1,0 +1,44 @@
+name: x64-linux-clang-tsan
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        PRESET: [clang-linux-debug]
+        WORK_ITEM: [CORO]
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        repository: tzcnt/tmc-examples
+        ref: main
+    - name: branch-examples
+      continue-on-error: true
+      run: git fetch && git checkout ${{env.BRANCH_NAME}}
+    - name: submodule-clone
+      run: >
+        cd submodules
+        && git clone https://github.com/tzcnt/TooManyCooks.git
+        && git clone https://github.com/tzcnt/tmc-asio.git
+    # If a branch with the same name exists in the dependency repos, use that. Otherwise, use main.
+    - name: submodule-branch-TMC
+      # continue-on-error: true # this should never fail if triggered from TMC workflow
+      run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
+    - name: submodule-branch-tmc-asio
+      continue-on-error: true
+      run: cd submodules/tmc-asio && git fetch && git checkout ${{env.BRANCH_NAME}}
+    - name: configure
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DCMD_COMPILE_FLAGS='-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}};-fsanitize=thread' -DCMD_LINK_FLAGS='-fsanitize=thread' --preset ${{matrix.PRESET}} .
+    - name: build
+      run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
+    - name: run tests
+      run: TSAN_OPTIONS="halt_on_error=1" ./build/${{matrix.PRESET}}/tests/tests

--- a/.github/workflows/x64-linux-clang-ubsan.yml
+++ b/.github/workflows/x64-linux-clang-ubsan.yml
@@ -1,4 +1,4 @@
-name: x64-linux-clang-ubsan
+name: UndefinedBehaviorSanitizer
 
 on:
   push:

--- a/.github/workflows/x64-linux-clang-ubsan.yml
+++ b/.github/workflows/x64-linux-clang-ubsan.yml
@@ -1,0 +1,44 @@
+name: x64-linux-clang-ubsan
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        PRESET: [clang-linux-debug]
+        WORK_ITEM: [CORO]
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        repository: tzcnt/tmc-examples
+        ref: main
+    - name: branch-examples
+      continue-on-error: true
+      run: git fetch && git checkout ${{env.BRANCH_NAME}}
+    - name: submodule-clone
+      run: >
+        cd submodules
+        && git clone https://github.com/tzcnt/TooManyCooks.git
+        && git clone https://github.com/tzcnt/tmc-asio.git
+    # If a branch with the same name exists in the dependency repos, use that. Otherwise, use main.
+    - name: submodule-branch-TMC
+      # continue-on-error: true # this should never fail if triggered from TMC workflow
+      run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
+    - name: submodule-branch-tmc-asio
+      continue-on-error: true
+      run: cd submodules/tmc-asio && git fetch && git checkout ${{env.BRANCH_NAME}}
+    - name: configure
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DCMD_COMPILE_FLAGS='-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}};-fsanitize=undefined;-fno-sanitize-recover' -DCMD_LINK_FLAGS='-fsanitize=undefined' --preset ${{matrix.PRESET}} .
+    - name: build
+      run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
+    - name: run tests
+      run: ./build/${{matrix.PRESET}}/tests/tests

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 ![x64-linux-gcc](https://github.com/tzcnt/TooManyCooks/actions/workflows/x64-linux-gcc.yml/badge.svg) ![x64-linux-clang](https://github.com/tzcnt/TooManyCooks/actions/workflows/x64-linux-clang.yml/badge.svg) ![x64-windows-clang-cl](https://github.com/tzcnt/TooManyCooks/actions/workflows/x64-windows-clang-cl.yml/badge.svg) ![arm64-macos-clang](https://github.com/tzcnt/TooManyCooks/actions/workflows/arm64-macos-clang.yml/badge.svg)
 
+![AddressSanitizer](https://github.com/tzcnt/TooManyCooks/actions/workflows/x64-linux-clang-asan.yml/badge.svg) ![ThreadSanitizer](https://github.com/tzcnt/TooManyCooks/actions/workflows/x64-linux-clang-tsan.yml/badge.svg) ![UndefinedBehaviorSanitizer](https://github.com/tzcnt/TooManyCooks/actions/workflows/x64-linux-clang-ubsan.yml/badge.svg)
+
+
 ## TooManyCooks
 TooManyCooks is a runtime and concurrency library for C++20 coroutines. Its goals:
 - be the fastest general-purpose coroutine library available


### PR DESCRIPTION
Run the test suite under each of Address Sanitizer, Thread Sanitizer, and Undefined Behavior Sanitizer in GitHub actions.

There are TSan failures only in a single file ([test_nested_executors.ipp](https://github.com/tzcnt/tmc-examples/blob/3e91b6bd499dd87bd761d4a6f97a6ec7b92ee0cf/tests/test_nested_executors.ipp)) - which I believe to be all the same kind of false positive. I've left more detail in the comments in that file, but for now have disabled those tests under TSan.