### PR TITLE
Rename `tmc::detail::type_erased_executor` to `tmc::ex_any`

### DIFF
--- a/include/tmc/aw_resume_on.hpp
+++ b/include/tmc/aw_resume_on.hpp
@@ -15,13 +15,13 @@ namespace tmc {
 /// The awaitable type returned by `tmc::resume_on()`.
 class [[nodiscard("You must co_await aw_resume_on for it to have any "
                   "effect.")]] aw_resume_on : tmc::detail::AwaitTagNoGroupAsIs {
-  tmc::detail::ex_any* executor;
+  tmc::ex_any* executor;
   size_t prio;
 
 public:
   /// It is recommended to call `resume_on()` instead of using this constructor
   /// directly.
-  aw_resume_on(tmc::detail::ex_any* Executor)
+  aw_resume_on(tmc::ex_any* Executor)
       : executor(Executor), prio(tmc::detail::this_thread::this_task.prio) {}
 
   /// Resume immediately if outer is already running on the requested executor,
@@ -58,7 +58,7 @@ public:
 /// Returns an awaitable that moves this task onto the requested executor. If
 /// this task is already running on the requested executor, the co_await will do
 /// nothing.
-inline aw_resume_on resume_on(tmc::detail::ex_any* Executor) {
+inline aw_resume_on resume_on(tmc::ex_any* Executor) {
   return aw_resume_on(Executor);
 }
 
@@ -91,10 +91,10 @@ template <typename E> inline aw_ex_scope_enter<E> enter(E* Executor);
 template <typename E>
 class aw_ex_scope_exit : tmc::detail::AwaitTagNoGroupAsIs {
   friend class aw_ex_scope_enter<E>;
-  tmc::detail::ex_any* continuation_executor;
+  tmc::ex_any* continuation_executor;
   size_t prio;
 
-  aw_ex_scope_exit(tmc::detail::ex_any* Executor, size_t Priority)
+  aw_ex_scope_exit(tmc::ex_any* Executor, size_t Priority)
       : continuation_executor(Executor), prio(Priority) {}
 
 public:
@@ -125,7 +125,7 @@ public:
 
   /// When awaited, the outer coroutine will be resumed on the provided
   /// executor.
-  inline aw_ex_scope_exit& resume_on(tmc::detail::ex_any* Executor) {
+  inline aw_ex_scope_exit& resume_on(tmc::ex_any* Executor) {
     continuation_executor = Executor;
     return *this;
   }
@@ -159,7 +159,7 @@ class [[nodiscard("You must co_await aw_ex_scope_enter for it to have any "
   friend aw_ex_scope_enter<E> enter<E>(E&);
   friend aw_ex_scope_enter<E> enter<E>(E*);
   E& scope_executor;
-  tmc::detail::ex_any* continuation_executor;
+  tmc::ex_any* continuation_executor;
   size_t prio;
   aw_ex_scope_enter(E& Executor)
       : scope_executor(Executor),

--- a/include/tmc/aw_resume_on.hpp
+++ b/include/tmc/aw_resume_on.hpp
@@ -15,13 +15,13 @@ namespace tmc {
 /// The awaitable type returned by `tmc::resume_on()`.
 class [[nodiscard("You must co_await aw_resume_on for it to have any "
                   "effect.")]] aw_resume_on : tmc::detail::AwaitTagNoGroupAsIs {
-  tmc::detail::type_erased_executor* executor;
+  tmc::detail::ex_any* executor;
   size_t prio;
 
 public:
   /// It is recommended to call `resume_on()` instead of using this constructor
   /// directly.
-  aw_resume_on(tmc::detail::type_erased_executor* Executor)
+  aw_resume_on(tmc::detail::ex_any* Executor)
       : executor(Executor), prio(tmc::detail::this_thread::this_task.prio) {}
 
   /// Resume immediately if outer is already running on the requested executor,
@@ -58,7 +58,7 @@ public:
 /// Returns an awaitable that moves this task onto the requested executor. If
 /// this task is already running on the requested executor, the co_await will do
 /// nothing.
-inline aw_resume_on resume_on(tmc::detail::type_erased_executor* Executor) {
+inline aw_resume_on resume_on(tmc::detail::ex_any* Executor) {
   return aw_resume_on(Executor);
 }
 
@@ -91,10 +91,10 @@ template <typename E> inline aw_ex_scope_enter<E> enter(E* Executor);
 template <typename E>
 class aw_ex_scope_exit : tmc::detail::AwaitTagNoGroupAsIs {
   friend class aw_ex_scope_enter<E>;
-  tmc::detail::type_erased_executor* continuation_executor;
+  tmc::detail::ex_any* continuation_executor;
   size_t prio;
 
-  aw_ex_scope_exit(tmc::detail::type_erased_executor* Executor, size_t Priority)
+  aw_ex_scope_exit(tmc::detail::ex_any* Executor, size_t Priority)
       : continuation_executor(Executor), prio(Priority) {}
 
 public:
@@ -125,8 +125,7 @@ public:
 
   /// When awaited, the outer coroutine will be resumed on the provided
   /// executor.
-  inline aw_ex_scope_exit& resume_on(tmc::detail::type_erased_executor* Executor
-  ) {
+  inline aw_ex_scope_exit& resume_on(tmc::detail::ex_any* Executor) {
     continuation_executor = Executor;
     return *this;
   }
@@ -160,7 +159,7 @@ class [[nodiscard("You must co_await aw_ex_scope_enter for it to have any "
   friend aw_ex_scope_enter<E> enter<E>(E&);
   friend aw_ex_scope_enter<E> enter<E>(E*);
   E& scope_executor;
-  tmc::detail::type_erased_executor* continuation_executor;
+  tmc::detail::ex_any* continuation_executor;
   size_t prio;
   aw_ex_scope_enter(E& Executor)
       : scope_executor(Executor),

--- a/include/tmc/channel.hpp
+++ b/include/tmc/channel.hpp
@@ -1092,7 +1092,7 @@ public:
       element* elem;
       size_t release_idx;
       bool ok;
-      tmc::detail::type_erased_executor* continuation_executor;
+      tmc::detail::ex_any* continuation_executor;
       std::coroutine_handle<> continuation;
       size_t prio;
       tmc::detail::channel_storage<T> t;

--- a/include/tmc/channel.hpp
+++ b/include/tmc/channel.hpp
@@ -1092,7 +1092,7 @@ public:
       element* elem;
       size_t release_idx;
       bool ok;
-      tmc::detail::ex_any* continuation_executor;
+      tmc::ex_any* continuation_executor;
       std::coroutine_handle<> continuation;
       size_t prio;
       tmc::detail::channel_storage<T> t;

--- a/include/tmc/detail/concepts.hpp
+++ b/include/tmc/detail/concepts.hpp
@@ -121,7 +121,7 @@ static constexpr configure_mode mode = COROUTINE;
 
 static constexpr configure_mode mode = ASYNC_INITIATE;
 static void async_initiate(
-  Awaitable&& YourAwaitable, tmc::detail::type_erased_executor* Executor,
+  Awaitable&& YourAwaitable, tmc::detail::ex_any* Executor,
   size_t Priority
 ) {}
 

--- a/include/tmc/detail/concepts.hpp
+++ b/include/tmc/detail/concepts.hpp
@@ -121,7 +121,7 @@ static constexpr configure_mode mode = COROUTINE;
 
 static constexpr configure_mode mode = ASYNC_INITIATE;
 static void async_initiate(
-  Awaitable&& YourAwaitable, tmc::detail::ex_any* Executor,
+  Awaitable&& YourAwaitable, tmc::ex_any* Executor,
   size_t Priority
 ) {}
 

--- a/include/tmc/detail/ex_braid.ipp
+++ b/include/tmc/detail/ex_braid.ipp
@@ -91,7 +91,7 @@ void ex_braid::post_runloop_task(size_t Priority) {
   }
 }
 
-ex_braid::ex_braid(tmc::detail::ex_any* Parent)
+ex_braid::ex_braid(tmc::ex_any* Parent)
     : queue(1), lock{std::make_shared<tiny_lock>()},
       destroyed_by_this_thread{new bool(false)}, type_erased_this(this),
       parent_executor(Parent) {
@@ -143,8 +143,7 @@ void executor_traits<tmc::ex_braid>::post(
   ex.post(std::move(Item), Priority, ThreadHint);
 }
 
-tmc::detail::ex_any*
-executor_traits<tmc::ex_braid>::type_erased(tmc::ex_braid& ex) {
+tmc::ex_any* executor_traits<tmc::ex_braid>::type_erased(tmc::ex_braid& ex) {
   return ex.type_erased();
 }
 

--- a/include/tmc/detail/ex_braid.ipp
+++ b/include/tmc/detail/ex_braid.ipp
@@ -91,7 +91,7 @@ void ex_braid::post_runloop_task(size_t Priority) {
   }
 }
 
-ex_braid::ex_braid(tmc::detail::type_erased_executor* Parent)
+ex_braid::ex_braid(tmc::detail::ex_any* Parent)
     : queue(1), lock{std::make_shared<tiny_lock>()},
       destroyed_by_this_thread{new bool(false)}, type_erased_this(this),
       parent_executor(Parent) {
@@ -143,7 +143,7 @@ void executor_traits<tmc::ex_braid>::post(
   ex.post(std::move(Item), Priority, ThreadHint);
 }
 
-tmc::detail::type_erased_executor*
+tmc::detail::ex_any*
 executor_traits<tmc::ex_braid>::type_erased(tmc::ex_braid& ex) {
   return ex.type_erased();
 }

--- a/include/tmc/detail/ex_cpu.ipp
+++ b/include/tmc/detail/ex_cpu.ipp
@@ -332,9 +332,7 @@ void ex_cpu::post(work_item&& Item, size_t Priority, size_t ThreadHint) {
   notify_n(1, Priority, NO_HINT, fromExecThread, true);
 }
 
-tmc::detail::type_erased_executor* ex_cpu::type_erased() {
-  return &type_erased_this;
-}
+tmc::detail::ex_any* ex_cpu::type_erased() { return &type_erased_this; }
 
 // Default constructor does not call init() - you need to do it afterward
 ex_cpu::ex_cpu()
@@ -702,8 +700,8 @@ void executor_traits<tmc::ex_cpu>::post(
   ex.post(std::move(Item), Priority, ThreadHint);
 }
 
-tmc::detail::type_erased_executor*
-executor_traits<tmc::ex_cpu>::type_erased(tmc::ex_cpu& ex) {
+tmc::detail::ex_any* executor_traits<tmc::ex_cpu>::type_erased(tmc::ex_cpu& ex
+) {
   return ex.type_erased();
 }
 

--- a/include/tmc/detail/ex_cpu.ipp
+++ b/include/tmc/detail/ex_cpu.ipp
@@ -332,7 +332,7 @@ void ex_cpu::post(work_item&& Item, size_t Priority, size_t ThreadHint) {
   notify_n(1, Priority, NO_HINT, fromExecThread, true);
 }
 
-tmc::detail::ex_any* ex_cpu::type_erased() { return &type_erased_this; }
+tmc::ex_any* ex_cpu::type_erased() { return &type_erased_this; }
 
 // Default constructor does not call init() - you need to do it afterward
 ex_cpu::ex_cpu()
@@ -700,8 +700,7 @@ void executor_traits<tmc::ex_cpu>::post(
   ex.post(std::move(Item), Priority, ThreadHint);
 }
 
-tmc::detail::ex_any* executor_traits<tmc::ex_cpu>::type_erased(tmc::ex_cpu& ex
-) {
+tmc::ex_any* executor_traits<tmc::ex_cpu>::type_erased(tmc::ex_cpu& ex) {
   return ex.type_erased();
 }
 

--- a/include/tmc/detail/mixins.hpp
+++ b/include/tmc/detail/mixins.hpp
@@ -16,8 +16,7 @@ namespace detail {
 template <typename Derived> class run_on_mixin {
 public:
   /// The wrapped task will run on the provided executor.
-  [[nodiscard]] inline Derived&
-  run_on(tmc::detail::type_erased_executor* Executor) & {
+  [[nodiscard]] inline Derived& run_on(tmc::detail::ex_any* Executor) & {
     static_cast<Derived*>(this)->executor = Executor;
     return static_cast<Derived&>(*this);
   }
@@ -35,8 +34,7 @@ public:
   }
 
   /// The wrapped task will run on the provided executor.
-  [[nodiscard]] inline Derived&&
-  run_on(tmc::detail::type_erased_executor* Executor) && {
+  [[nodiscard]] inline Derived&& run_on(tmc::detail::ex_any* Executor) && {
     static_cast<Derived*>(this)->executor = Executor;
     return static_cast<Derived&&>(*this);
   }
@@ -57,8 +55,7 @@ public:
 template <typename Derived> class resume_on_mixin {
 public:
   /// The wrapped task will run on the provided executor.
-  [[nodiscard]] inline Derived&
-  resume_on(tmc::detail::type_erased_executor* Executor) & {
+  [[nodiscard]] inline Derived& resume_on(tmc::detail::ex_any* Executor) & {
     static_cast<Derived*>(this)->continuation_executor = Executor;
     return static_cast<Derived&>(*this);
   }
@@ -76,8 +73,7 @@ public:
   }
 
   /// The wrapped task will run on the provided executor.
-  [[nodiscard]] inline Derived&&
-  resume_on(tmc::detail::type_erased_executor* Executor) && {
+  [[nodiscard]] inline Derived&& resume_on(tmc::detail::ex_any* Executor) && {
     static_cast<Derived*>(this)->continuation_executor = Executor;
     return static_cast<Derived&&>(*this);
   }

--- a/include/tmc/detail/mixins.hpp
+++ b/include/tmc/detail/mixins.hpp
@@ -16,7 +16,7 @@ namespace detail {
 template <typename Derived> class run_on_mixin {
 public:
   /// The wrapped task will run on the provided executor.
-  [[nodiscard]] inline Derived& run_on(tmc::detail::ex_any* Executor) & {
+  [[nodiscard]] inline Derived& run_on(tmc::ex_any* Executor) & {
     static_cast<Derived*>(this)->executor = Executor;
     return static_cast<Derived&>(*this);
   }
@@ -34,7 +34,7 @@ public:
   }
 
   /// The wrapped task will run on the provided executor.
-  [[nodiscard]] inline Derived&& run_on(tmc::detail::ex_any* Executor) && {
+  [[nodiscard]] inline Derived&& run_on(tmc::ex_any* Executor) && {
     static_cast<Derived*>(this)->executor = Executor;
     return static_cast<Derived&&>(*this);
   }
@@ -55,7 +55,7 @@ public:
 template <typename Derived> class resume_on_mixin {
 public:
   /// The wrapped task will run on the provided executor.
-  [[nodiscard]] inline Derived& resume_on(tmc::detail::ex_any* Executor) & {
+  [[nodiscard]] inline Derived& resume_on(tmc::ex_any* Executor) & {
     static_cast<Derived*>(this)->continuation_executor = Executor;
     return static_cast<Derived&>(*this);
   }
@@ -73,7 +73,7 @@ public:
   }
 
   /// The wrapped task will run on the provided executor.
-  [[nodiscard]] inline Derived&& resume_on(tmc::detail::ex_any* Executor) && {
+  [[nodiscard]] inline Derived&& resume_on(tmc::ex_any* Executor) && {
     static_cast<Derived*>(this)->continuation_executor = Executor;
     return static_cast<Derived&&>(*this);
   }

--- a/include/tmc/detail/thread_locals.hpp
+++ b/include/tmc/detail/thread_locals.hpp
@@ -51,14 +51,14 @@ using work_item = tmc::coro_functor;
 namespace tmc {
 namespace detail {
 
-class type_erased_executor;
+class ex_any;
 
 // The default executor that is used by post_checked / post_bulk_checked
 // when the current (non-TMC) thread's executor == nullptr.
 // Its value can be populated by calling tmc::external::set_default_executor().
-inline constinit std::atomic<type_erased_executor*> g_ex_default = nullptr;
+inline constinit std::atomic<ex_any*> g_ex_default = nullptr;
 
-class type_erased_executor {
+class ex_any {
 public:
   // Pointers to the real executor and its function implementations.
   void* executor;
@@ -84,10 +84,10 @@ public:
 
   // A default constructor is offered so that other executors can initialize
   // this with their own function pointers.
-  type_erased_executor() {}
+  ex_any() {}
 
   // This constructor is used by TMC executors.
-  template <typename T> type_erased_executor(T* Executor) {
+  template <typename T> ex_any(T* Executor) {
     executor = Executor;
     s_post =
       [](void* Erased, work_item&& Item, size_t Priority, size_t ThreadHint) {
@@ -112,11 +112,11 @@ struct running_task_data {
 };
 
 namespace this_thread { // namespace reserved for thread_local variables
-inline constinit thread_local type_erased_executor* executor = nullptr;
+inline constinit thread_local ex_any* executor = nullptr;
 inline constinit thread_local size_t thread_index = TMC_ALL_ONES;
 inline constinit thread_local running_task_data this_task = {0, &never_yield};
 inline constinit thread_local void* producers = nullptr;
-inline bool exec_is(type_erased_executor const* const Executor) {
+inline bool exec_is(ex_any const* const Executor) {
   return Executor == executor;
 }
 inline bool prio_is(size_t const Priority) {
@@ -126,8 +126,8 @@ inline bool prio_is(size_t const Priority) {
 } // namespace this_thread
 
 inline void post_checked(
-  tmc::detail::type_erased_executor* executor, work_item&& Item,
-  size_t Priority = 0, size_t ThreadHint = NO_HINT
+  tmc::detail::ex_any* executor, work_item&& Item, size_t Priority = 0,
+  size_t ThreadHint = NO_HINT
 ) {
   if (executor == nullptr) {
     executor = g_ex_default.load(std::memory_order_acquire);
@@ -139,7 +139,7 @@ inline void post_checked(
   executor->post(std::move(Item), Priority, ThreadHint);
 }
 inline void post_bulk_checked(
-  tmc::detail::type_erased_executor* executor, work_item* Items, size_t Count,
+  tmc::detail::ex_any* executor, work_item* Items, size_t Count,
   size_t Priority = 0, size_t ThreadHint = NO_HINT
 ) {
   if (Count == 0) {
@@ -159,7 +159,7 @@ inline void post_bulk_checked(
 
 /// Returns a pointer to the current thread's type-erased executor.
 /// Returns nullptr if this thread is not associated with an executor.
-inline tmc::detail::type_erased_executor* current_executor() {
+inline tmc::detail::ex_any* current_executor() {
   return tmc::detail::this_thread::executor;
 }
 

--- a/include/tmc/ex_braid.hpp
+++ b/include/tmc/ex_braid.hpp
@@ -101,6 +101,10 @@ public:
     post_runloop_task(Priority);
   }
 
+  /// Returns a pointer to the type erased `ex_any` version of this executor.
+  /// This object shares a lifetime with this executor, and can be used for
+  /// pointer-based equality comparison against the thread-local
+  /// `tmc::current_executor()`.
   inline tmc::ex_any* type_erased() { return &type_erased_this; }
 
 private:

--- a/include/tmc/ex_braid.hpp
+++ b/include/tmc/ex_braid.hpp
@@ -52,8 +52,8 @@ class ex_braid {
   // it is only w->r by one thread.
   bool* destroyed_by_this_thread;
 
-  tmc::detail::type_erased_executor type_erased_this;
-  tmc::detail::type_erased_executor* parent_executor;
+  tmc::detail::ex_any type_erased_this;
+  tmc::detail::ex_any* parent_executor;
   tmc::detail::running_task_data stored_context;
 
   /// The main loop of the braid; only 1 thread is allowed to enter the inner
@@ -101,12 +101,10 @@ public:
     post_runloop_task(Priority);
   }
 
-  inline tmc::detail::type_erased_executor* type_erased() {
-    return &type_erased_this;
-  }
+  inline tmc::detail::ex_any* type_erased() { return &type_erased_this; }
 
 private:
-  ex_braid(tmc::detail::type_erased_executor* Parent);
+  ex_braid(tmc::detail::ex_any* Parent);
 
 public:
   /// Construct a braid with the current executor as its parent. It is an error
@@ -152,7 +150,7 @@ template <> struct executor_traits<tmc::ex_braid> {
     ex.post_bulk(std::forward<It>(Items), Count, Priority, ThreadHint);
   }
 
-  static tmc::detail::type_erased_executor* type_erased(tmc::ex_braid& ex);
+  static tmc::detail::ex_any* type_erased(tmc::ex_braid& ex);
 
   static std::coroutine_handle<> task_enter_context(
     tmc::ex_braid& ex, std::coroutine_handle<> Outer, size_t Priority

--- a/include/tmc/ex_braid.hpp
+++ b/include/tmc/ex_braid.hpp
@@ -52,8 +52,8 @@ class ex_braid {
   // it is only w->r by one thread.
   bool* destroyed_by_this_thread;
 
-  tmc::detail::ex_any type_erased_this;
-  tmc::detail::ex_any* parent_executor;
+  tmc::ex_any type_erased_this;
+  tmc::ex_any* parent_executor;
   tmc::detail::running_task_data stored_context;
 
   /// The main loop of the braid; only 1 thread is allowed to enter the inner
@@ -101,10 +101,10 @@ public:
     post_runloop_task(Priority);
   }
 
-  inline tmc::detail::ex_any* type_erased() { return &type_erased_this; }
+  inline tmc::ex_any* type_erased() { return &type_erased_this; }
 
 private:
-  ex_braid(tmc::detail::ex_any* Parent);
+  ex_braid(tmc::ex_any* Parent);
 
 public:
   /// Construct a braid with the current executor as its parent. It is an error
@@ -150,7 +150,7 @@ template <> struct executor_traits<tmc::ex_braid> {
     ex.post_bulk(std::forward<It>(Items), Count, Priority, ThreadHint);
   }
 
-  static tmc::detail::ex_any* type_erased(tmc::ex_braid& ex);
+  static tmc::ex_any* type_erased(tmc::ex_braid& ex);
 
   static std::coroutine_handle<> task_enter_context(
     tmc::ex_braid& ex, std::coroutine_handle<> Outer, size_t Priority

--- a/include/tmc/ex_cpu.hpp
+++ b/include/tmc/ex_cpu.hpp
@@ -188,6 +188,10 @@ public:
   /// `tmc::post()` free function template.
   void post(work_item&& Item, size_t Priority = 0, size_t ThreadHint = NO_HINT);
 
+  /// Returns a pointer to the type erased `ex_any` version of this executor.
+  /// This object shares a lifetime with this executor, and can be used for
+  /// pointer-based equality comparison against the thread-local
+  /// `tmc::current_executor()`.
   tmc::ex_any* type_erased();
 
   /// Submits `count` items to the executor. `It` is expected to be an iterator

--- a/include/tmc/ex_cpu.hpp
+++ b/include/tmc/ex_cpu.hpp
@@ -56,7 +56,7 @@ class ex_cpu {
 
   InitParams* init_params;                     // accessed only during init()
   tmc::detail::tiny_vec<std::jthread> threads; // size() == thread_count()
-  tmc::detail::ex_any type_erased_this;
+  tmc::ex_any type_erased_this;
   tmc::detail::tiny_vec<task_queue_t> work_queues; // size() == PRIORITY_COUNT
   // stop_sources that correspond to this pool's threads
   tmc::detail::tiny_vec<std::stop_source> thread_stoppers;
@@ -188,7 +188,7 @@ public:
   /// `tmc::post()` free function template.
   void post(work_item&& Item, size_t Priority = 0, size_t ThreadHint = NO_HINT);
 
-  tmc::detail::ex_any* type_erased();
+  tmc::ex_any* type_erased();
 
   /// Submits `count` items to the executor. `It` is expected to be an iterator
   /// type that implements `operator*()` and `It& operator++()`.
@@ -239,7 +239,7 @@ template <> struct executor_traits<tmc::ex_cpu> {
     ex.post_bulk(std::forward<It>(Items), Count, Priority, ThreadHint);
   }
 
-  static tmc::detail::ex_any* type_erased(tmc::ex_cpu& ex);
+  static tmc::ex_any* type_erased(tmc::ex_cpu& ex);
 
   static std::coroutine_handle<> task_enter_context(
     tmc::ex_cpu& ex, std::coroutine_handle<> Outer, size_t Priority

--- a/include/tmc/ex_cpu.hpp
+++ b/include/tmc/ex_cpu.hpp
@@ -56,7 +56,7 @@ class ex_cpu {
 
   InitParams* init_params;                     // accessed only during init()
   tmc::detail::tiny_vec<std::jthread> threads; // size() == thread_count()
-  tmc::detail::type_erased_executor type_erased_this;
+  tmc::detail::ex_any type_erased_this;
   tmc::detail::tiny_vec<task_queue_t> work_queues; // size() == PRIORITY_COUNT
   // stop_sources that correspond to this pool's threads
   tmc::detail::tiny_vec<std::stop_source> thread_stoppers;
@@ -188,7 +188,7 @@ public:
   /// `tmc::post()` free function template.
   void post(work_item&& Item, size_t Priority = 0, size_t ThreadHint = NO_HINT);
 
-  tmc::detail::type_erased_executor* type_erased();
+  tmc::detail::ex_any* type_erased();
 
   /// Submits `count` items to the executor. `It` is expected to be an iterator
   /// type that implements `operator*()` and `It& operator++()`.
@@ -239,7 +239,7 @@ template <> struct executor_traits<tmc::ex_cpu> {
     ex.post_bulk(std::forward<It>(Items), Count, Priority, ThreadHint);
   }
 
-  static tmc::detail::type_erased_executor* type_erased(tmc::ex_cpu& ex);
+  static tmc::detail::ex_any* type_erased(tmc::ex_cpu& ex);
 
   static std::coroutine_handle<> task_enter_context(
     tmc::ex_cpu& ex, std::coroutine_handle<> Outer, size_t Priority

--- a/include/tmc/external.hpp
+++ b/include/tmc/external.hpp
@@ -27,7 +27,7 @@ namespace external {
 ///
 /// then that function will use this default executor (instead of deferencing
 /// nullptr and crashing).
-inline void set_default_executor(tmc::detail::type_erased_executor* Executor) {
+inline void set_default_executor(tmc::detail::ex_any* Executor) {
   tmc::detail::g_ex_default.store(Executor, std::memory_order_release);
 }
 /// You only need to set this if you are planning to integrate TMC with external

--- a/include/tmc/external.hpp
+++ b/include/tmc/external.hpp
@@ -27,7 +27,7 @@ namespace external {
 ///
 /// then that function will use this default executor (instead of deferencing
 /// nullptr and crashing).
-inline void set_default_executor(tmc::detail::ex_any* Executor) {
+inline void set_default_executor(tmc::ex_any* Executor) {
   tmc::detail::g_ex_default.store(Executor, std::memory_order_release);
 }
 /// You only need to set this if you are planning to integrate TMC with external

--- a/include/tmc/spawn_func.hpp
+++ b/include/tmc/spawn_func.hpp
@@ -24,8 +24,8 @@ template <typename Result> class aw_spawned_func;
 
 template <typename Result> class aw_spawned_func_impl {
   std::function<Result()> wrapped;
-  tmc::detail::type_erased_executor* executor;
-  tmc::detail::type_erased_executor* continuation_executor;
+  tmc::detail::ex_any* executor;
+  tmc::detail::ex_any* continuation_executor;
   size_t prio;
 
   struct empty {};
@@ -39,8 +39,8 @@ template <typename Result> class aw_spawned_func_impl {
   friend aw_spawned_func<Result>;
 
   aw_spawned_func_impl(
-    std::function<Result()> Func, tmc::detail::type_erased_executor* Executor,
-    tmc::detail::type_erased_executor* ContinuationExecutor, size_t Prio
+    std::function<Result()> Func, tmc::detail::ex_any* Executor,
+    tmc::detail::ex_any* ContinuationExecutor, size_t Prio
   )
       : wrapped(std::move(Func)), executor(Executor),
         continuation_executor(ContinuationExecutor), prio(Prio) {}
@@ -101,7 +101,7 @@ public:
 
 template <typename Result> class aw_spawned_func_run_early_impl {
   std::coroutine_handle<> continuation;
-  tmc::detail::type_erased_executor* continuation_executor;
+  tmc::detail::ex_any* continuation_executor;
   std::atomic<ptrdiff_t> done_count;
 
   struct empty {};
@@ -115,8 +115,8 @@ template <typename Result> class aw_spawned_func_run_early_impl {
   friend aw_spawned_func<Result>;
 
   aw_spawned_func_run_early_impl(
-    std::function<Result()> Func, tmc::detail::type_erased_executor* Executor,
-    tmc::detail::type_erased_executor* ContinuationExecutor, size_t Prio
+    std::function<Result()> Func, tmc::detail::ex_any* Executor,
+    tmc::detail::ex_any* ContinuationExecutor, size_t Prio
   )
       : continuation_executor(ContinuationExecutor) {
 #if TMC_WORK_ITEM_IS(CORO)
@@ -249,8 +249,8 @@ class [[nodiscard("You must await or initiate the result of spawn_func()."
   friend class tmc::detail::resume_on_mixin<aw_spawned_func<Result>>;
   friend class tmc::detail::with_priority_mixin<aw_spawned_func<Result>>;
   std::function<Result()> wrapped;
-  tmc::detail::type_erased_executor* executor;
-  tmc::detail::type_erased_executor* continuation_executor;
+  tmc::detail::ex_any* executor;
+  tmc::detail::ex_any* continuation_executor;
   size_t prio;
 #ifndef NDEBUG
   bool is_empty;

--- a/include/tmc/spawn_func.hpp
+++ b/include/tmc/spawn_func.hpp
@@ -24,8 +24,8 @@ template <typename Result> class aw_spawned_func;
 
 template <typename Result> class aw_spawned_func_impl {
   std::function<Result()> wrapped;
-  tmc::detail::ex_any* executor;
-  tmc::detail::ex_any* continuation_executor;
+  tmc::ex_any* executor;
+  tmc::ex_any* continuation_executor;
   size_t prio;
 
   struct empty {};
@@ -39,8 +39,8 @@ template <typename Result> class aw_spawned_func_impl {
   friend aw_spawned_func<Result>;
 
   aw_spawned_func_impl(
-    std::function<Result()> Func, tmc::detail::ex_any* Executor,
-    tmc::detail::ex_any* ContinuationExecutor, size_t Prio
+    std::function<Result()> Func, tmc::ex_any* Executor,
+    tmc::ex_any* ContinuationExecutor, size_t Prio
   )
       : wrapped(std::move(Func)), executor(Executor),
         continuation_executor(ContinuationExecutor), prio(Prio) {}
@@ -101,7 +101,7 @@ public:
 
 template <typename Result> class aw_spawned_func_run_early_impl {
   std::coroutine_handle<> continuation;
-  tmc::detail::ex_any* continuation_executor;
+  tmc::ex_any* continuation_executor;
   std::atomic<ptrdiff_t> done_count;
 
   struct empty {};
@@ -115,8 +115,8 @@ template <typename Result> class aw_spawned_func_run_early_impl {
   friend aw_spawned_func<Result>;
 
   aw_spawned_func_run_early_impl(
-    std::function<Result()> Func, tmc::detail::ex_any* Executor,
-    tmc::detail::ex_any* ContinuationExecutor, size_t Prio
+    std::function<Result()> Func, tmc::ex_any* Executor,
+    tmc::ex_any* ContinuationExecutor, size_t Prio
   )
       : continuation_executor(ContinuationExecutor) {
 #if TMC_WORK_ITEM_IS(CORO)
@@ -249,8 +249,8 @@ class [[nodiscard("You must await or initiate the result of spawn_func()."
   friend class tmc::detail::resume_on_mixin<aw_spawned_func<Result>>;
   friend class tmc::detail::with_priority_mixin<aw_spawned_func<Result>>;
   std::function<Result()> wrapped;
-  tmc::detail::ex_any* executor;
-  tmc::detail::ex_any* continuation_executor;
+  tmc::ex_any* executor;
+  tmc::ex_any* continuation_executor;
   size_t prio;
 #ifndef NDEBUG
   bool is_empty;

--- a/include/tmc/spawn_many.hpp
+++ b/include/tmc/spawn_many.hpp
@@ -220,7 +220,7 @@ public:
     ptrdiff_t remaining_count;
   };
   std::coroutine_handle<> continuation;
-  tmc::detail::type_erased_executor* continuation_executor;
+  tmc::detail::ex_any* continuation_executor;
   union {
     std::atomic<ptrdiff_t> done_count;
     std::atomic<ptrdiff_t> sync_flags;
@@ -278,9 +278,8 @@ public:
 
   template <typename TaskIter>
   inline aw_task_many_impl(
-    TaskIter Iter, size_t TaskCount,
-    tmc::detail::type_erased_executor* Executor,
-    tmc::detail::type_erased_executor* ContinuationExecutor, size_t Prio,
+    TaskIter Iter, size_t TaskCount, tmc::detail::ex_any* Executor,
+    tmc::detail::ex_any* ContinuationExecutor, size_t Prio,
     bool DoSymmetricTransfer
   )
       : continuation_executor{ContinuationExecutor} {
@@ -382,9 +381,8 @@ public:
   template <typename TaskIter>
   inline aw_task_many_impl(
     TaskIter Begin, TaskIter End, size_t MaxCount,
-    tmc::detail::type_erased_executor* Executor,
-    tmc::detail::type_erased_executor* ContinuationExecutor, size_t Prio,
-    bool DoSymmetricTransfer
+    tmc::detail::ex_any* Executor, tmc::detail::ex_any* ContinuationExecutor,
+    size_t Prio, bool DoSymmetricTransfer
   )
     requires(requires(TaskIter a, TaskIter b) {
       ++a;
@@ -861,8 +859,8 @@ class [[nodiscard("You must await or initiate the result of spawn_many()."
   IterBegin iter;
   IterEnd sentinel;
   size_t maxCount;
-  tmc::detail::type_erased_executor* executor;
-  tmc::detail::type_erased_executor* continuation_executor;
+  tmc::detail::ex_any* executor;
+  tmc::detail::ex_any* continuation_executor;
   size_t prio;
 #ifndef NDEBUG
   bool is_empty;

--- a/include/tmc/spawn_many.hpp
+++ b/include/tmc/spawn_many.hpp
@@ -220,7 +220,7 @@ public:
     ptrdiff_t remaining_count;
   };
   std::coroutine_handle<> continuation;
-  tmc::detail::ex_any* continuation_executor;
+  tmc::ex_any* continuation_executor;
   union {
     std::atomic<ptrdiff_t> done_count;
     std::atomic<ptrdiff_t> sync_flags;
@@ -278,9 +278,8 @@ public:
 
   template <typename TaskIter>
   inline aw_task_many_impl(
-    TaskIter Iter, size_t TaskCount, tmc::detail::ex_any* Executor,
-    tmc::detail::ex_any* ContinuationExecutor, size_t Prio,
-    bool DoSymmetricTransfer
+    TaskIter Iter, size_t TaskCount, tmc::ex_any* Executor,
+    tmc::ex_any* ContinuationExecutor, size_t Prio, bool DoSymmetricTransfer
   )
       : continuation_executor{ContinuationExecutor} {
     if constexpr (!IsEach) {
@@ -380,9 +379,8 @@ public:
 
   template <typename TaskIter>
   inline aw_task_many_impl(
-    TaskIter Begin, TaskIter End, size_t MaxCount,
-    tmc::detail::ex_any* Executor, tmc::detail::ex_any* ContinuationExecutor,
-    size_t Prio, bool DoSymmetricTransfer
+    TaskIter Begin, TaskIter End, size_t MaxCount, tmc::ex_any* Executor,
+    tmc::ex_any* ContinuationExecutor, size_t Prio, bool DoSymmetricTransfer
   )
     requires(requires(TaskIter a, TaskIter b) {
       ++a;
@@ -859,8 +857,8 @@ class [[nodiscard("You must await or initiate the result of spawn_many()."
   IterBegin iter;
   IterEnd sentinel;
   size_t maxCount;
-  tmc::detail::ex_any* executor;
-  tmc::detail::ex_any* continuation_executor;
+  tmc::ex_any* executor;
+  tmc::ex_any* continuation_executor;
   size_t prio;
 #ifndef NDEBUG
   bool is_empty;

--- a/include/tmc/spawn_task.hpp
+++ b/include/tmc/spawn_task.hpp
@@ -38,7 +38,7 @@ class [[nodiscard("You must co_await aw_run_early. "
 
 template <typename Awaitable, typename Result> class aw_run_early_impl {
   std::coroutine_handle<> continuation;
-  tmc::detail::ex_any* continuation_executor;
+  tmc::ex_any* continuation_executor;
   std::atomic<ptrdiff_t> done_count;
   tmc::detail::result_storage_t<Result> result;
 
@@ -49,8 +49,8 @@ template <typename Awaitable, typename Result> class aw_run_early_impl {
   // Private constructor from aw_spawned_task. Takes ownership of parent's
   // task.
   aw_run_early_impl(
-    Awaitable&& Task, tmc::detail::ex_any* Executor,
-    tmc::detail::ex_any* ContinuationExecutor, size_t Priority
+    Awaitable&& Task, tmc::ex_any* Executor, tmc::ex_any* ContinuationExecutor,
+    size_t Priority
   )
       : continuation{nullptr}, continuation_executor(ContinuationExecutor),
         done_count(1) {
@@ -118,7 +118,7 @@ public:
 
 template <typename Awaitable> class aw_run_early_impl<Awaitable, void> {
   std::coroutine_handle<> continuation;
-  tmc::detail::ex_any* continuation_executor;
+  tmc::ex_any* continuation_executor;
   std::atomic<ptrdiff_t> done_count;
 
   using AwaitableTraits = tmc::detail::get_awaitable_traits<Awaitable>;
@@ -128,8 +128,8 @@ template <typename Awaitable> class aw_run_early_impl<Awaitable, void> {
   // Private constructor from aw_spawned_task. Takes ownership of parent's
   // task.
   aw_run_early_impl(
-    Awaitable&& Task, tmc::detail::ex_any* Executor,
-    tmc::detail::ex_any* ContinuationExecutor, size_t Priority
+    Awaitable&& Task, tmc::ex_any* Executor, tmc::ex_any* ContinuationExecutor,
+    size_t Priority
   )
       : continuation{nullptr}, continuation_executor(ContinuationExecutor),
         done_count(1) {
@@ -196,8 +196,8 @@ class aw_spawned_task_impl;
 
 template <typename Awaitable, typename Result> class aw_spawned_task_impl {
   Awaitable wrapped;
-  tmc::detail::ex_any* executor;
-  tmc::detail::ex_any* continuation_executor;
+  tmc::ex_any* executor;
+  tmc::ex_any* continuation_executor;
   size_t prio;
 
   struct empty {};
@@ -208,8 +208,8 @@ template <typename Awaitable, typename Result> class aw_spawned_task_impl {
   friend aw_spawned_task<Awaitable>;
 
   aw_spawned_task_impl(
-    Awaitable Task, tmc::detail::ex_any* Executor,
-    tmc::detail::ex_any* ContinuationExecutor, size_t Prio
+    Awaitable Task, tmc::ex_any* Executor, tmc::ex_any* ContinuationExecutor,
+    size_t Prio
   )
       : wrapped{std::move(Task)}, executor{Executor},
         continuation_executor{ContinuationExecutor}, prio{Prio} {}
@@ -274,8 +274,8 @@ class [[nodiscard("You must await or initiate the result of spawn()."
   friend class tmc::detail::with_priority_mixin<
     aw_spawned_task<Awaitable, Result>>;
   Awaitable wrapped;
-  tmc::detail::ex_any* executor;
-  tmc::detail::ex_any* continuation_executor;
+  tmc::ex_any* executor;
+  tmc::ex_any* continuation_executor;
   size_t prio;
 
 #ifndef NDEBUG

--- a/include/tmc/spawn_task.hpp
+++ b/include/tmc/spawn_task.hpp
@@ -38,7 +38,7 @@ class [[nodiscard("You must co_await aw_run_early. "
 
 template <typename Awaitable, typename Result> class aw_run_early_impl {
   std::coroutine_handle<> continuation;
-  tmc::detail::type_erased_executor* continuation_executor;
+  tmc::detail::ex_any* continuation_executor;
   std::atomic<ptrdiff_t> done_count;
   tmc::detail::result_storage_t<Result> result;
 
@@ -49,8 +49,8 @@ template <typename Awaitable, typename Result> class aw_run_early_impl {
   // Private constructor from aw_spawned_task. Takes ownership of parent's
   // task.
   aw_run_early_impl(
-    Awaitable&& Task, tmc::detail::type_erased_executor* Executor,
-    tmc::detail::type_erased_executor* ContinuationExecutor, size_t Priority
+    Awaitable&& Task, tmc::detail::ex_any* Executor,
+    tmc::detail::ex_any* ContinuationExecutor, size_t Priority
   )
       : continuation{nullptr}, continuation_executor(ContinuationExecutor),
         done_count(1) {
@@ -118,7 +118,7 @@ public:
 
 template <typename Awaitable> class aw_run_early_impl<Awaitable, void> {
   std::coroutine_handle<> continuation;
-  tmc::detail::type_erased_executor* continuation_executor;
+  tmc::detail::ex_any* continuation_executor;
   std::atomic<ptrdiff_t> done_count;
 
   using AwaitableTraits = tmc::detail::get_awaitable_traits<Awaitable>;
@@ -128,8 +128,8 @@ template <typename Awaitable> class aw_run_early_impl<Awaitable, void> {
   // Private constructor from aw_spawned_task. Takes ownership of parent's
   // task.
   aw_run_early_impl(
-    Awaitable&& Task, tmc::detail::type_erased_executor* Executor,
-    tmc::detail::type_erased_executor* ContinuationExecutor, size_t Priority
+    Awaitable&& Task, tmc::detail::ex_any* Executor,
+    tmc::detail::ex_any* ContinuationExecutor, size_t Priority
   )
       : continuation{nullptr}, continuation_executor(ContinuationExecutor),
         done_count(1) {
@@ -196,8 +196,8 @@ class aw_spawned_task_impl;
 
 template <typename Awaitable, typename Result> class aw_spawned_task_impl {
   Awaitable wrapped;
-  tmc::detail::type_erased_executor* executor;
-  tmc::detail::type_erased_executor* continuation_executor;
+  tmc::detail::ex_any* executor;
+  tmc::detail::ex_any* continuation_executor;
   size_t prio;
 
   struct empty {};
@@ -208,8 +208,8 @@ template <typename Awaitable, typename Result> class aw_spawned_task_impl {
   friend aw_spawned_task<Awaitable>;
 
   aw_spawned_task_impl(
-    Awaitable Task, tmc::detail::type_erased_executor* Executor,
-    tmc::detail::type_erased_executor* ContinuationExecutor, size_t Prio
+    Awaitable Task, tmc::detail::ex_any* Executor,
+    tmc::detail::ex_any* ContinuationExecutor, size_t Prio
   )
       : wrapped{std::move(Task)}, executor{Executor},
         continuation_executor{ContinuationExecutor}, prio{Prio} {}
@@ -274,8 +274,8 @@ class [[nodiscard("You must await or initiate the result of spawn()."
   friend class tmc::detail::with_priority_mixin<
     aw_spawned_task<Awaitable, Result>>;
   Awaitable wrapped;
-  tmc::detail::type_erased_executor* executor;
-  tmc::detail::type_erased_executor* continuation_executor;
+  tmc::detail::ex_any* executor;
+  tmc::detail::ex_any* continuation_executor;
   size_t prio;
 
 #ifndef NDEBUG

--- a/include/tmc/spawn_tuple.hpp
+++ b/include/tmc/spawn_tuple.hpp
@@ -114,7 +114,7 @@ template <bool IsEach, typename... Awaitable> class aw_spawned_task_tuple_impl {
     ptrdiff_t remaining_count;
   };
   std::coroutine_handle<> continuation;
-  tmc::detail::ex_any* continuation_executor;
+  tmc::ex_any* continuation_executor;
   union {
     std::atomic<ptrdiff_t> done_count;
     std::atomic<size_t> sync_flags;
@@ -189,9 +189,8 @@ template <bool IsEach, typename... Awaitable> class aw_spawned_task_tuple_impl {
   }
 
   aw_spawned_task_tuple_impl(
-    AwaitableTuple&& Tasks, tmc::detail::ex_any* Executor,
-    tmc::detail::ex_any* ContinuationExecutor, size_t Prio,
-    bool DoSymmetricTransfer
+    AwaitableTuple&& Tasks, tmc::ex_any* Executor,
+    tmc::ex_any* ContinuationExecutor, size_t Prio, bool DoSymmetricTransfer
   )
       : continuation_executor{ContinuationExecutor} {
     if constexpr (!IsEach) {
@@ -469,8 +468,8 @@ class [[nodiscard("You must await or initiate the result of spawn_tuple()."
 
   using AwaitableTuple = std::tuple<Awaitable...>;
   AwaitableTuple wrapped;
-  tmc::detail::ex_any* executor;
-  tmc::detail::ex_any* continuation_executor;
+  tmc::ex_any* executor;
+  tmc::ex_any* continuation_executor;
   size_t prio;
 
 #ifndef NDEBUG

--- a/include/tmc/spawn_tuple.hpp
+++ b/include/tmc/spawn_tuple.hpp
@@ -114,7 +114,7 @@ template <bool IsEach, typename... Awaitable> class aw_spawned_task_tuple_impl {
     ptrdiff_t remaining_count;
   };
   std::coroutine_handle<> continuation;
-  tmc::detail::type_erased_executor* continuation_executor;
+  tmc::detail::ex_any* continuation_executor;
   union {
     std::atomic<ptrdiff_t> done_count;
     std::atomic<size_t> sync_flags;
@@ -189,8 +189,8 @@ template <bool IsEach, typename... Awaitable> class aw_spawned_task_tuple_impl {
   }
 
   aw_spawned_task_tuple_impl(
-    AwaitableTuple&& Tasks, tmc::detail::type_erased_executor* Executor,
-    tmc::detail::type_erased_executor* ContinuationExecutor, size_t Prio,
+    AwaitableTuple&& Tasks, tmc::detail::ex_any* Executor,
+    tmc::detail::ex_any* ContinuationExecutor, size_t Prio,
     bool DoSymmetricTransfer
   )
       : continuation_executor{ContinuationExecutor} {
@@ -469,8 +469,8 @@ class [[nodiscard("You must await or initiate the result of spawn_tuple()."
 
   using AwaitableTuple = std::tuple<Awaitable...>;
   AwaitableTuple wrapped;
-  tmc::detail::type_erased_executor* executor;
-  tmc::detail::type_erased_executor* continuation_executor;
+  tmc::detail::ex_any* executor;
+  tmc::detail::ex_any* continuation_executor;
   size_t prio;
 
 #ifndef NDEBUG

--- a/include/tmc/sync.hpp
+++ b/include/tmc/sync.hpp
@@ -144,7 +144,7 @@ template <
     std::promise<void> promise;
     std::atomic<ptrdiff_t> done_count;
     std::coroutine_handle<> continuation;
-    tmc::detail::type_erased_executor* continuation_executor;
+    tmc::detail::ex_any* continuation_executor;
   };
   std::shared_ptr<BulkSyncState> sharedState =
     std::make_shared<BulkSyncState>(std::promise<void>(), Count - 1, nullptr);

--- a/include/tmc/sync.hpp
+++ b/include/tmc/sync.hpp
@@ -144,7 +144,7 @@ template <
     std::promise<void> promise;
     std::atomic<ptrdiff_t> done_count;
     std::coroutine_handle<> continuation;
-    tmc::detail::ex_any* continuation_executor;
+    tmc::ex_any* continuation_executor;
   };
   std::shared_ptr<BulkSyncState> sharedState =
     std::make_shared<BulkSyncState>(std::promise<void>(), Count - 1, nullptr);

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -72,13 +72,13 @@ struct awaitable_customizer_base {
   TMC_FORCE_INLINE inline std::coroutine_handle<>
   resume_continuation(size_t Priority) noexcept {
     std::coroutine_handle<> finalContinuation = nullptr;
-    tmc::detail::type_erased_executor* continuationExecutor = nullptr;
+    tmc::detail::ex_any* continuationExecutor = nullptr;
     if (done_count == nullptr) {
       // being awaited alone, or detached
       // continuation is a std::coroutine_handle<>
-      // continuation_executor is a tmc::detail::type_erased_executor*
+      // continuation_executor is a tmc::detail::ex_any*
       continuationExecutor =
-        static_cast<tmc::detail::type_erased_executor*>(continuation_executor);
+        static_cast<tmc::detail::ex_any*>(continuation_executor);
       finalContinuation = std::coroutine_handle<>::from_address(continuation);
     } else {
       // being awaited as part of a group
@@ -101,15 +101,13 @@ struct awaitable_customizer_base {
       } else {
         // task is part of a spawn_many group, or run_early
         // continuation is a std::coroutine_handle<>*
-        // continuation_executor is a tmc::detail::type_erased_executor**
+        // continuation_executor is a tmc::detail::ex_any**
         shouldResume = static_cast<std::atomic<ptrdiff_t>*>(done_count)
                          ->fetch_sub(1, std::memory_order_acq_rel) == 0;
       }
       if (shouldResume) {
         continuationExecutor =
-          *static_cast<tmc::detail::type_erased_executor**>(
-            continuation_executor
-          );
+          *static_cast<tmc::detail::ex_any**>(continuation_executor);
         finalContinuation =
           *(static_cast<std::coroutine_handle<>*>(continuation));
       }
@@ -203,7 +201,7 @@ template <typename Result> struct task {
   /// on the provided executor.
   [[nodiscard("You must submit or co_await task for execution. Failure to "
               "do so will result in a memory leak.")]] inline task&
-  resume_on(tmc::detail::type_erased_executor* Executor) & {
+  resume_on(tmc::detail::ex_any* Executor) & {
     handle.promise().customizer.continuation_executor = Executor;
     return *this;
   }
@@ -229,7 +227,7 @@ template <typename Result> struct task {
   /// on the provided executor.
   [[nodiscard("You must submit or co_await task for execution. Failure to "
               "do so will result in a memory leak.")]] inline task&&
-  resume_on(tmc::detail::type_erased_executor* Executor) && {
+  resume_on(tmc::detail::ex_any* Executor) && {
     handle.promise().customizer.continuation_executor = Executor;
     return *this;
   }
@@ -909,9 +907,8 @@ public:
 namespace detail {
 // Used by spawn_* wrapper functions to coordinate the behavior of awaitables.
 template <typename Awaitable>
-TMC_FORCE_INLINE inline void initiate_one(
-  Awaitable&& Item, tmc::detail::type_erased_executor* Executor, size_t Priority
-) {
+TMC_FORCE_INLINE inline void
+initiate_one(Awaitable&& Item, tmc::detail::ex_any* Executor, size_t Priority) {
   if constexpr (tmc::detail::get_awaitable_traits<Awaitable>::mode ==
                   TMC_TASK ||
                 tmc::detail::get_awaitable_traits<Awaitable>::mode ==


### PR DESCRIPTION
This type may be useful to end users, so it's helpful to expose in the primary namespace. The new name is simple and to the point - "any" is a common term for a type erased object these days. I deliberately avoided calling it `any_executor` because there is already a type `asio::any_executor` and I want to avoid confusion with that. This name also follows the naming convention for the other executor types.