### PR TITLE
qu_lockfree improvements

### DIFF
--- a/include/tmc/detail/qu_lockfree.hpp
+++ b/include/tmc/detail/qu_lockfree.hpp
@@ -2392,27 +2392,31 @@ public:
     // This is always called in exactly one place. TMC_FORCE_INLINE empirically
     // determined to improve perf.
     template <typename U> TMC_FORCE_INLINE bool dequeue_lifo(U& element) {
+      auto prevIndex = this->tailIndex.load(std::memory_order_relaxed);
       if (!details::circular_less_than<index_t>(
             this->dequeueOptimisticCount.load(std::memory_order_relaxed) -
               this->dequeueOvercommit.load(std::memory_order_relaxed),
-            this->tailIndex.load(std::memory_order_relaxed)
+            prevIndex
           )) {
         return false;
       }
+      // Prevent prior loads to be reordered past this.
       std::atomic_thread_fence(std::memory_order_acquire);
-      auto prevIndex = this->tailIndex.fetch_sub(1, std::memory_order_acq_rel);
+      // Looks like there's data to dequeue. Decrement tail and check again.
       auto index = prevIndex - 1;
+      this->tailIndex.store(index, std::memory_order_seq_cst);
+      // StoreLoad barrier required before checking reader variables
       auto myOvercommit =
-        this->dequeueOvercommit.load(std::memory_order_acquire);
+        this->dequeueOvercommit.load(std::memory_order_seq_cst);
       auto myDequeueCount =
-        this->dequeueOptimisticCount.load(std::memory_order_acquire);
+        this->dequeueOptimisticCount.load(std::memory_order_seq_cst);
       // don't need to reload tail since it can only be modified by this thread
       if (!details::circular_less_than<index_t>(
             myDequeueCount - myOvercommit, prevIndex
           )) [[unlikely]] {
         // Wasn't anything to dequeue after all; make the effective dequeue
         // count eventually consistent
-        this->tailIndex.fetch_add(1, std::memory_order_release);
+        this->tailIndex.store(prevIndex, std::memory_order_release);
         return false;
       }
 


### PR DESCRIPTION
dequeue_lifo: `fetch_add()` in practice is `lock xadd` on x86 which is quite expensive. Since `tailIndex` is only modified by a single thread, we can use a relaxed read - add - write and be sure that another thread won't modify it in between. We do need a StoreLoad barrier between the store to tailIndex and the loads of dequeueOvercommit and dequeueOptimisticCount. This could be implemented using either:
- tailIndex.store(seq_cst)
- dequeueOvercommit.load(seq_cst)
- dequeueOptimisticCount.load(seq_cst)
or:
- tailIndex.store(relaxed)
- memory_barrier()
- dequeueOvercommit.load(acquire)
- dequeueOptimisticCount.load(acquire)

Note that the 2 loads both have to be acquire at least, to ensure that Overcommit is loaded prior to OptimisticCount. Performance testing determined that making all 3 operations seq_cst performed better on both x86 and AArch64.

---

empty: size() doesn't need to be seq_cst; there are multiple rounds of spinning which use pause() instruction to allow memory effects to become visible. Additionally, there is a memory barrier in the calling function between notifying that the thread will sleep and checking empty() one last time. Thus we can use relaxed loads to check if the queue is empty.