### PR TITLE
Rename run_early() to fork()

### DIFF
--- a/include/tmc/spawn_func.hpp
+++ b/include/tmc/spawn_func.hpp
@@ -279,7 +279,11 @@ public:
     );
   }
 
-  [[nodiscard("You must co_await the result of fork()."
+  /// Submits the task to the executor immediately, without suspending the
+  /// current coroutine. You must join the forked task by awaiting the returned
+  /// awaitable before it goes out of scope.
+  [[nodiscard(
+    "You must co_await the fork() awaitable before it goes out of scope."
   )]] aw_spawned_func_fork<Result>
   fork() && {
 #ifndef NDEBUG

--- a/include/tmc/spawn_many.hpp
+++ b/include/tmc/spawn_many.hpp
@@ -911,8 +911,10 @@ public:
   }
 
   /// Submits the tasks to the executor immediately, without suspending the
-  /// current coroutine. You must await the return type before destroying it.
-  [[nodiscard("You must co_await the result of fork()."
+  /// current coroutine. You must join the forked tasks by awaiting the returned
+  /// awaitable before it goes out of scope.
+  [[nodiscard(
+    "You must co_await the fork() awaitable before it goes out of scope."
   )]] inline aw_task_many_fork<Result, Count, IsFunc>
   fork() && {
 #ifndef NDEBUG

--- a/include/tmc/spawn_many.hpp
+++ b/include/tmc/spawn_many.hpp
@@ -831,7 +831,7 @@ public:
 };
 
 template <typename Result, size_t Count, bool IsFunc>
-using aw_task_many_run_early = tmc::detail::rvalue_only_awaitable<
+using aw_task_many_fork = tmc::detail::rvalue_only_awaitable<
   aw_task_many_impl<Result, Count, false, IsFunc>>;
 
 template <typename Result, size_t Count, bool IsFunc>
@@ -912,22 +912,22 @@ public:
 
   /// Submits the tasks to the executor immediately, without suspending the
   /// current coroutine. You must await the return type before destroying it.
-  [[nodiscard("You must co_await the result of run_early()."
-  )]] inline aw_task_many_run_early<Result, Count, IsFunc>
-  run_early() && {
+  [[nodiscard("You must co_await the result of fork()."
+  )]] inline aw_task_many_fork<Result, Count, IsFunc>
+  fork() && {
 #ifndef NDEBUG
     assert(!is_empty && "You may only submit or co_await this once.");
     is_empty = true;
 #endif
     if constexpr (std::is_convertible_v<IterEnd, size_t>) {
       // "Sentinel" is actually a count
-      return aw_task_many_run_early<Result, Count, IsFunc>(
+      return aw_task_many_fork<Result, Count, IsFunc>(
         std::move(iter), std::move(sentinel), executor, continuation_executor,
         prio, false
       );
     } else {
       // We have both a sentinel and a MaxCount
-      return aw_task_many_run_early<Result, Count, IsFunc>(
+      return aw_task_many_fork<Result, Count, IsFunc>(
         std::move(iter), std::move(sentinel), maxCount, executor,
         continuation_executor, prio, false
       );

--- a/include/tmc/spawn_task.hpp
+++ b/include/tmc/spawn_task.hpp
@@ -25,18 +25,18 @@ class aw_spawned_task;
 
 /// A wrapper that converts lazy task(s) to eager task(s),
 /// and allows the task(s) to be awaited after it has been started.
-/// It is created by calling `run_early()` on a parent awaitable
+/// It is created by calling `fork()` on a parent awaitable
 /// from `spawn()`.
 ///
 /// `Result` is the type of a single result value.
 template <
   typename Awaitable,
   typename Result = tmc::detail::awaitable_result_t<Awaitable>>
-class [[nodiscard("You must co_await aw_run_early. "
-                  "It is not safe to destroy aw_run_early without first "
-                  "awaiting it.")]] aw_run_early_impl;
+class [[nodiscard("You must co_await aw_fork. "
+                  "It is not safe to destroy aw_fork without first "
+                  "awaiting it.")]] aw_fork_impl;
 
-template <typename Awaitable, typename Result> class aw_run_early_impl {
+template <typename Awaitable, typename Result> class aw_fork_impl {
   std::coroutine_handle<> continuation;
   tmc::ex_any* continuation_executor;
   std::atomic<ptrdiff_t> done_count;
@@ -48,7 +48,7 @@ template <typename Awaitable, typename Result> class aw_run_early_impl {
 
   // Private constructor from aw_spawned_task. Takes ownership of parent's
   // task.
-  aw_run_early_impl(
+  aw_fork_impl(
     Awaitable&& Task, tmc::ex_any* Executor, tmc::ex_any* ContinuationExecutor,
     size_t Priority
   )
@@ -101,22 +101,20 @@ public:
 
   // This must be awaited and the child task completed before destruction.
 #ifndef NDEBUG
-  ~aw_run_early_impl() noexcept {
-    assert(
-      done_count.load() < 0 && "You must co_await the result of run_early()."
-    );
+  ~aw_fork_impl() noexcept {
+    assert(done_count.load() < 0 && "You must co_await the result of fork().");
   }
 #endif
 
   // Not movable or copyable due to child task being spawned in constructor,
   // and having pointers to this.
-  aw_run_early_impl& operator=(const aw_run_early_impl& other) = delete;
-  aw_run_early_impl(const aw_run_early_impl& other) = delete;
-  aw_run_early_impl& operator=(const aw_run_early_impl&& other) = delete;
-  aw_run_early_impl(const aw_run_early_impl&& other) = delete;
+  aw_fork_impl& operator=(const aw_fork_impl& other) = delete;
+  aw_fork_impl(const aw_fork_impl& other) = delete;
+  aw_fork_impl& operator=(const aw_fork_impl&& other) = delete;
+  aw_fork_impl(const aw_fork_impl&& other) = delete;
 };
 
-template <typename Awaitable> class aw_run_early_impl<Awaitable, void> {
+template <typename Awaitable> class aw_fork_impl<Awaitable, void> {
   std::coroutine_handle<> continuation;
   tmc::ex_any* continuation_executor;
   std::atomic<ptrdiff_t> done_count;
@@ -127,7 +125,7 @@ template <typename Awaitable> class aw_run_early_impl<Awaitable, void> {
 
   // Private constructor from aw_spawned_task. Takes ownership of parent's
   // task.
-  aw_run_early_impl(
+  aw_fork_impl(
     Awaitable&& Task, tmc::ex_any* Executor, tmc::ex_any* ContinuationExecutor,
     size_t Priority
   )
@@ -172,22 +170,21 @@ public:
 
 // This must be awaited and the child task completed before destruction.
 #ifndef NDEBUG
-  ~aw_run_early_impl() noexcept {
+  ~aw_fork_impl() noexcept {
     assert(done_count.load() < 0 && "You must submit or co_await this.");
   }
 #endif
 
   // Not movable or copyable due to child task being spawned in constructor,
   // and having pointers to this.
-  aw_run_early_impl& operator=(const aw_run_early_impl& Other) = delete;
-  aw_run_early_impl(const aw_run_early_impl& Other) = delete;
-  aw_run_early_impl& operator=(const aw_run_early_impl&& Other) = delete;
-  aw_run_early_impl(const aw_run_early_impl&& Other) = delete;
+  aw_fork_impl& operator=(const aw_fork_impl& Other) = delete;
+  aw_fork_impl(const aw_fork_impl& Other) = delete;
+  aw_fork_impl& operator=(const aw_fork_impl&& Other) = delete;
+  aw_fork_impl(const aw_fork_impl&& Other) = delete;
 };
 
 template <typename Awaitable>
-using aw_run_early =
-  tmc::detail::rvalue_only_awaitable<aw_run_early_impl<Awaitable>>;
+using aw_fork = tmc::detail::rvalue_only_awaitable<aw_fork_impl<Awaitable>>;
 
 template <
   typename Awaitable,
@@ -351,15 +348,15 @@ public:
 
   /// Submits the wrapped task immediately, without suspending the current
   /// coroutine. You must await the return type before destroying it.
-  [[nodiscard("You must co_await the result of run_early()."
-  )]] inline aw_run_early<Awaitable>
-  run_early() && {
+  [[nodiscard("You must co_await the result of fork()."
+  )]] inline aw_fork<Awaitable>
+  fork() && {
 
 #ifndef NDEBUG
     assert(!is_empty && "You may only submit or co_await this once.");
     is_empty = true;
 #endif
-    return aw_run_early<Awaitable>(
+    return aw_fork<Awaitable>(
       std::move(wrapped), executor, continuation_executor, prio
     );
   }
@@ -387,7 +384,7 @@ struct awaitable_traits<aw_spawned_task<Awaitable, Result>> {
 ///
 /// Before the task is submitted for execution, you may call any or all of
 /// `run_on()`, `resume_on()`, `with_priority()`. The task must then be
-/// submitted for execution by calling exactly one of: `co_await`, `run_early()`
+/// submitted for execution by calling exactly one of: `co_await`, `fork()`
 /// or `detach()`.
 template <typename Awaitable>
 aw_spawned_task<Awaitable> spawn(Awaitable&& Task) {

--- a/include/tmc/spawn_task.hpp
+++ b/include/tmc/spawn_task.hpp
@@ -102,7 +102,10 @@ public:
   // This must be awaited and the child task completed before destruction.
 #ifndef NDEBUG
   ~aw_fork_impl() noexcept {
-    assert(done_count.load() < 0 && "You must co_await the result of fork().");
+    assert(
+      done_count.load() < 0 &&
+      "You must co_await the fork() awaitable before it goes out of scope."
+    );
   }
 #endif
 
@@ -346,9 +349,11 @@ public:
     return *this;
   }
 
-  /// Submits the wrapped task immediately, without suspending the current
-  /// coroutine. You must await the return type before destroying it.
-  [[nodiscard("You must co_await the result of fork()."
+  /// Submits the task to the executor immediately, without suspending the
+  /// current coroutine. You must join the forked task by awaiting the returned
+  /// awaitable before it goes out of scope.
+  [[nodiscard(
+    "You must co_await the fork() awaitable before it goes out of scope."
   )]] inline aw_fork<Awaitable>
   fork() && {
 

--- a/include/tmc/spawn_tuple.hpp
+++ b/include/tmc/spawn_tuple.hpp
@@ -441,7 +441,7 @@ public:
 };
 
 template <typename... Result>
-using aw_spawned_task_tuple_run_early = tmc::detail::rvalue_only_awaitable<
+using aw_spawned_task_tuple_fork = tmc::detail::rvalue_only_awaitable<
   aw_spawned_task_tuple_impl<false, Result...>>;
 
 template <typename... Result>
@@ -590,9 +590,9 @@ public:
 
   /// Submits the tasks to the executor immediately, without suspending the
   /// current coroutine. You must await the return type before destroying it.
-  [[nodiscard("You must co_await the result of run_early()."
-  )]] inline aw_spawned_task_tuple_run_early<Awaitable...>
-  run_early() && {
+  [[nodiscard("You must co_await the result of fork()."
+  )]] inline aw_spawned_task_tuple_fork<Awaitable...>
+  fork() && {
 
 #ifndef NDEBUG
     if constexpr (Count != 0) {
@@ -601,7 +601,7 @@ public:
     }
     is_empty = true;
 #endif
-    return aw_spawned_task_tuple_run_early<Awaitable...>(
+    return aw_spawned_task_tuple_fork<Awaitable...>(
       std::move(wrapped), executor, continuation_executor, prio, false
     );
   }

--- a/include/tmc/spawn_tuple.hpp
+++ b/include/tmc/spawn_tuple.hpp
@@ -589,8 +589,10 @@ public:
   }
 
   /// Submits the tasks to the executor immediately, without suspending the
-  /// current coroutine. You must await the return type before destroying it.
-  [[nodiscard("You must co_await the result of fork()."
+  /// current coroutine. You must join the forked tasks by awaiting the returned
+  /// awaitable before it goes out of scope.
+  [[nodiscard(
+    "You must co_await the fork() awaitable before it goes out of scope."
   )]] inline aw_spawned_task_tuple_fork<Awaitable...>
   fork() && {
 

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -36,7 +36,7 @@ static inline constexpr size_t OFFSET_MASK = TMC_PLATFORM_BITS - 1;
 ///
 /// `done_count` is used as an atomic barrier to synchronize with other tasks in
 /// the same spawn group (in the case of spawn_many()), or the awaiting task (in
-/// the case of run_early()). In other scenarios, `done_count` is unused,and is
+/// the case of fork()). In other scenarios, `done_count` is unused,and is
 /// expected to be nullptr.
 ///
 /// If `done_count` is nullptr, `continuation` and `continuation_executor` are
@@ -98,7 +98,7 @@ struct awaitable_customizer_base {
                     std::memory_order_acq_rel
                   ));
       } else {
-        // task is part of a spawn_many group, or run_early
+        // task is part of a spawn_many group, or fork
         // continuation is a std::coroutine_handle<>*
         // continuation_executor is a tmc::ex_any**
         shouldResume = static_cast<std::atomic<ptrdiff_t>*>(done_count)


### PR DESCRIPTION
fork() carries the same connotation - that there is an expectation that it be followed by a join (in this case, co_awaiting the returned awaitable). And it is a shorter and more standard name.