### PR TITLE
channel fixes

### DIFF
--- a/include/tmc/channel.hpp
+++ b/include/tmc/channel.hpp
@@ -1032,8 +1032,7 @@ private:
     // this token's hazptr will already be advanced to the new block.
     // Only consumers participate in reclamation and only 1 consumer at a time.
     if ((Idx & BlockSizeMask) == 1 && blocks_lock.try_lock()) {
-      // seq_cst to ensure we see any writer-protected blocks
-      size_t protectIdx = write_offset.load(std::memory_order_seq_cst);
+      size_t protectIdx = write_offset.load(std::memory_order_acquire);
       try_reclaim_blocks(Haz, protectIdx);
       blocks_lock.unlock();
     }

--- a/include/tmc/channel.hpp
+++ b/include/tmc/channel.hpp
@@ -483,10 +483,10 @@ private:
   static_assert(std::atomic<size_t>::is_always_lock_free);
   static_assert(std::atomic<data_block*>::is_always_lock_free);
 
-  static inline constexpr size_t WRITE_CLOSED_BIT = TMC_ONE_BIT;
-  static inline constexpr size_t READ_CLOSED_BIT = TMC_ONE_BIT << 1ULL;
-  static inline constexpr size_t BOTH_CLOSED_BITS =
-    WRITE_CLOSED_BIT | READ_CLOSED_BIT;
+  static inline constexpr size_t WRITE_CLOSING_BIT = TMC_ONE_BIT;
+  static inline constexpr size_t WRITE_CLOSED_BIT = TMC_ONE_BIT << 1ULL;
+  static inline constexpr size_t READ_CLOSED_BIT = TMC_ONE_BIT << 2ULL;
+  static inline constexpr size_t ALL_CLOSED_BITS = (TMC_ONE_BIT << 3ULL) - 1;
 
   // Infrequently modified values can share a cache line.
   // Written by drain() / close()
@@ -974,10 +974,24 @@ private:
     assert(
       circular_less_than(block->offset.load(std::memory_order_relaxed), 1 + Idx)
     );
-    // close() will set `closed` before incrementing offset.
-    // Thus we are guaranteed to see it if we acquire offset first.
-    if (0 != closed.load(std::memory_order_relaxed)) {
-      return nullptr;
+    // close() will set `closed` before incrementing write_offset.
+    // Thus we are guaranteed to see it if we acquire offset first (our Idx will
+    // be past write_closed_at).
+    //
+    // We may also see it earlier than that, in which case we should not return
+    // early (our Idx is less than write_closed_at).
+    auto closedState = closed.load(std::memory_order_acquire);
+    if (0 != closedState) [[unlikely]] {
+      // Wait for the write_closed_at index to become available.
+      while (0 == (closedState & WRITE_CLOSED_BIT)) {
+        TMC_CPU_PAUSE();
+        closedState = closed.load(std::memory_order_acquire);
+      }
+      if (circular_less_than(
+            write_closed_at.load(std::memory_order_relaxed), 1 + Idx
+          )) {
+        return nullptr;
+      }
     }
     block = find_block(block, Idx);
     // Update last known block.
@@ -1003,13 +1017,22 @@ private:
     assert(
       circular_less_than(block->offset.load(std::memory_order_relaxed), 1 + Idx)
     );
-    // close() will set `closed` before incrementing offset.
-    // Thus we are guaranteed to see it if we acquire offset first.
-    if (0 != closed.load(std::memory_order_acquire)) {
+
+    // close() will set `closed` before incrementing read_offset.
+    // Thus we are guaranteed to see it if we acquire offset first (our Idx
+    // will be past read_closed_at).
+    //
+    // We may see closed earlier than that, in which case our index will be
+    // between write_closed_at and read_closed_at. Make a best effort to return
+    // early in this case.
+    auto closedState = closed.load(std::memory_order_acquire);
+    if (0 != closedState) [[unlikely]] {
+      // Wait for the write_closed_at index to become available.
+      while (0 == (closedState & WRITE_CLOSED_BIT)) {
+        TMC_CPU_PAUSE();
+        closedState = closed.load(std::memory_order_acquire);
+      }
       // If closed, continue draining until the channel is empty.
-      // Producers *may* produce elements up to write_closed_at, or they may
-      // stop producing slightly sooner, in which case this consumer will be
-      // woken by drain().
       if (circular_less_than(
             write_closed_at.load(std::memory_order_relaxed), 1 + Idx
           )) {
@@ -1351,13 +1374,15 @@ private:
       woff + InactiveHazptrOffset, std::memory_order_seq_cst
     );
 
-    closed.store(WRITE_CLOSED_BIT, std::memory_order_seq_cst);
+    closed.store(WRITE_CLOSING_BIT, std::memory_order_seq_cst);
 
     // Now mark the real closed_at index. Past this index, producers are
-    // guaranteed to not produce.
-    write_closed_at.store(
-      write_offset.fetch_add(1, std::memory_order_seq_cst),
-      std::memory_order_seq_cst
+    // guaranteed to not produce. Prior to this index, producers may or may not
+    // produce, depending on when they see the closed flag being set.
+    woff = write_offset.fetch_add(1, std::memory_order_seq_cst);
+    write_closed_at.store(woff, std::memory_order_seq_cst);
+    closed.store(
+      WRITE_CLOSING_BIT | WRITE_CLOSED_BIT, std::memory_order_seq_cst
     );
   }
 
@@ -1393,12 +1418,12 @@ private:
 
     // Slow-path wait for the channel to drain.
     // Check each element prior to write_closed_at write index.
+    // Producers and consumers will be present at these indexes.
     size_t consumerWaitSpins = 0;
     while (true) {
       while (circular_less_than(i, roff) && circular_less_than(i, woff)) {
         size_t idx = i & BlockSizeMask;
         auto v = &block->values[idx];
-        // Data is present at these elements; wait for consumer
         while (!v->is_done()) {
           TMC_CPU_PAUSE();
         }
@@ -1451,15 +1476,16 @@ private:
     // In order to ensure that it is seen in a timely fashion, this
     // creates a release sequence with the acquire load in consumer.
 
-    if (closed.load() != BOTH_CLOSED_BITS) {
-      read_closed_at.store(read_offset.fetch_add(1, std::memory_order_relaxed));
-      closed.store(BOTH_CLOSED_BITS, std::memory_order_seq_cst);
+    if (closed.load() != ALL_CLOSED_BITS) {
+      read_closed_at.store(read_offset.fetch_add(1, std::memory_order_seq_cst));
+      closed.store(ALL_CLOSED_BITS, std::memory_order_seq_cst);
     }
-    roff = read_closed_at.load(std::memory_order_relaxed);
+    roff = read_closed_at.load(std::memory_order_seq_cst);
 
-    // No data will be written to these elements. They are past the
-    // write_closed_at write index. `roff` is now read_closed_at.
-    // Consumers may be waiting at indexes prior to `roff`.
+    // We  are past the write_closed_at write index; no producers will use these
+    // indexes. `roff` is now read_closed_at. Consumers may be waiting at
+    // indexes prior to `roff`, or they may see that the queue is closed and
+    // mark their elements as done.
     while (circular_less_than(i, roff)) {
       size_t idx = i & BlockSizeMask;
       auto v = &block->values[idx];
@@ -1506,11 +1532,11 @@ private:
 
     // Slow-path wait for the channel to drain.
     // Check each element prior to write_closed_at write index.
+    // Producers and consumers will be present at these indexes.
     while (true) {
       while (circular_less_than(i, roff) && circular_less_than(i, woff)) {
         size_t idx = i & BlockSizeMask;
         auto v = &block->values[idx];
-        // Data is present at these elements; wait for consumer
         while (!v->is_done()) {
           TMC_CPU_PAUSE();
         }
@@ -1543,15 +1569,16 @@ private:
     // In order to ensure that it is seen in a timely fashion, this
     // creates a release sequence with the acquire load in consumer.
 
-    if (closed.load() != BOTH_CLOSED_BITS) {
-      read_closed_at.store(read_offset.fetch_add(1, std::memory_order_relaxed));
-      closed.store(BOTH_CLOSED_BITS, std::memory_order_seq_cst);
+    if (closed.load() != ALL_CLOSED_BITS) {
+      read_closed_at.store(read_offset.fetch_add(1, std::memory_order_seq_cst));
+      closed.store(ALL_CLOSED_BITS, std::memory_order_seq_cst);
     }
-    roff = read_closed_at.load(std::memory_order_relaxed);
+    roff = read_closed_at.load(std::memory_order_seq_cst);
 
-    // No data will be written to these elements. They are past the
-    // write_closed_at write index. `roff` is now read_closed_at.
-    // Consumers may be waiting at indexes prior to `roff`.
+    // We  are past the write_closed_at write index; no producers will use these
+    // indexes. `roff` is now read_closed_at. Consumers may be waiting at
+    // indexes prior to `roff`, or they may see that the queue is closed and
+    // mark their elements as done.
     while (circular_less_than(i, roff)) {
       size_t idx = i & BlockSizeMask;
       auto v = &block->values[idx];


### PR DESCRIPTION
Detected some issues with the new channel fuzz tester.

- reopen() has been removed as it was unsound in the current implementation. I'd like to bring it back later but it will require some more finagling.
- get_write_ticket() could see the closed flag before write_closed_at was available, causing writers to abort prior to that index. This would leave readers hanging. A two-phase commit has been added so get_write_ticket() can wait for the correct write_closed_at index.
- Tweaked some atomics to introduce a proper StoreLoad barrier between fetch_add and a subsequent load. This was not observed to cause issues but is theoretically necessary.