### PR TITLE
Split detail headers into public APIs

### DIFF
--- a/include/tmc/all_headers.hpp
+++ b/include/tmc/all_headers.hpp
@@ -11,6 +11,7 @@
 #include "tmc/aw_yield.hpp"     // IWYU pragma: export
 #include "tmc/channel.hpp"      // IWYU pragma: export
 #include "tmc/current.hpp"      // IWYU pragma: export
+#include "tmc/ex_any.hpp"       // IWYU pragma: export
 #include "tmc/ex_braid.hpp"     // IWYU pragma: export
 #include "tmc/ex_cpu.hpp"       // IWYU pragma: export
 #include "tmc/external.hpp"     // IWYU pragma: export
@@ -20,3 +21,4 @@
 #include "tmc/spawn_tuple.hpp"  // IWYU pragma: export
 #include "tmc/sync.hpp"         // IWYU pragma: export
 #include "tmc/task.hpp"         // IWYU pragma: export
+#include "tmc/work_item.hpp"    // IWYU pragma: export

--- a/include/tmc/all_headers.hpp
+++ b/include/tmc/all_headers.hpp
@@ -10,6 +10,7 @@
 #include "tmc/aw_resume_on.hpp" // IWYU pragma: export
 #include "tmc/aw_yield.hpp"     // IWYU pragma: export
 #include "tmc/channel.hpp"      // IWYU pragma: export
+#include "tmc/current.hpp"      // IWYU pragma: export
 #include "tmc/ex_braid.hpp"     // IWYU pragma: export
 #include "tmc/ex_cpu.hpp"       // IWYU pragma: export
 #include "tmc/external.hpp"     // IWYU pragma: export

--- a/include/tmc/aw_resume_on.hpp
+++ b/include/tmc/aw_resume_on.hpp
@@ -8,6 +8,7 @@
 #include "tmc/detail/compat.hpp"
 #include "tmc/detail/concepts.hpp" // IWYU pragma: keep
 #include "tmc/detail/thread_locals.hpp"
+#include "tmc/ex_any.hpp"
 
 #include <coroutine>
 

--- a/include/tmc/channel.hpp
+++ b/include/tmc/channel.hpp
@@ -23,9 +23,9 @@
 // 'A wait-free queue as fast as fetch-and-add' by Yang & Mellor-Crummey
 // https://dl.acm.org/doi/10.1145/2851141.2851168
 
+#include "tmc/current.hpp"
 #include "tmc/detail/compat.hpp"
 #include "tmc/detail/concepts.hpp"
-#include "tmc/detail/thread_locals.hpp"
 #include "tmc/detail/tiny_lock.hpp"
 #include "tmc/task.hpp"
 

--- a/include/tmc/channel.hpp
+++ b/include/tmc/channel.hpp
@@ -27,6 +27,7 @@
 #include "tmc/detail/compat.hpp"
 #include "tmc/detail/concepts.hpp"
 #include "tmc/detail/tiny_lock.hpp"
+#include "tmc/ex_any.hpp"
 #include "tmc/task.hpp"
 
 #include <array>

--- a/include/tmc/current.hpp
+++ b/include/tmc/current.hpp
@@ -1,0 +1,32 @@
+// Copyright (c) 2023-2025 Logan McDougall
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include "tmc/detail/thread_locals.hpp"
+#include "tmc/ex_any.hpp"
+
+namespace tmc {
+
+/// Returns the current task's priority.
+/// Returns 0 (highest priority) if this thread is not associated with an
+/// executor.
+inline size_t current_priority() noexcept {
+  return tmc::detail::this_thread::this_task.prio;
+}
+
+/// Returns a pointer to the current thread's type-erased executor.
+/// Returns nullptr if this thread is not associated with an executor.
+inline tmc::ex_any* current_executor() noexcept {
+  return tmc::detail::this_thread::executor;
+}
+
+/// Returns the current thread's index within its executor.
+/// Returns -1 if this thread is not associated with an executor.
+inline size_t current_thread_index() noexcept {
+  return tmc::detail::this_thread::thread_index;
+}
+
+} // namespace tmc

--- a/include/tmc/detail/ex_braid.ipp
+++ b/include/tmc/detail/ex_braid.ipp
@@ -8,7 +8,9 @@
 // units, you can instead include this file directly in a CPP file.
 
 #include "tmc/detail/thread_locals.hpp"
+#include "tmc/ex_any.hpp"
 #include "tmc/ex_braid.hpp"
+#include "tmc/work_item.hpp"
 
 #include <atomic>
 

--- a/include/tmc/detail/ex_cpu.ipp
+++ b/include/tmc/detail/ex_cpu.ipp
@@ -7,11 +7,14 @@
 // anywhere TMC_IMPL is defined. If you prefer to manually separate compilation
 // units, you can instead include this file directly in a CPP file.
 
+#include "tmc/current.hpp"
 #include "tmc/detail/compat.hpp"
 #include "tmc/detail/qu_lockfree.hpp"
 #include "tmc/detail/thread_layout.hpp"
 #include "tmc/detail/thread_locals.hpp"
+#include "tmc/ex_any.hpp"
 #include "tmc/ex_cpu.hpp"
+#include "tmc/work_item.hpp"
 
 #include <bit>
 

--- a/include/tmc/detail/mixins.hpp
+++ b/include/tmc/detail/mixins.hpp
@@ -6,7 +6,7 @@
 #pragma once
 
 #include "tmc/detail/concepts.hpp"
-#include "tmc/detail/thread_locals.hpp"
+#include "tmc/ex_any.hpp"
 
 namespace tmc {
 namespace detail {

--- a/include/tmc/detail/qu_inbox.hpp
+++ b/include/tmc/detail/qu_inbox.hpp
@@ -11,6 +11,7 @@
 // At the moment it uses a single block, thus Capacity == BlockSize.
 
 #include "tmc/detail/compat.hpp"
+
 #include <array>
 #include <atomic>
 #include <cstddef>

--- a/include/tmc/detail/thread_locals.hpp
+++ b/include/tmc/detail/thread_locals.hpp
@@ -75,24 +75,4 @@ inline void post_bulk_checked(
 }
 
 } // namespace detail
-
-/// Returns a pointer to the current thread's type-erased executor.
-/// Returns nullptr if this thread is not associated with an executor.
-inline tmc::ex_any* current_executor() noexcept {
-  return tmc::detail::this_thread::executor;
-}
-
-/// Returns the current thread's index within its executor.
-/// Returns -1 if this thread is not associated with an executor.
-inline size_t current_thread_index() noexcept {
-  return tmc::detail::this_thread::thread_index;
-}
-
-/// Returns the current task's priority.
-/// Returns 0 (highest priority) if this thread is not associated with an
-/// executor.
-inline size_t current_priority() noexcept {
-  return tmc::detail::this_thread::this_task.prio;
-}
-
 } // namespace tmc

--- a/include/tmc/ex_any.hpp
+++ b/include/tmc/ex_any.hpp
@@ -63,4 +63,5 @@ public:
     };
   }
 };
+
 } // namespace tmc

--- a/include/tmc/ex_any.hpp
+++ b/include/tmc/ex_any.hpp
@@ -1,0 +1,66 @@
+// Copyright (c) 2023-2025 Logan McDougall
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include "tmc/detail/compat.hpp"
+#include "tmc/work_item.hpp"
+
+#include <cstddef>
+
+namespace tmc {
+// A type-erased executor that may represent any kind of TMC executor.
+class ex_any {
+public:
+  // Pointers to the real executor and its function implementations.
+  void* executor;
+  void (*s_post)(
+    void* Erased, work_item&& Item, size_t Priority, size_t ThreadHint
+  ) noexcept;
+  void (*s_post_bulk)(
+    void* Erased, work_item* Items, size_t Count, size_t Priority,
+    size_t ThreadHint
+  ) noexcept;
+
+  // API functions that delegate to the real executor.
+
+  /// Submits a single work item to the delegated executor.
+  inline void post(
+    work_item&& Item, size_t Priority = 0, size_t ThreadHint = NO_HINT
+  ) noexcept {
+    s_post(executor, static_cast<work_item&&>(Item), Priority, ThreadHint);
+  }
+
+  /// Submits `Count` work items from the array pointed to by `Items` to the
+  /// delegated executor.
+  inline void post_bulk(
+    work_item* Items, size_t Count, size_t Priority = 0,
+    size_t ThreadHint = NO_HINT
+  ) noexcept {
+    s_post_bulk(executor, Items, Count, Priority, ThreadHint);
+  }
+
+  /// A default constructor is offered so that other executors can initialize
+  /// this with their own function pointers.
+  ex_any() {}
+
+  /// This constructor is used by TMC executors.
+  template <typename T> ex_any(T* Executor) {
+    executor = Executor;
+    s_post = [](
+               void* Erased, work_item&& Item, size_t Priority,
+               size_t ThreadHint
+             ) noexcept {
+      static_cast<T*>(Erased)->post(std::move(Item), Priority, ThreadHint);
+    };
+    s_post_bulk = [](
+                    void* Erased, work_item* Items, size_t Count,
+                    size_t Priority, size_t ThreadHint
+                  ) noexcept {
+      static_cast<T*>(Erased)->post_bulk(Items, Count, Priority, ThreadHint);
+    };
+  }
+};
+} // namespace tmc

--- a/include/tmc/ex_braid.hpp
+++ b/include/tmc/ex_braid.hpp
@@ -15,7 +15,9 @@
 #include "tmc/detail/compat.hpp"
 #include "tmc/detail/thread_locals.hpp"
 #include "tmc/detail/tiny_lock.hpp"
+#include "tmc/ex_any.hpp"
 #include "tmc/task.hpp"
+#include "tmc/work_item.hpp"
 
 #include <coroutine>
 #include <memory>

--- a/include/tmc/ex_cpu.hpp
+++ b/include/tmc/ex_cpu.hpp
@@ -130,8 +130,8 @@ public:
   /// Builder func to set the number of threads per core before calling
   /// `init()`. Requires TMC_USE_HWLOC. The default is 1.0f, which will cause
   /// `init()` to automatically create threads equal to the number of physical
-  /// cores. If you want full SMT, set it to 2.0. Increments smaller than 0.25
-  /// are unlikely to work well.
+  /// cores. If you want full SMT, set it to 2.0. Smaller increments (1.5, 1.75)
+  /// are also valid to increase thread occupancy without full saturation.
   ex_cpu& set_thread_occupancy(float ThreadOccupancy);
 #endif
 #ifndef TMC_PRIORITY_COUNT

--- a/include/tmc/ex_cpu.hpp
+++ b/include/tmc/ex_cpu.hpp
@@ -12,6 +12,7 @@
 #endif
 
 #include "tmc/aw_resume_on.hpp"
+#include "tmc/current.hpp"
 #include "tmc/detail/compat.hpp"
 #include "tmc/detail/qu_inbox.hpp"
 #include "tmc/detail/thread_locals.hpp"

--- a/include/tmc/ex_cpu.hpp
+++ b/include/tmc/ex_cpu.hpp
@@ -17,7 +17,9 @@
 #include "tmc/detail/qu_inbox.hpp"
 #include "tmc/detail/thread_locals.hpp"
 #include "tmc/detail/tiny_vec.hpp"
+#include "tmc/ex_any.hpp"
 #include "tmc/task.hpp"
+#include "tmc/work_item.hpp"
 
 #include <atomic>
 #include <cassert>

--- a/include/tmc/external.hpp
+++ b/include/tmc/external.hpp
@@ -10,6 +10,7 @@
 
 #include "tmc/detail/concepts.hpp" // IWYU pragma: keep
 #include "tmc/detail/thread_locals.hpp"
+#include "tmc/ex_any.hpp"
 
 #include <atomic>
 

--- a/include/tmc/spawn_func.hpp
+++ b/include/tmc/spawn_func.hpp
@@ -9,7 +9,9 @@
 #include "tmc/detail/concepts.hpp" // IWYU pragma: keep
 #include "tmc/detail/mixins.hpp"
 #include "tmc/detail/thread_locals.hpp"
+#include "tmc/ex_any.hpp"
 #include "tmc/task.hpp"
+#include "tmc/work_item.hpp"
 
 #include <cassert>
 #include <coroutine>

--- a/include/tmc/spawn_many.hpp
+++ b/include/tmc/spawn_many.hpp
@@ -9,7 +9,9 @@
 #include "tmc/detail/concepts.hpp" // IWYU pragma: keep
 #include "tmc/detail/mixins.hpp"
 #include "tmc/detail/thread_locals.hpp"
+#include "tmc/ex_any.hpp"
 #include "tmc/task.hpp"
+#include "tmc/work_item.hpp"
 
 #include <array>
 #include <atomic>

--- a/include/tmc/spawn_task.hpp
+++ b/include/tmc/spawn_task.hpp
@@ -9,6 +9,7 @@
 #include "tmc/detail/concepts.hpp" // IWYU pragma: keep
 #include "tmc/detail/mixins.hpp"
 #include "tmc/detail/thread_locals.hpp"
+#include "tmc/ex_any.hpp"
 #include "tmc/task.hpp"
 
 #include <cassert>

--- a/include/tmc/spawn_tuple.hpp
+++ b/include/tmc/spawn_tuple.hpp
@@ -9,7 +9,9 @@
 #include "tmc/detail/concepts.hpp" // IWYU pragma: keep
 #include "tmc/detail/mixins.hpp"
 #include "tmc/detail/thread_locals.hpp"
+#include "tmc/ex_any.hpp"
 #include "tmc/task.hpp"
+#include "tmc/work_item.hpp"
 
 #include <bit>
 #include <cassert>

--- a/include/tmc/sync.hpp
+++ b/include/tmc/sync.hpp
@@ -15,8 +15,10 @@
 // small performance penalty.
 
 #include "tmc/detail/compat.hpp"
+#include "tmc/ex_any.hpp"
 #include "tmc/task.hpp"
 #include "tmc/utils.hpp"
+#include "tmc/work_item.hpp"
 
 #include <atomic>
 #include <coroutine>

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -9,6 +9,8 @@
 #include "tmc/detail/compat.hpp"
 #include "tmc/detail/concepts.hpp" // IWYU pragma: keep
 #include "tmc/detail/thread_locals.hpp"
+#include "tmc/ex_any.hpp"
+#include "tmc/work_item.hpp"
 
 #include <atomic>
 #include <cassert>

--- a/include/tmc/work_item.hpp
+++ b/include/tmc/work_item.hpp
@@ -1,0 +1,48 @@
+// Copyright (c) 2023-2025 Logan McDougall
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Selects the type of tmc::work_item based on the provided compile time
+// parameter TMC_WORK_ITEM=
+// CORO, FUNC, or FUNCORO
+
+// CORO will be the default if undefined
+
+#pragma once
+
+// Macro hackery to enable defines TMC_WORK_ITEM=CORO / TMC_WORK_ITEM=FUNC, etc
+#ifndef TMC_WORK_ITEM
+#define TMC_WORK_ITEM CORO
+#endif
+
+#define TMC_WORK_ITEM_CORO 0
+#define TMC_WORK_ITEM_FUNC 1
+#define TMC_WORK_ITEM_FUNCORO 2
+#define TMC_CONCAT_impl(a, b) a##b
+#define TMC_CONCAT(a, b) TMC_CONCAT_impl(a, b)
+#define TMC_WORK_ITEM_IS_impl(WORK_ITEM_TYPE)                                  \
+  TMC_CONCAT(TMC_WORK_ITEM_, TMC_WORK_ITEM) ==                                 \
+    TMC_CONCAT(TMC_WORK_ITEM_, WORK_ITEM_TYPE)
+#define TMC_WORK_ITEM_IS(WORK_ITEM_TYPE) TMC_WORK_ITEM_IS_impl(WORK_ITEM_TYPE)
+
+#if TMC_WORK_ITEM_IS(CORO)
+#include <coroutine>
+namespace tmc {
+using work_item = std::coroutine_handle<>;
+}
+#define TMC_WORK_ITEM_AS_STD_CORO(x) (x)
+#elif TMC_WORK_ITEM_IS(FUNC)
+#include <functional>
+namespace tmc {
+using work_item = std::function<void()>;
+}
+#define TMC_WORK_ITEM_AS_STD_CORO(x)                                           \
+  (*x.template target<std::coroutine_handle<>>())
+#elif TMC_WORK_ITEM_IS(FUNCORO)
+#include "tmc/detail/coro_functor.hpp"
+namespace tmc {
+using work_item = tmc::coro_functor;
+}
+#define TMC_WORK_ITEM_AS_STD_CORO(x) (x.as_coroutine())
+#endif


### PR DESCRIPTION
Should limit the need for most use cases to need to include any headers in the "detail" folder.

3 new public headers:
- "tmc/current.hpp" - exposes `tmc::current_priority()`, `tmc::current_executor()`, `tmc::current_thread_index()`
- "tmc/ex_any.hpp" - exposes the `tmc::ex_any` type-erased executor type
- "tmc/work_item.hpp" - exposes the `tmc::work_item` type