### PR TITLE
Spawn_many / post_bulk accepts range object parameter

### DIFF
--- a/include/tmc/detail/concepts_awaitable.hpp
+++ b/include/tmc/detail/concepts_awaitable.hpp
@@ -186,5 +186,17 @@ struct awaitable_traits<Awaitable> {
     decltype(get_awaiter(std::declval<Awaitable>()).await_resume())>;
 };
 
+template <typename T>
+concept IsRange = requires(T a) {
+  // This concept is somewhat incomplete - also need to test for
+  // operator++ and operator*. However, along with the
+  // iter_value_t template deduction, it is sufficient.
+  a.begin() == a.end();
+};
+
+template <IsRange R> struct range_iter {
+  using type = decltype(std::declval<R>().begin());
+};
+
 } // namespace detail
 } // namespace tmc


### PR DESCRIPTION
All iterator-accepting work item creation functions now accept 3 forms of iterator parameters:
- func(Range) // where Range has begin() and end() functions
- func(BeginIter, EndIter)
- func(BeginIter, Count)

Implemented for `tmc::spawn_many()`, `tmc::spawn_func_many()`, `tmc::post_bulk()` and `tmc::post_bulk_waitable()`.

New tests added for all variations in https://github.com/tzcnt/tmc-examples/pull/34

Closes #54 