### PR TITLE
CI Test Coverage, round 2

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -45,10 +45,10 @@ jobs:
     - name: merge
       run: llvm-profdata-18 merge -sparse raw.profraw -o coverage.profdata
     - name: show
-      run: llvm-cov-18 show ./build/${{matrix.PRESET}}/tests/tests -instr-profile=coverage.profdata ./submodules/TooManyCooks/ > coverage.txt
+      run: llvm-cov-18 show ./build/${{matrix.PRESET}}/tests/tests -instr-profile=coverage.profdata ./submodules/TooManyCooks/ > ./submodules/TooManyCooks/coverage.txt
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v5
       with:
         token: ${{secrets.CODECOV_TOKEN}}
         slug: tzcnt/TooManyCooks
-        recurse_submodules: true
+        working-directory: ./submodules/TooManyCooks

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -45,7 +45,7 @@ jobs:
     - name: merge
       run: llvm-profdata-18 merge -sparse raw.profraw -o coverage.profdata
     - name: show
-      run: llvm-cov-18 show ./build/${{matrix.PRESET}}/tests/tests -instr-profile=coverage.profdata > coverage.txt
+      run: llvm-cov-18 show ./build/${{matrix.PRESET}}/tests/tests -instr-profile=coverage.profdata ./submodules/TooManyCooks/ > coverage.txt
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v5
       with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -45,9 +45,7 @@ jobs:
     - name: merge
       run: llvm-profdata-18 merge -sparse raw.profraw -o coverage.profdata
     - name: show
-      run: llvm-cov-18 show ./build/${{matrix.PRESET}}/tests/tests -instr-profile=coverage.profdata ./submodules/TooManyCooks/ > ./submodules/TooManyCooks/coverage.txt
-    - name: sed
-      run: sed -i 's/\/home\/runner\/work\/TooManyCooks\/TooManyCooks\/submodules\/TooManyCooks\/include/\/home\/runner\/work\/TooManyCooks\/TooManyCooks\/include/g' ./submodules/TooManyCooks/coverage.txt
+      run: llvm-cov-18 export -format=lcov -instr-profile=coverage.profdata ./build/${{matrix.PRESET}}/tests/tests ./submodules/TooManyCooks/ > ./submodules/TooManyCooks/coverage.info
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v5
       with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -46,6 +46,8 @@ jobs:
       run: llvm-profdata-18 merge -sparse raw.profraw -o coverage.profdata
     - name: show
       run: llvm-cov-18 show ./build/${{matrix.PRESET}}/tests/tests -instr-profile=coverage.profdata ./submodules/TooManyCooks/ > ./submodules/TooManyCooks/coverage.txt
+    - name: sed
+      run: sed -i 's/\/home\/runner\/work\/TooManyCooks\/TooManyCooks\/submodules\/TooManyCooks\/include/include/g' ./submodules/TooManyCooks/coverage.txt
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v5
       with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -51,5 +51,4 @@ jobs:
       with:
         token: ${{secrets.CODECOV_TOKEN}}
         slug: tzcnt/TooManyCooks
-        directory: ./
-        working-directory: ./submodules/TooManyCooks/
+        recurse_submodules: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -51,3 +51,5 @@ jobs:
       with:
         token: ${{secrets.CODECOV_TOKEN}}
         slug: tzcnt/TooManyCooks
+        directory: ./
+        working-directory: ./submodules/TooManyCooks/

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -47,7 +47,7 @@ jobs:
     - name: show
       run: llvm-cov-18 show ./build/${{matrix.PRESET}}/tests/tests -instr-profile=coverage.profdata ./submodules/TooManyCooks/ > ./submodules/TooManyCooks/coverage.txt
     - name: sed
-      run: sed -i 's/\/home\/runner\/work\/TooManyCooks\/TooManyCooks\/submodules\/TooManyCooks\/include/include/g' ./submodules/TooManyCooks/coverage.txt
+      run: sed -i 's/\/home\/runner\/work\/TooManyCooks\/TooManyCooks\/submodules\/TooManyCooks\/include/\/home\/runner\/work\/TooManyCooks\/TooManyCooks\/include/g' ./submodules/TooManyCooks/coverage.txt
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v5
       with:


### PR DESCRIPTION
Calculate coverage for the library, not the test files. Configuring codecov correctly took some experimentation.