### PR TITLE
Additional test coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -41,11 +41,15 @@ jobs:
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests
-      run: LLVM_PROFILE_FILE=raw.profraw ./build/${{matrix.PRESET}}/tests/tests
+      run: LLVM_PROFILE_FILE=tests.profraw ./build/${{matrix.PRESET}}/tests/tests
+      # test_exceptions depends on unknown awaitables which are disabled during the regular tests
+      # thus it must be compiled and run separately
+    - name: run tests
+      run: LLVM_PROFILE_FILE=test_exceptions.profraw ./build/${{matrix.PRESET}}/tests/test_exceptions
     - name: merge
-      run: llvm-profdata-18 merge -sparse raw.profraw -o coverage.profdata
+      run: llvm-profdata-18 merge -sparse tests.profraw test_exceptions.profraw -o coverage.profdata
     - name: show
-      run: llvm-cov-18 export -format=lcov -instr-profile=coverage.profdata ./build/${{matrix.PRESET}}/tests/tests ./submodules/TooManyCooks/ > ./submodules/TooManyCooks/coverage.info
+      run: llvm-cov-18 export -format=lcov -instr-profile=coverage.profdata ./build/${{matrix.PRESET}}/tests/tests ./build/${{matrix.PRESET}}/tests/test_exceptions ./submodules/TooManyCooks/ > ./submodules/TooManyCooks/coverage.info
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v5
       with:

--- a/include/tmc/detail/ex_cpu.ipp
+++ b/include/tmc/detail/ex_cpu.ipp
@@ -317,8 +317,20 @@ bool ex_cpu::try_run_some(
   }
 }
 
+void ex_cpu::clamp_priority(size_t& Priority) {
+#ifdef TMC_PRIORITY_COUNT
+  if constexpr (PRIORITY_COUNT == 1) {
+    Priority = 0;
+    return;
+  }
+#endif
+  if (Priority > PRIORITY_COUNT - 1) {
+    Priority = PRIORITY_COUNT - 1;
+  }
+}
+
 void ex_cpu::post(work_item&& Item, size_t Priority, size_t ThreadHint) {
-  assert(Priority < PRIORITY_COUNT);
+  clamp_priority(Priority);
   bool fromExecThread = tmc::detail::this_thread::executor == &type_erased_this;
   if (ThreadHint < thread_count()) {
     if (thread_states[ThreadHint].inbox->try_push(std::move(Item))) {

--- a/include/tmc/detail/qu_lockfree.hpp
+++ b/include/tmc/detail/qu_lockfree.hpp
@@ -2443,7 +2443,9 @@ public:
 
       // Dequeue
       T& el = *((*block)[index]);
-      if (!MOODYCAMEL_NOEXCEPT_ASSIGN(element = static_cast<T&&>(el))) {
+      if constexpr (!MOODYCAMEL_NOEXCEPT_ASSIGN(
+                      element = static_cast<T&&>(el)
+                    )) {
         struct Guard {
           Block* block;
           index_t index;
@@ -2570,7 +2572,9 @@ public:
 
       // Dequeue
       T& el = *((*block)[index]);
-      if (!MOODYCAMEL_NOEXCEPT_ASSIGN(element = static_cast<T&&>(el))) {
+      if constexpr (!MOODYCAMEL_NOEXCEPT_ASSIGN(
+                      element = static_cast<T&&>(el)
+                    )) {
         // Make sure the element is still fully dequeued and destroyed even
         // if the assignment throws
         struct Guard {
@@ -2960,10 +2964,10 @@ public:
                 ? firstIndex + static_cast<index_t>(actualCount)
                 : endIndex;
             auto block = localBlockIndex->entries[indexIndex].block;
-            if (MOODYCAMEL_NOEXCEPT_ASSIGN(
-                  details::deref_noexcept(itemFirst) =
-                    static_cast<T&&>((*(*block)[index]))
-                )) {
+            if constexpr (MOODYCAMEL_NOEXCEPT_ASSIGN(
+                            details::deref_noexcept(itemFirst) =
+                              static_cast<T&&>((*(*block)[index]))
+                          )) {
               while (index != endIndex) {
                 T& el = *((*block)[index]);
                 *itemFirst = static_cast<T&&>(el);
@@ -3305,7 +3309,9 @@ private:
       auto block = entry->value.load(std::memory_order_relaxed);
       T& el = *((*block)[index]);
 
-      if (!MOODYCAMEL_NOEXCEPT_ASSIGN(element = static_cast<T&&>(el))) {
+      if constexpr (!MOODYCAMEL_NOEXCEPT_ASSIGN(
+                      element = static_cast<T&&>(el)
+                    )) {
 #ifdef MCDBGQ_NOLOCKFREE_IMPLICITPRODBLOCKINDEX
         // Note: Acquiring the mutex with every dequeue instead of only when
         // a block is released is very sub-optimal, but it is, after all,
@@ -3639,10 +3645,10 @@ private:
 
             auto entry = localBlockIndex->index[indexIndex];
             auto block = entry->value.load(std::memory_order_relaxed);
-            if (MOODYCAMEL_NOEXCEPT_ASSIGN(
-                  details::deref_noexcept(itemFirst) =
-                    static_cast<T&&>((*(*block)[index]))
-                )) {
+            if constexpr (MOODYCAMEL_NOEXCEPT_ASSIGN(
+                            details::deref_noexcept(itemFirst) =
+                              static_cast<T&&>((*(*block)[index]))
+                          )) {
               while (index != endIndex) {
                 T& el = *((*block)[index]);
                 *itemFirst = static_cast<T&&>(el);

--- a/include/tmc/detail/thread_layout.hpp
+++ b/include/tmc/detail/thread_layout.hpp
@@ -31,7 +31,7 @@ std::vector<L3CacheSet> group_cores_by_l3c(hwloc_topology_t& Topology);
 // enabled.
 // Returns the PU-to-thread-index mapping used by notify_n.
 std::vector<size_t> adjust_thread_groups(
-  size_t RequestedThreadCount, size_t RequestedOccupancy,
+  size_t RequestedThreadCount, float RequestedOccupancy,
   std::vector<L3CacheSet>& GroupedCores, bool& Lasso
 );
 
@@ -94,7 +94,7 @@ slice_matrix(std::vector<size_t> const& InputMatrix, size_t N, size_t Slot);
 
 #ifndef NDEBUG
 void print_square_matrix(
-  std::vector<size_t> mat, size_t n, char* header = nullptr
+  std::vector<size_t> mat, size_t n, const char* header = nullptr
 );
 #endif
 } // namespace detail

--- a/include/tmc/ex_cpu.hpp
+++ b/include/tmc/ex_cpu.hpp
@@ -77,6 +77,8 @@ class ex_cpu {
 
   bool is_initialized();
 
+  void clamp_priority(size_t& Priority);
+
   void notify_n(
     size_t Count, size_t Priority, size_t ThreadHint, bool FromExecThread,
     bool FromPost
@@ -190,7 +192,7 @@ public:
   void post_bulk(
     It&& Items, size_t Count, size_t Priority = 0, size_t ThreadHint = NO_HINT
   ) {
-    assert(Priority < PRIORITY_COUNT);
+    clamp_priority(Priority);
     bool fromExecThread =
       tmc::detail::this_thread::executor == &type_erased_this;
     if (ThreadHint < thread_count()) {


### PR DESCRIPTION
The only functional change is that submitting a task with priority that is outside of the allowed range to ex_cpu (that is, >= ex.priority_count()), will be clamped to the lowest priority (ex.priority_count() - 1) instead of asserting.

Removing some unused code from qu_lockfree - for this library the queue cannot be moved or swapped