### PR TITLE
handle irregular work stealing matrixes

### DIFF
--- a/include/tmc/detail/thread_layout.ipp
+++ b/include/tmc/detail/thread_layout.ipp
@@ -469,14 +469,22 @@ get_lattice_matrix(std::vector<L3CacheSet> const& groupedCores) {
   return forward;
 }
 
+// For each thread, find the threads that will search it to steal from soonest.
+// These are the threads that should be woken first to steal from this thread.
 std::vector<size_t>
 invert_matrix(std::vector<size_t> const& InputMatrix, size_t N) {
   std::vector<size_t> output;
   output.resize(N * N);
-  for (size_t row = 0; row < N; ++row) {
-    for (size_t col = 0; col < N; ++col) {
-      size_t val = InputMatrix[row * N + col];
-      output[val * N + col] = row;
+  // Same as doing push_back to a vector<vector> but we know the fixed size in
+  // advance. So just track the sub-index (col) of each nested vector (row).
+  std::vector<size_t> outCols(N, 0);
+  for (size_t col = 0; col < N; ++col) {
+    for (size_t row = 0; row < N; ++row) {
+      size_t val = InputMatrix[row * N];
+      size_t outRow = InputMatrix[row * N + col];
+      size_t outCol = outCols[outRow];
+      output[outRow * N + outCol] = val;
+      ++outCols[outRow];
     }
   }
   return output;


### PR DESCRIPTION
Experimenting with the hwloc layout on my Khadas Edge2 which has a RK3588S processor - I observed that it only produces a single group due to the [single L3 cache on the system](https://www.cnx-software.com/2022/01/12/rockchip-rk3588s-cost-optimized-cortex-a76-a55-processor/). I tried some experimentation and was unable to see the 4+4 layout described in the block diagram based on L2 caches... but I did find a 4+2+2 layout when partitioning based on HWLOC_OBJ_PACKAGE. This is an issue with the way the system represents itself to hwloc and something to be explored in a future PR.

When using this 4+2+2 layout I observed that the inverse work stealing (aka waker) matrix was not generating properly. This is because the original inverting algorithm expected that each output index was unique - e.g. for thread 3, that only 1 other thread would steal from thread 3 in its Nth order in its steal list. However, in this layout multiple threads may steal from another thread in the same order in their steal list. E.g. in the steal matrix, threads 2, 4, and 6 all check thread 0 as their 3rd choice to steal from.

So, rather than outputting based on fixed index, output using "push_back" - so 2, 4, 6 appear sequentially in the list for 0's waker matrix. On machines with regular structures, this will produce an identical output to the existing code.

<details>
<summary>Steal matrix for 4+2+2 configuration</summary>

```
   0   1   2   3   4   6   5   7
   1   2   3   0   5   7   4   6
   2   3   0   1   4   6   5   7
   3   0   1   2   5   7   4   6
   4   5   0   6   1   2   3   7
   5   4   1   7   2   3   0   6
   6   7   0   4   1   2   3   5
   7   6   1   5   2   3   0   4
```
</details>

<details>
<summary>Bugged waker matrix</summary>

```
   0   3   6   1   0   0   7   0
   1   0   7   2   6   0   0   0
   2   1   0   3   7   6   0   0
   3   2   1   0   0   7   6   0
   4   5   0   6   2   0   3   7
   5   4   0   7   3   0   2   6
   6   7   0   4   0   2   0   5
   7   6   0   5   0   3   0   4
```
</details>

<details>
<summary>Fixed waker matrix</summary>

```
   0   3   2   4   6   1   5   7
   1   0   3   5   7   2   4   6
   2   1   0   3   5   7   4   6
   3   2   1   0   5   7   4   6
   4   5   6   0   2   1   3   7
   5   4   7   1   3   0   2   6
   6   7   4   0   2   1   3   5
   7   6   5   1   3   0   2   4
```
</details>

---

The resulting waker matrix still isn't ideal but at least it's well-formed. The ideal matrix *would* have unique indexes for each output. Fixing that is in-scope for a future PR, and would likely go along with the P+E detection as that also handles irregularly sized groups.

Additionally, fixing the HWLOC detection to handle machines that report themselves weirdly (like the 4+2+2 split based on PACKAGE and not L3CACHE) will also go in a future PR. It's also worth noting that on the RK3588S this isn't a performance win, and it appears to be better to just use a single group - likely because of the performance differential between P and E cores.