### PR TITLE
replace void spawn specialization with no_unique_address empty struct

### DIFF
--- a/include/tmc/channel.hpp
+++ b/include/tmc/channel.hpp
@@ -1330,7 +1330,7 @@ public:
             );
 
             if (elapsed >= parent.haz_ptr->minCycles * writerCount) {
-              // Just suspend without clustering (to allow other producers to
+              // Just suspend without clustering (to allow other consumers to
               // run)
               parent.haz_ptr->write_count.store(0, std::memory_order_relaxed);
               parent.haz_ptr->read_count.store(0, std::memory_order_relaxed);

--- a/include/tmc/ex_any.hpp
+++ b/include/tmc/ex_any.hpp
@@ -11,7 +11,7 @@
 #include <cstddef>
 
 namespace tmc {
-// A type-erased executor that may represent any kind of TMC executor.
+/// A type-erased executor that may represent any kind of TMC executor.
 class ex_any {
 public:
   // Pointers to the real executor and its function implementations.

--- a/include/tmc/spawn_task.hpp
+++ b/include/tmc/spawn_task.hpp
@@ -282,7 +282,7 @@ public:
   /// Submits the wrapped task to the executor immediately. It cannot be awaited
   /// afterward.
   void detach()
-    requires(!std::is_void_v<Awaitable>)
+    requires(std::is_void_v<Result>)
   {
 #ifndef NDEBUG
     assert(!is_empty && "You may only submit or co_await this once.");


### PR DESCRIPTION
Other newer implementations of spawn functions already make use of this. Having a single implementation rather than a specialization is much easier to maintain.