### PR TITLE
cleanup each_result

### DIFF
--- a/include/tmc/aw_resume_on.hpp
+++ b/include/tmc/aw_resume_on.hpp
@@ -110,7 +110,10 @@ public:
   }
 
   /// Always suspends.
-  inline bool await_ready() { return false; }
+  inline bool await_ready() {
+    // Always suspends, due to the possibility to resume on another executor.
+    return false;
+  }
 
   /// Post this task to the continuation executor.
   TMC_FORCE_INLINE inline void await_suspend(std::coroutine_handle<> Outer) {
@@ -170,9 +173,7 @@ class [[nodiscard("You must co_await aw_ex_scope_enter for it to have any "
 public:
   /// Always suspends.
   inline bool await_ready() {
-    // always have to suspend here, even if we can get the lock right away
-    // we need to resume() inside of run_loop so that if this coro gets
-    // suspended, it won't suspend while holding the lock forever
+    // Always suspends, due to the possibility to resume on another executor.
     return false;
   }
 

--- a/include/tmc/aw_yield.hpp
+++ b/include/tmc/aw_yield.hpp
@@ -25,7 +25,7 @@ inline bool yield_requested() {
 class [[nodiscard("You must co_await aw_yield for it to have any effect."
 )]] aw_yield : tmc::detail::AwaitTagNoGroupAsIs {
 public:
-  /// This awaitable always suspends outer.
+  /// Always suspends.
   inline bool await_ready() const noexcept { return false; }
 
   /// Post the outer task to its current executor, so that a higher priority

--- a/include/tmc/spawn_func.hpp
+++ b/include/tmc/spawn_func.hpp
@@ -50,7 +50,10 @@ template <typename Result> class aw_spawn_func_impl {
 
 public:
   /// Always suspends.
-  inline bool await_ready() const noexcept { return false; }
+  inline bool await_ready() const noexcept {
+    // Always suspends, due to the possibility to resume on another executor.
+    return false;
+  }
 
   /// Suspends the outer coroutine, submits the wrapped task to the
   /// executor, and waits for it to complete.
@@ -162,7 +165,10 @@ template <typename Result> class aw_spawn_func_fork_impl {
 
 public:
   /// Always suspends.
-  inline bool await_ready() const noexcept { return false; }
+  inline bool await_ready() const noexcept {
+    // Always suspends, due to the possibility to resume on another executor.
+    return false;
+  }
 
   /// Suspends the outer coroutine, submits the wrapped task to the
   /// executor, and waits for it to complete.

--- a/include/tmc/spawn_many.hpp
+++ b/include/tmc/spawn_many.hpp
@@ -713,6 +713,7 @@ public:
   inline bool await_ready() const noexcept
     requires(!IsEach)
   {
+    // Always suspends, due to the possibility to resume on another executor.
     return false;
   }
 
@@ -787,7 +788,7 @@ public:
     requires(IsEach)
   {
     return tmc::detail::each_result_await_suspend(
-      Outer, continuation, continuation_executor, sync_flags
+      remaining_count, Outer, continuation, continuation_executor, sync_flags
     );
   }
 

--- a/include/tmc/spawn_task.hpp
+++ b/include/tmc/spawn_task.hpp
@@ -94,7 +94,10 @@ template <typename Awaitable, typename Result> class aw_spawn_fork_impl {
 
 public:
   /// Always suspends.
-  inline bool await_ready() const noexcept { return false; }
+  inline bool await_ready() const noexcept {
+    // Always suspends, due to the possibility to resume on another executor.
+    return false;
+  }
 
   /// Suspends the outer coroutine, submits the wrapped task to the
   /// executor, and waits for it to complete.

--- a/include/tmc/spawn_tuple.hpp
+++ b/include/tmc/spawn_tuple.hpp
@@ -271,6 +271,7 @@ public:
   inline bool await_ready() const noexcept
     requires(!IsEach)
   {
+    // Always suspends, due to the possibility to resume on another executor.
     return false;
   }
 
@@ -341,7 +342,7 @@ public:
     requires(IsEach)
   {
     return tmc::detail::each_result_await_suspend(
-      Outer, continuation, continuation_executor, sync_flags
+      remaining_count, Outer, continuation, continuation_executor, sync_flags
     );
   }
 


### PR DESCRIPTION
each_result must always suspend in order to be able to implement resume_on executor transfer. Also make the logic a bit cleaner.