### PR TITLE
Channel fixes

### DIFF
--- a/include/tmc/channel.hpp
+++ b/include/tmc/channel.hpp
@@ -417,13 +417,13 @@ private:
       // These defaults ensure sane behavior.
       write_block.store(nullptr, std::memory_order_relaxed);
       read_block.store(nullptr, std::memory_order_relaxed);
-      active_offset.store(InactiveHazptrOffset, std::memory_order_relaxed);
     }
 
     hazard_ptr() noexcept {
       thread_index.store(
         static_cast<int>(tmc::current_thread_index()), std::memory_order_relaxed
       );
+      active_offset.store(InactiveHazptrOffset, std::memory_order_relaxed);
       release();
     }
 


### PR DESCRIPTION
Resolve issues identified by new tests in https://github.com/tzcnt/tmc-examples/pull/43

The prior fix https://github.com/tzcnt/TooManyCooks/pull/63/commits/f3ec85b5b07e01b314ab785db17268aeaaba2119 failed to account for conditions where a single token may be used first as a producer and then later as a consumer. A separate next_protect index needs to be cached for the read and write indexes.

It was observed the try_reclaim_blocks() call in drain() may not see the block next pointer be updated - because it doesn't wait for the block to be ready, like the loop later in the same function, it may just go to a nullptr block. This is resolved by now waiting for the block to appear before calling try_reclaim_blocks().