### PR TITLE
Make qu_lockfree enqueue() operations infallible

### DIFF
--- a/include/tmc/detail/qu_lockfree.hpp
+++ b/include/tmc/detail/qu_lockfree.hpp
@@ -783,49 +783,47 @@ public:
   // Enqueues a single item (by copying it).
   // Allocates memory if required.
   // Thread-safe.
-  inline bool enqueue(T const& item) { return inner_enqueue(item); }
+  inline void enqueue(T const& item) { inner_enqueue(item); }
 
   // Enqueues a single item (by moving it, if possible).
   // Allocates memory if required.
   // Thread-safe.
-  inline bool enqueue(T&& item) {
-    return inner_enqueue(static_cast<T&&>(item));
-  }
+  inline void enqueue(T&& item) { inner_enqueue(static_cast<T&&>(item)); }
 
-  inline bool enqueue_ex_cpu(T const& item, size_t priority) {
+  inline void enqueue_ex_cpu(T const& item, size_t priority) {
     ExplicitProducer** producers =
       static_cast<ExplicitProducer**>(tmc::detail::this_thread::producers);
     ExplicitProducer* this_thread_prod =
       static_cast<ExplicitProducer*>(producers[priority * dequeueProducerCount]
       );
-    return this_thread_prod->enqueue(item);
+    this_thread_prod->enqueue(item);
   }
 
-  inline bool enqueue_ex_cpu(T&& item, size_t priority) {
+  inline void enqueue_ex_cpu(T&& item, size_t priority) {
     ExplicitProducer** producers =
       static_cast<ExplicitProducer**>(tmc::detail::this_thread::producers);
     ExplicitProducer* this_thread_prod =
       static_cast<ExplicitProducer*>(producers[priority * dequeueProducerCount]
       );
-    return this_thread_prod->enqueue(static_cast<T&&>(item));
+    this_thread_prod->enqueue(static_cast<T&&>(item));
   }
 
   // Enqueues several items.
   // Allocates memory if required.
   // Note: Use std::make_move_iterator if the elements should be moved instead
   // of copied. Thread-safe.
-  template <typename It> bool enqueue_bulk(It itemFirst, size_t count) {
-    return inner_enqueue_bulk(itemFirst, count);
+  template <typename It> void enqueue_bulk(It itemFirst, size_t count) {
+    inner_enqueue_bulk(itemFirst, count);
   }
 
   template <typename It>
-  bool enqueue_bulk_ex_cpu(It itemFirst, size_t count, size_t priority) {
+  void enqueue_bulk_ex_cpu(It itemFirst, size_t count, size_t priority) {
     ExplicitProducer** producers =
       static_cast<ExplicitProducer**>(tmc::detail::this_thread::producers);
     ExplicitProducer* this_thread_prod =
       static_cast<ExplicitProducer*>(producers[priority * dequeueProducerCount]
       );
-    return this_thread_prod->enqueue_bulk(itemFirst, count);
+    this_thread_prod->enqueue_bulk(itemFirst, count);
   }
 
   // Attempts to dequeue from the queue.
@@ -1018,19 +1016,17 @@ private:
   // Queue methods
   ///////////////////////////////
 
-  template <typename U> inline bool inner_enqueue(U&& element) {
+  template <typename U> inline void inner_enqueue(U&& element) {
     auto producer = get_or_add_implicit_producer();
-    return producer->ConcurrentQueue::ImplicitProducer::enqueue(
+    producer->ConcurrentQueue::ImplicitProducer::enqueue(
       static_cast<U&&>(element)
     );
   }
 
   template <typename It>
-  inline bool inner_enqueue_bulk(It itemFirst, size_t count) {
+  inline void inner_enqueue_bulk(It itemFirst, size_t count) {
     auto producer = get_or_add_implicit_producer();
-    return producer->ConcurrentQueue::ImplicitProducer::enqueue_bulk(
-      itemFirst, count
-    );
+    producer->ConcurrentQueue::ImplicitProducer::enqueue_bulk(itemFirst, count);
   }
 
   ///////////////////////////

--- a/include/tmc/detail/qu_lockfree.hpp
+++ b/include/tmc/detail/qu_lockfree.hpp
@@ -1913,7 +1913,7 @@ public:
 
       // First, we need to make sure we have enough room to enqueue all of the
       // elements; this means pre-allocating blocks and putting them in the
-      // block index (but only if all the allocations succeeded).
+      // block index.
       index_t startTailIndex = this->tailIndex.load(std::memory_order_relaxed);
       auto startBlock = this->tailBlock;
       auto originalBlockIndexFront = pr_blockIndexFront;
@@ -2009,8 +2009,8 @@ public:
           }
         }
 
-        // Excellent, all allocations succeeded. Reset each block's emptiness
-        // before we fill them up, and publish the new block index front
+        // Reset each block's emptiness before we fill them up, and publish the
+        // new block index front
         auto block = firstAllocatedBlock;
         while (true) {
           block->ConcurrentQueue::Block::template reset_empty<explicit_context>(
@@ -2601,7 +2601,7 @@ private:
 
       // First, we need to make sure we have enough room to enqueue all of the
       // elements; this means pre-allocating blocks and putting them in the
-      // block index (but only if all the allocations succeeded).
+      // block index.
 
       // Note that the tailBlock we start off with may not be owned by us any
       // more; this happens if it was filled up exactly to the top (setting
@@ -2645,9 +2645,8 @@ private:
           // Insert the new block into the index
           idxEntry->value.store(newBlock, std::memory_order_relaxed);
 
-          // Store the chain of blocks so that we can undo if later allocations
-          // fail, and so that we can find the blocks when we do the actual
-          // enqueueing
+          // Store the chain of blocks so that we can find the blocks when we do
+          // the actual enqueueing
           if ((startTailIndex & static_cast<index_t>(BLOCK_MASK)) != 0 ||
               firstAllocatedBlock != nullptr) {
             assert(this->tailBlock != nullptr);
@@ -3357,7 +3356,6 @@ private:
     implicitProducerHash.store(hash, std::memory_order_relaxed);
   }
 
-  // Only fails (returns nullptr) if memory allocation fails
   ImplicitProducer* get_or_add_implicit_producer() {
     // Note that since the data is essentially thread-local (key is thread ID),
     // there's a reduced need for fences (memory ordering is already consistent

--- a/include/tmc/detail/qu_lockfree.hpp
+++ b/include/tmc/detail/qu_lockfree.hpp
@@ -1584,7 +1584,7 @@ public:
       }
     }
 
-    template <typename U> inline bool enqueue(U&& element) {
+    template <typename U> inline void enqueue(U&& element) {
       index_t currentTailIndex =
         this->tailIndex.load(std::memory_order_relaxed);
       index_t newTailIndex = 1 + currentTailIndex;
@@ -1679,7 +1679,7 @@ public:
         if constexpr (!MOODYCAMEL_NOEXCEPT_CTOR(new (static_cast<T*>(nullptr)
                       ) T(static_cast<U&&>(element)))) {
           this->tailIndex.store(newTailIndex, std::memory_order_release);
-          return true;
+          return;
         }
       }
 
@@ -1687,7 +1687,6 @@ public:
       new ((*this->tailBlock)[currentTailIndex]) T(static_cast<U&&>(element));
 
       this->tailIndex.store(newTailIndex, std::memory_order_release);
-      return true;
     }
 
     // TZCNT MODIFIED: Pops from tail (like a LIFO stack) instead of from head
@@ -1924,7 +1923,7 @@ public:
     }
 
     template <typename It>
-    bool MOODYCAMEL_NO_TSAN enqueue_bulk(It itemFirst, size_t count) {
+    void MOODYCAMEL_NO_TSAN enqueue_bulk(It itemFirst, size_t count) {
       static constexpr bool HasMoveConstructor = std::is_constructible_v<
         T, std::add_rvalue_reference_t<std::iter_value_t<It>>>;
       static constexpr bool HasNoexceptMoveConstructor =
@@ -2180,7 +2179,6 @@ public:
       }
 
       this->tailIndex.store(newTailIndex, std::memory_order_release);
-      return true;
     }
 
     template <typename It> size_t dequeue_bulk(It& itemFirst, size_t max) {
@@ -2477,7 +2475,7 @@ private:
       }
     }
 
-    template <typename U> inline bool enqueue(U&& element) {
+    template <typename U> inline void enqueue(U&& element) {
       index_t currentTailIndex =
         this->tailIndex.load(std::memory_order_relaxed);
       index_t newTailIndex = 1 + currentTailIndex;
@@ -2523,7 +2521,7 @@ private:
         if constexpr (!MOODYCAMEL_NOEXCEPT_CTOR(new (static_cast<T*>(nullptr)
                       ) T(static_cast<U&&>(element)))) {
           this->tailIndex.store(newTailIndex, std::memory_order_release);
-          return true;
+          return;
         }
       }
 
@@ -2531,7 +2529,6 @@ private:
       new ((*this->tailBlock)[currentTailIndex]) T(static_cast<U&&>(element));
 
       this->tailIndex.store(newTailIndex, std::memory_order_release);
-      return true;
     }
 
     template <typename U> bool dequeue(U& element) {
@@ -2619,7 +2616,7 @@ private:
       return true;
     }
 
-    template <typename It> bool enqueue_bulk(It itemFirst, size_t count) {
+    template <typename It> void enqueue_bulk(It itemFirst, size_t count) {
       static constexpr bool HasMoveConstructor = std::is_constructible_v<
         T, std::add_rvalue_reference_t<std::iter_value_t<It>>>;
       static constexpr bool HasNoexceptMoveConstructor =
@@ -2808,7 +2805,6 @@ private:
         this->tailBlock = this->tailBlock->next;
       }
       this->tailIndex.store(newTailIndex, std::memory_order_release);
-      return true;
     }
 
     template <typename It> size_t dequeue_bulk(It& itemFirst, size_t max) {


### PR DESCRIPTION
The last remaining possible failure mode for the enqueue() operation was:
```cpp
bool full = !details::circular_less_than<index_t>(head, currentTailIndex + PRODUCER_BLOCK_SIZE);
if (full) {
  // ... rewind the insertion in various ways
  return false;
}
```
Given that there was an assert immediately before this that is essentially `assert(head <= currentTailIndex);` I've determined that this can only happen if the queue is very full and `currentTailIndex + PRODUCER_BLOCK_SIZE` exceeds the threshold for `circular_less_than` / "wraps around" so that the queue now thinks that it's less than head.

On 32 bit it may happen if there are ~2^30 elements in the queue. Given that the element size is at least a pointer (4 bytes on 32-bit) that means there would be 4GB of data in the queue alone - leaving no room for anything else in the system with the maximum address space of a 32 bit system.

On 64 bit this can never happen - the index won't roll over in any real time frame, nor can the system memory capacity handle the number of elements that would need to be present in the queue to make this happen.

Thus I feel confident that this check can be removed.

---

After removing this last check, I also removed some leftover bits that were related to the fallibility checks, and inlined some functions that were previously used for dynamic dispatch but no longer are needed.