### PR TITLE
make TMC_CUSTOM_CORO_ALLOC the default behavior

### DIFF
--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -266,7 +266,6 @@ template <typename Result> struct task_promise {
   }
 #endif
 
-#ifdef TMC_CUSTOM_CORO_ALLOC
   // Round up the coroutine allocation to next 64 bytes.
   // This reduces false sharing with adjacent coroutines.
   static void* operator new(std::size_t n) noexcept {
@@ -305,7 +304,6 @@ template <typename Result> struct task_promise {
   static task<Result> get_return_object_on_allocation_failure() noexcept {
     return {};
   }
-#endif
 #endif
 };
 


### PR DESCRIPTION
Other libraries such as libfork and TBB always ship custom allocation behavior for coroutines. Since the user doesn't have direct ability to create coroutine frames anyway, there's no reason to make this possible to disable. Therefore it should always be turned on and there can be 1 less compilation parameter to mess about with.