### PR TITLE
implement `tmc::barrier`

### DIFF
--- a/include/tmc/all_headers.hpp
+++ b/include/tmc/all_headers.hpp
@@ -9,6 +9,7 @@
 
 #include "tmc/aw_resume_on.hpp" // IWYU pragma: export
 #include "tmc/aw_yield.hpp"     // IWYU pragma: export
+#include "tmc/barrier.hpp"      // IWYU pragma: export
 #include "tmc/channel.hpp"      // IWYU pragma: export
 #include "tmc/current.hpp"      // IWYU pragma: export
 #include "tmc/ex_any.hpp"       // IWYU pragma: export

--- a/include/tmc/barrier.hpp
+++ b/include/tmc/barrier.hpp
@@ -1,0 +1,72 @@
+// Copyright (c) 2023-2025 Logan McDougall
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include "tmc/detail/concepts_awaitable.hpp"
+#include "tmc/detail/waiter_list.hpp"
+
+#include <atomic>
+#include <coroutine>
+#include <cstddef>
+
+namespace tmc {
+class barrier;
+
+class aw_barrier {
+  tmc::detail::waiter_list_node me;
+  barrier* parent;
+  inline aw_barrier(barrier* Parent) : parent(Parent) {}
+
+  friend class barrier;
+
+public:
+  inline bool await_ready() noexcept { return false; }
+  inline void await_resume() noexcept {}
+
+  bool await_suspend(std::coroutine_handle<> Outer);
+
+  aw_barrier(aw_barrier const&) = delete;
+  aw_barrier& operator=(aw_barrier const&) = delete;
+  aw_barrier(aw_barrier&&) = delete;
+  aw_barrier& operator=(aw_barrier&&) = delete;
+};
+
+/// Similar semantics to std::barrier, although it only exposes one operation -
+/// `co_await` is equivalent to `std::barrier::arrive_and_wait`.
+/// Like std::barrier, the count will be automatically reset after all awaiters
+/// arrive, and it may be reused afterward.
+class barrier {
+  std::atomic<tmc::detail::waiter_list_node*> waiters;
+  std::atomic<ptrdiff_t> start_count;
+  std::atomic<ptrdiff_t> done_count;
+
+  friend class aw_barrier;
+
+public:
+  inline barrier(size_t Count)
+      : waiters(nullptr), start_count{static_cast<ptrdiff_t>(Count - 1)},
+        done_count{static_cast<ptrdiff_t>(Count - 1)} {}
+
+  inline aw_barrier operator co_await() { return aw_barrier(this); }
+};
+namespace detail {
+template <> struct awaitable_traits<tmc::barrier> {
+  static constexpr configure_mode mode = WRAPPER;
+
+  using result_type = void;
+  using self_type = tmc::barrier;
+  using awaiter_type = tmc::aw_barrier;
+
+  static awaiter_type get_awaiter(self_type& Awaitable) {
+    return Awaitable.operator co_await();
+  }
+};
+} // namespace detail
+} // namespace tmc
+
+#ifdef TMC_IMPL
+#include "tmc/detail/barrier.ipp"
+#endif

--- a/include/tmc/barrier.hpp
+++ b/include/tmc/barrier.hpp
@@ -46,10 +46,16 @@ class barrier {
   friend class aw_barrier;
 
 public:
+  /// Sets the number of waiters for the barrier. Setting this to zero or a
+  /// negative number will cause awaiters to resume immediately.
   inline barrier(size_t Count)
       : waiters(nullptr), start_count{static_cast<ptrdiff_t>(Count - 1)},
         done_count{static_cast<ptrdiff_t>(Count - 1)} {}
 
+  /// Equivalent to `std::barrier::arrive_and_wait`. Decrements the barrier
+  /// count, and if the count reaches 0, wakes all waiters, and resets the count
+  /// to the original maximum as specified in the constructor. Otherwise,
+  /// suspends until Count waiters have reached this point.
   inline aw_barrier operator co_await() { return aw_barrier(this); }
 };
 namespace detail {

--- a/include/tmc/detail/barrier.ipp
+++ b/include/tmc/detail/barrier.ipp
@@ -1,0 +1,60 @@
+// Copyright (c) 2023-2025 Logan McDougall
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include "tmc/barrier.hpp"
+#include "tmc/detail/waiter_list.hpp"
+
+#include <atomic>
+#include <coroutine>
+
+namespace tmc {
+class barrier;
+
+bool aw_barrier::await_suspend(std::coroutine_handle<> Outer) {
+  // Configure this awaiter
+  me.continuation = Outer;
+  me.continuation_executor = tmc::detail::this_thread::executor;
+  me.continuation_priority = tmc::detail::this_thread::this_task.prio;
+
+  // Add this awaiter to the waiter list
+  auto h = parent->waiters.load(std::memory_order_acquire);
+  do {
+    me.next = h;
+  } while (!parent->waiters.compare_exchange_strong(
+    h, &me, std::memory_order_acq_rel, std::memory_order_acquire
+  ));
+
+  // Decrement and check the barrier count
+  auto remaining = parent->done_count.fetch_sub(1, std::memory_order_acq_rel);
+  if (remaining > 0) {
+    return true;
+  }
+
+  // If the waiters are resumed before this is reset, they may immediately
+  // await this again, and resume immediately. To prevent this, we must get the
+  // list of waiters to be resumed, then set this to the not-ready state,
+  // then resume the waiters.
+
+  // Get the waiters
+  auto curr = parent->waiters.exchange(nullptr, std::memory_order_acq_rel);
+
+  // Reset this
+  parent->done_count = parent->start_count.load();
+
+  // Resume the waiters
+  while (curr != nullptr) {
+    auto next = curr->next;
+    if (curr != &me) {
+      // Symmetric transfer to this coroutine.
+      // Others are posted to the executor.
+      curr->resume();
+    }
+    curr = next;
+  }
+  return false;
+}
+} // namespace tmc

--- a/include/tmc/detail/waiter_list.hpp
+++ b/include/tmc/detail/waiter_list.hpp
@@ -1,0 +1,29 @@
+// Copyright (c) 2023-2025 Logan McDougall
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include "tmc/detail/thread_locals.hpp"
+#include "tmc/ex_any.hpp"
+
+#include <coroutine>
+#include <cstddef>
+
+namespace tmc {
+namespace detail {
+struct waiter_list_node {
+  waiter_list_node* next;
+  std::coroutine_handle<> continuation;
+  tmc::ex_any* continuation_executor;
+  size_t continuation_priority;
+
+  inline void resume() {
+    tmc::detail::post_checked(
+      continuation_executor, std::move(continuation), continuation_priority
+    );
+  }
+};
+} // namespace detail
+} // namespace tmc


### PR DESCRIPTION
`tmc::barrier` behaves similarly to `std::barrier` - but with a simplified api:
- constructor sets the waiter count, which can never change
- `co_await` is equivalent to `std::barrier::arrive_and_wait`

Other methods of `std::barrier` could be implemented later if needed.

Closes https://github.com/tzcnt/TooManyCooks/issues/70