### PR TITLE
implement `tmc::semaphore`

### DIFF
--- a/include/tmc/all_headers.hpp
+++ b/include/tmc/all_headers.hpp
@@ -16,6 +16,7 @@
 #include "tmc/ex_braid.hpp"     // IWYU pragma: export
 #include "tmc/ex_cpu.hpp"       // IWYU pragma: export
 #include "tmc/external.hpp"     // IWYU pragma: export
+#include "tmc/semaphore.hpp"    // IWYU pragma: export
 #include "tmc/spawn.hpp"        // IWYU pragma: export
 #include "tmc/spawn_func.hpp"   // IWYU pragma: export
 #include "tmc/spawn_many.hpp"   // IWYU pragma: export

--- a/include/tmc/barrier.hpp
+++ b/include/tmc/barrier.hpp
@@ -45,7 +45,7 @@ public:
 /// Like std::barrier, the count will be automatically reset after all awaiters
 /// arrive, and it may be reused afterward.
 class barrier {
-  std::atomic<tmc::detail::waiter_list_node*> waiters;
+  tmc::detail::waiter_list waiters;
   std::atomic<ptrdiff_t> start_count;
   std::atomic<ptrdiff_t> done_count;
 
@@ -55,7 +55,7 @@ public:
   /// Sets the number of waiters for the barrier. Setting this to zero or a
   /// negative number will cause awaiters to resume immediately.
   inline barrier(size_t Count) noexcept
-      : waiters(nullptr), start_count{static_cast<ptrdiff_t>(Count - 1)},
+      : start_count{static_cast<ptrdiff_t>(Count - 1)},
         done_count{static_cast<ptrdiff_t>(Count - 1)} {}
 
   /// Equivalent to `std::barrier::arrive_and_wait`. Decrements the barrier

--- a/include/tmc/detail/semaphore.ipp
+++ b/include/tmc/detail/semaphore.ipp
@@ -1,0 +1,105 @@
+// Copyright (c) 2023-2025 Logan McDougall
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include "tmc/detail/waiter_list.hpp"
+#include "tmc/semaphore.hpp"
+
+#include <atomic>
+#include <cassert>
+#include <coroutine>
+
+namespace tmc {
+bool aw_semaphore::await_ready() noexcept { return parent->try_acquire(); }
+
+bool aw_semaphore::await_suspend(std::coroutine_handle<> Outer) noexcept {
+  // Configure this awaiter
+  me.continuation = Outer;
+  me.continuation_executor = tmc::detail::this_thread::executor;
+  me.continuation_priority = tmc::detail::this_thread::this_task.prio;
+
+  // Add this awaiter to the waiter list
+  auto h = parent->waiters.load(std::memory_order_acquire);
+  do {
+    me.next = h;
+  } while (!parent->waiters.compare_exchange_strong(
+    h, &me, std::memory_order_acq_rel, std::memory_order_acquire
+  ));
+
+  // Release the operation by increasing the waiter count
+  auto add = TMC_ONE_BIT << semaphore::WAITERS_OFFSET;
+  auto v = add + parent->value.fetch_add(add, std::memory_order_acq_rel);
+
+  // Using the fetched value, see if there are both resources available and
+  // waiters to wake.
+  parent->maybe_wake(v);
+  return true;
+}
+
+void semaphore::maybe_wake(size_t v) noexcept {
+  size_t count, waiterCount, newV, wakeCount;
+  do {
+    unpack_value(v, count, waiterCount);
+    if (count == 0 || waiterCount == 0) {
+      return;
+    }
+    // By atomically subtracting from both values at once, this thread
+    // "takes ownership" of wakeCount number of resources and waiters
+    // simultaneously.
+    if (count < waiterCount) {
+      newV = pack_value(0, waiterCount - count);
+      wakeCount = count;
+    } else {
+      newV = pack_value(count - waiterCount, 0);
+      wakeCount = waiterCount;
+    }
+  } while (!value.compare_exchange_strong(
+    v, newV, std::memory_order_acq_rel, std::memory_order_acquire
+  ));
+
+  auto toWake = waiters.load(std::memory_order_acquire);
+  for (size_t i = 0; i < wakeCount; ++i) {
+    do {
+      // should be guaranteed to see at least wakeCount waiters
+      assert(toWake != nullptr);
+    } while (!waiters.compare_exchange_strong(
+      toWake, toWake->next, std::memory_order_acq_rel, std::memory_order_acquire
+    ));
+    toWake->resume();
+  }
+}
+
+bool semaphore::try_acquire() noexcept {
+  auto v = value.load(std::memory_order_relaxed);
+  size_t count, waiterCount, newV;
+  do {
+    unpack_value(v, count, waiterCount);
+    if (0 == count) {
+      return false;
+    }
+    newV = pack_value(count - 1, waiterCount);
+  } while (!value.compare_exchange_strong(
+    v, newV, std::memory_order_acq_rel, std::memory_order_acquire
+  ));
+  return true;
+}
+
+void semaphore::release(size_t ReleaseCount) noexcept {
+  size_t v =
+    ReleaseCount + value.fetch_add(ReleaseCount, std::memory_order_release);
+  maybe_wake(v);
+}
+
+semaphore::~semaphore() {
+  auto curr = waiters.exchange(nullptr, std::memory_order_acq_rel);
+  while (curr != nullptr) {
+    auto next = curr->next;
+    curr->resume();
+    curr = next;
+  }
+}
+
+} // namespace tmc

--- a/include/tmc/detail/waiter_list.ipp
+++ b/include/tmc/detail/waiter_list.ipp
@@ -1,0 +1,57 @@
+// Copyright (c) 2023-2025 Logan McDougall
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include "tmc/detail/thread_locals.hpp"
+#include "tmc/detail/waiter_list.hpp"
+
+#include <cassert>
+#include <cstddef>
+
+namespace tmc {
+namespace detail {
+void waiter_list_node::resume() noexcept {
+  tmc::detail::post_checked(
+    continuation_executor, std::move(continuation), continuation_priority
+  );
+}
+
+void waiter_list::add_waiter(tmc::detail::waiter_list_node& w) noexcept {
+  auto h = head.load(std::memory_order_acquire);
+  do {
+    w.next = h;
+  } while (!head.compare_exchange_strong(
+    h, &w, std::memory_order_acq_rel, std::memory_order_acquire
+  ));
+}
+
+void waiter_list::wake_all() noexcept {
+  auto curr = head.exchange(nullptr, std::memory_order_acq_rel);
+  while (curr != nullptr) {
+    auto next = curr->next;
+    curr->resume();
+    curr = next;
+  }
+}
+
+waiter_list_node* waiter_list::take_all() noexcept {
+  return head.exchange(nullptr, std::memory_order_acq_rel);
+}
+
+void waiter_list::must_wake_n(size_t n) noexcept {
+  auto toWake = head.load(std::memory_order_acquire);
+  for (size_t i = 0; i < n; ++i) {
+    do {
+      // should be guaranteed to see at least wakeCount waiters
+      assert(toWake != nullptr);
+    } while (!head.compare_exchange_strong(
+      toWake, toWake->next, std::memory_order_acq_rel, std::memory_order_acquire
+    ));
+    toWake->resume();
+  }
+}
+} // namespace detail
+} // namespace tmc

--- a/include/tmc/semaphore.hpp
+++ b/include/tmc/semaphore.hpp
@@ -1,0 +1,126 @@
+// Copyright (c) 2023-2025 Logan McDougall
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include "tmc/detail/compat.hpp"
+#include "tmc/detail/concepts_awaitable.hpp"
+#include "tmc/detail/waiter_list.hpp"
+
+#include <atomic>
+#include <coroutine>
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+namespace tmc {
+class semaphore;
+
+class aw_semaphore {
+  tmc::detail::waiter_list_node me;
+  semaphore* parent;
+
+  friend class semaphore;
+
+  inline aw_semaphore(semaphore* Parent) noexcept : parent(Parent) {}
+
+public:
+  bool await_ready() noexcept;
+
+  bool await_suspend(std::coroutine_handle<> Outer) noexcept;
+
+  inline void await_resume() noexcept {}
+
+  // Cannot be moved or copied due to holding intrusive list pointer
+  aw_semaphore(aw_semaphore const&) = delete;
+  aw_semaphore& operator=(aw_semaphore const&) = delete;
+  aw_semaphore(aw_semaphore&&) = delete;
+  aw_semaphore& operator=(aw_semaphore&&) = delete;
+};
+
+class semaphore {
+  std::atomic<tmc::detail::waiter_list_node*> waiters;
+  // Low half bits are the semaphore value.
+  // High half bits are the number of waiters.
+  std::atomic<size_t> value;
+
+  friend class aw_semaphore;
+
+  static inline constexpr size_t WAITERS_OFFSET = TMC_PLATFORM_BITS / 2;
+  static inline constexpr size_t HALF_MASK =
+    (TMC_ONE_BIT << (TMC_PLATFORM_BITS / 2)) - 1;
+
+  static inline void unpack_value(
+    size_t Value, size_t& Count_out, size_t& WaiterCount_out
+  ) noexcept {
+    Count_out = Value & HALF_MASK;
+    WaiterCount_out = (Value >> WAITERS_OFFSET) & HALF_MASK;
+  }
+
+  static inline size_t pack_value(size_t Count, size_t WaiterCount) noexcept {
+    return (WaiterCount << WAITERS_OFFSET) | Count;
+  }
+
+  // Called after increasing Count or WaiterCount.
+  // If Count > 0 && WaiterCount > 0, this will try to wake some number of
+  // waiters.
+  void maybe_wake(size_t v) noexcept;
+
+public:
+  /// The count is packed into half a machine word along with the waiter count.
+  /// Thus it is only allowed half a machine word of bits.
+  using half_word =
+    std::conditional_t<TMC_PLATFORM_BITS == 64, uint32_t, uint16_t>;
+
+  /// Sets the initial number of resources available in the semaphore.
+  /// This is only an initial value and not a maximum; by calling release(), the
+  /// number of resources available may exceed this initial value.
+  inline semaphore(half_word InitialCount) noexcept
+      : waiters{nullptr}, value{static_cast<size_t>(InitialCount)} {}
+
+  /// Returns an estimate of the current number of available resources.
+  /// This value is not guaranteed to be consistent with any other operation.
+  /// Even if this returns non-zero, awaiting afterward may suspend.
+  /// Even if this returns zero, awaiting afterward may not suspend.
+  inline size_t count() noexcept {
+    return HALF_MASK & value.load(std::memory_order_relaxed);
+  }
+
+  /// Returns true if the count was non-zero and was successfully decremented.
+  /// Returns false if the count was zero.
+  bool try_acquire() noexcept;
+
+  /// Increases the available resources by ReleaseCount. If there are waiting
+  /// waiters, they will be awoken until all resources have been consumed.
+  void release(size_t ReleaseCount = 1) noexcept;
+
+  /// Tries to acquire the semaphore, and if no resources are ready, will
+  /// suspend until a resource becomes ready.
+  inline aw_semaphore operator co_await() noexcept {
+    return aw_semaphore(this);
+  }
+
+  /// On destruction, any waiting waiters will be resumed.
+  ~semaphore();
+};
+
+namespace detail {
+template <> struct awaitable_traits<tmc::semaphore> {
+  static constexpr configure_mode mode = WRAPPER;
+
+  using result_type = void;
+  using self_type = tmc::semaphore;
+  using awaiter_type = tmc::aw_semaphore;
+
+  static awaiter_type get_awaiter(self_type& Awaitable) noexcept {
+    return Awaitable.operator co_await();
+  }
+};
+} // namespace detail
+} // namespace tmc
+
+#ifdef TMC_IMPL
+#include "tmc/detail/semaphore.ipp"
+#endif

--- a/include/tmc/semaphore.hpp
+++ b/include/tmc/semaphore.hpp
@@ -41,7 +41,7 @@ public:
 };
 
 class semaphore {
-  std::atomic<tmc::detail::waiter_list_node*> waiters;
+  tmc::detail::waiter_list waiters;
   // Low half bits are the semaphore value.
   // High half bits are the number of waiters.
   std::atomic<size_t> value;
@@ -78,7 +78,7 @@ public:
   /// This is only an initial value and not a maximum; by calling release(), the
   /// number of resources available may exceed this initial value.
   inline semaphore(half_word InitialCount) noexcept
-      : waiters{nullptr}, value{static_cast<size_t>(InitialCount)} {}
+      : value{static_cast<size_t>(InitialCount)} {}
 
   /// Returns an estimate of the current number of available resources.
   /// This value is not guaranteed to be consistent with any other operation.


### PR DESCRIPTION
Async version of `std::counting_semaphore`. Operations:
- constructor(InitialCount)
- size_t count()
- bool try_acquire()
- void release(size_t ReleaseCount = 1)
- operator co_await - acquire or suspend a resource can be acquired
- destructor - resumes any remaining waiters

This is not a saturating semaphore; InitialCount is just the initial count. release() is allowed to increase the number of resources above the starting value.

Waiters will be woken in LIFO order.

Closes https://github.com/tzcnt/TooManyCooks/issues/71