### PR TITLE
implement `tmc::mutex`

### DIFF
--- a/include/tmc/all_headers.hpp
+++ b/include/tmc/all_headers.hpp
@@ -16,6 +16,7 @@
 #include "tmc/ex_braid.hpp"     // IWYU pragma: export
 #include "tmc/ex_cpu.hpp"       // IWYU pragma: export
 #include "tmc/external.hpp"     // IWYU pragma: export
+#include "tmc/mutex.hpp"        // IWYU pragma: export
 #include "tmc/semaphore.hpp"    // IWYU pragma: export
 #include "tmc/spawn.hpp"        // IWYU pragma: export
 #include "tmc/spawn_func.hpp"   // IWYU pragma: export

--- a/include/tmc/detail/mutex.ipp
+++ b/include/tmc/detail/mutex.ipp
@@ -1,0 +1,78 @@
+// Copyright (c) 2023-2025 Logan McDougall
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include "tmc/detail/thread_locals.hpp"
+#include "tmc/detail/waiter_list.hpp"
+#include "tmc/mutex.hpp"
+
+#include <atomic>
+#include <cassert>
+#include <coroutine>
+
+namespace tmc {
+bool aw_mutex::await_ready() noexcept { return parent->try_lock(); }
+
+bool aw_mutex::await_suspend(std::coroutine_handle<> Outer) noexcept {
+  // Configure this awaiter
+  me.continuation = Outer;
+  me.continuation_executor = tmc::detail::this_thread::executor;
+  me.continuation_priority = tmc::detail::this_thread::this_task.prio;
+
+  // Add this awaiter to the waiter list
+  parent->waiters.add_waiter(me);
+
+  // Release the operation by increasing the waiter count
+  auto add = TMC_ONE_BIT << mutex::WAITERS_OFFSET;
+  auto v = add + parent->value.fetch_add(add, std::memory_order_acq_rel);
+
+  // Using the fetched value, see if there are both resources available and
+  // waiters to wake.
+  parent->maybe_wake(v);
+  return true;
+}
+
+void mutex::maybe_wake(size_t v) noexcept {
+  size_t state, waiterCount, newV, wakeCount;
+  do {
+    unpack_value(v, state, waiterCount);
+    if (state == LOCKED || waiterCount == 0) {
+      return;
+    }
+    // By atomically modifying both values at once, this thread
+    // "takes ownership" of the lock and 1 waiter simultaneously.
+    newV = pack_value(LOCKED, waiterCount - 1);
+  } while (!value.compare_exchange_strong(
+    v, newV, std::memory_order_acq_rel, std::memory_order_acquire
+  ));
+
+  waiters.must_wake_n(1);
+}
+
+bool mutex::try_lock() noexcept {
+  auto v = value.load(std::memory_order_relaxed);
+  size_t state, waiterCount, newV;
+  do {
+    unpack_value(v, state, waiterCount);
+    if (LOCKED == state) {
+      return false;
+    }
+    newV = pack_value(LOCKED, waiterCount);
+  } while (!value.compare_exchange_strong(
+    v, newV, std::memory_order_acq_rel, std::memory_order_acquire
+  ));
+  return true;
+}
+
+void mutex::unlock() noexcept {
+  assert(is_locked());
+  size_t v = UNLOCKED | value.fetch_or(UNLOCKED, std::memory_order_release);
+  maybe_wake(v);
+}
+
+mutex::~mutex() { waiters.wake_all(); }
+
+} // namespace tmc

--- a/include/tmc/mutex.hpp
+++ b/include/tmc/mutex.hpp
@@ -1,0 +1,115 @@
+// Copyright (c) 2023-2025 Logan McDougall
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include "tmc/detail/compat.hpp"
+#include "tmc/detail/concepts_awaitable.hpp"
+#include "tmc/detail/waiter_list.hpp"
+
+#include <atomic>
+#include <coroutine>
+#include <cstddef>
+
+namespace tmc {
+class mutex;
+
+class aw_mutex {
+  tmc::detail::waiter_list_node me;
+  mutex* parent;
+
+  friend class mutex;
+
+  inline aw_mutex(mutex* Parent) noexcept : parent(Parent) {}
+
+public:
+  bool await_ready() noexcept;
+
+  bool await_suspend(std::coroutine_handle<> Outer) noexcept;
+
+  inline void await_resume() noexcept {}
+
+  // Cannot be moved or copied due to holding intrusive list pointer
+  aw_mutex(aw_mutex const&) = delete;
+  aw_mutex& operator=(aw_mutex const&) = delete;
+  aw_mutex(aw_mutex&&) = delete;
+  aw_mutex& operator=(aw_mutex&&) = delete;
+};
+
+class mutex {
+  tmc::detail::waiter_list waiters;
+  // Low half bits are the mutex value.
+  // High half bits are the number of waiters.
+  std::atomic<size_t> value;
+
+  friend class aw_mutex;
+
+  static inline constexpr size_t LOCKED = 0;
+  static inline constexpr size_t UNLOCKED = 1;
+
+  static inline constexpr size_t WAITERS_OFFSET = TMC_PLATFORM_BITS / 2;
+  static inline constexpr size_t HALF_MASK =
+    (TMC_ONE_BIT << (TMC_PLATFORM_BITS / 2)) - 1;
+
+  static inline void unpack_value(
+    size_t Value, size_t& State_out, size_t& WaiterCount_out
+  ) noexcept {
+    State_out = Value & HALF_MASK;
+    WaiterCount_out = (Value >> WAITERS_OFFSET) & HALF_MASK;
+  }
+
+  static inline size_t pack_value(size_t State, size_t WaiterCount) noexcept {
+    return (WaiterCount << WAITERS_OFFSET) | State;
+  }
+
+  // Called after increasing State or WaiterCount.
+  // If State > 0 && WaiterCount > 0, this will try to wake some number of
+  // awaiters.
+  void maybe_wake(size_t v) noexcept;
+
+public:
+  /// Mutex begins in the unlocked state.
+  inline mutex() noexcept : value{UNLOCKED} {}
+
+  /// Returns true if some task is holding the mutex.
+  inline bool is_locked() noexcept {
+    return 0 == (HALF_MASK & value.load(std::memory_order_relaxed));
+  }
+
+  /// Returns true if the mutex was unlocked and the lock was successfully
+  /// acquired. Returns false if the mutex was locked. Not re-entrant.
+  bool try_lock() noexcept;
+
+  /// Unlocks the mutex. If there are any awaiters, an awaiter will be resumed
+  /// and the lock will be re-locked and transferred to that awaiter.
+  /// Does not symmetric transfer; awaiter will be posted to its executor.
+  void unlock() noexcept;
+
+  /// Tries to acquire the mutex, and if no resources are ready, will
+  /// suspend until a resource becomes ready. Not re-entrant.
+  inline aw_mutex operator co_await() noexcept { return aw_mutex(this); }
+
+  /// On destruction, any awaiters will be resumed.
+  ~mutex();
+};
+
+namespace detail {
+template <> struct awaitable_traits<tmc::mutex> {
+  static constexpr configure_mode mode = WRAPPER;
+
+  using result_type = void;
+  using self_type = tmc::mutex;
+  using awaiter_type = tmc::aw_mutex;
+
+  static awaiter_type get_awaiter(self_type& Awaitable) noexcept {
+    return Awaitable.operator co_await();
+  }
+};
+} // namespace detail
+} // namespace tmc
+
+#ifdef TMC_IMPL
+#include "tmc/detail/mutex.ipp"
+#endif


### PR DESCRIPTION
Implementation is very similar to a semaphore, but only protects 1 resource. Operations:
- constructor: begins in the unlocked state
- is_locked()
- try_lock()
- unlock()
- operator co_await - waits until lock can be acquired
- destructor - resumes any remaining waiters

It would be good to provide a way to symmetric transfer when unlock()ing to a different task - this will come in a future PR.