### PR TITLE
implement `tmc::atomic_condvar`

### DIFF
--- a/include/tmc/all_headers.hpp
+++ b/include/tmc/all_headers.hpp
@@ -7,21 +7,22 @@
 
 // This header includes all of the TMC headers
 
-#include "tmc/aw_resume_on.hpp" // IWYU pragma: export
-#include "tmc/aw_yield.hpp"     // IWYU pragma: export
-#include "tmc/barrier.hpp"      // IWYU pragma: export
-#include "tmc/channel.hpp"      // IWYU pragma: export
-#include "tmc/current.hpp"      // IWYU pragma: export
-#include "tmc/ex_any.hpp"       // IWYU pragma: export
-#include "tmc/ex_braid.hpp"     // IWYU pragma: export
-#include "tmc/ex_cpu.hpp"       // IWYU pragma: export
-#include "tmc/external.hpp"     // IWYU pragma: export
-#include "tmc/mutex.hpp"        // IWYU pragma: export
-#include "tmc/semaphore.hpp"    // IWYU pragma: export
-#include "tmc/spawn.hpp"        // IWYU pragma: export
-#include "tmc/spawn_func.hpp"   // IWYU pragma: export
-#include "tmc/spawn_many.hpp"   // IWYU pragma: export
-#include "tmc/spawn_tuple.hpp"  // IWYU pragma: export
-#include "tmc/sync.hpp"         // IWYU pragma: export
-#include "tmc/task.hpp"         // IWYU pragma: export
-#include "tmc/work_item.hpp"    // IWYU pragma: export
+#include "tmc/atomic_condvar.hpp" // IWYU pragma: export
+#include "tmc/aw_resume_on.hpp"   // IWYU pragma: export
+#include "tmc/aw_yield.hpp"       // IWYU pragma: export
+#include "tmc/barrier.hpp"        // IWYU pragma: export
+#include "tmc/channel.hpp"        // IWYU pragma: export
+#include "tmc/current.hpp"        // IWYU pragma: export
+#include "tmc/ex_any.hpp"         // IWYU pragma: export
+#include "tmc/ex_braid.hpp"       // IWYU pragma: export
+#include "tmc/ex_cpu.hpp"         // IWYU pragma: export
+#include "tmc/external.hpp"       // IWYU pragma: export
+#include "tmc/mutex.hpp"          // IWYU pragma: export
+#include "tmc/semaphore.hpp"      // IWYU pragma: export
+#include "tmc/spawn.hpp"          // IWYU pragma: export
+#include "tmc/spawn_func.hpp"     // IWYU pragma: export
+#include "tmc/spawn_many.hpp"     // IWYU pragma: export
+#include "tmc/spawn_tuple.hpp"    // IWYU pragma: export
+#include "tmc/sync.hpp"           // IWYU pragma: export
+#include "tmc/task.hpp"           // IWYU pragma: export
+#include "tmc/work_item.hpp"      // IWYU pragma: export

--- a/include/tmc/atomic_condvar.hpp
+++ b/include/tmc/atomic_condvar.hpp
@@ -1,0 +1,250 @@
+// Copyright (c) 2023-2025 Logan McDougall
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+// An async implementation of std::atomic::wait().
+
+#include "tmc/detail/compat.hpp"
+#include "tmc/detail/concepts_awaitable.hpp"
+#include "tmc/detail/thread_locals.hpp"
+#include "tmc/detail/waiter_list.hpp"
+
+#include <atomic>
+#include <coroutine>
+#include <cstddef>
+#include <mutex>
+#include <vector>
+
+namespace tmc {
+template <typename T> class atomic_condvar;
+template <typename T> class aw_atomic_condvar_co_notify;
+
+/// The awaitable type returned by `atomic_condvar.await()`
+template <typename T>
+class [[nodiscard(
+  "You must co_await aw_atomic_condvar for it to have any effect."
+)]] aw_atomic_condvar : tmc::detail::AwaitTagNoGroupAsIs {
+  T expected;
+  atomic_condvar<T>* parent;
+  tmc::detail::waiter_list_waiter waiter;
+
+  friend class atomic_condvar<T>;
+  friend class aw_atomic_condvar_co_notify<T>;
+
+  inline aw_atomic_condvar(atomic_condvar<T>* Parent, T Expected) noexcept
+      : expected(Expected), parent(Parent) {}
+
+public:
+  inline bool await_ready() noexcept {
+    return parent->value.load(std::memory_order_seq_cst) != expected;
+  }
+
+  inline bool await_suspend(std::coroutine_handle<> Outer) noexcept {
+    // Configure this awaiter
+    waiter.continuation = Outer;
+    waiter.continuation_executor = tmc::detail::this_thread::executor;
+    waiter.continuation_priority = tmc::detail::this_thread::this_task.prio;
+
+    std::scoped_lock l{parent->waiters_lock};
+    if (parent->value.load(std::memory_order_relaxed) != expected) {
+      return false;
+    } else {
+      parent->waiters.push_back(this);
+      return true;
+    }
+  }
+
+  inline void await_resume() noexcept {}
+
+  // Cannot be moved or copied due to holding intrusive list pointer
+  aw_atomic_condvar(aw_atomic_condvar const&) = delete;
+  aw_atomic_condvar& operator=(aw_atomic_condvar const&) = delete;
+  aw_atomic_condvar(aw_atomic_condvar&&) = delete;
+  aw_atomic_condvar& operator=(aw_atomic_condvar&&) = delete;
+};
+
+/// The awaitable type returned by `atomic_condvar.co_notify_one()`,
+/// `atomic_condvar.co_notify_n()`, and `atomic_condvar.co_notify_all()`.
+template <typename T>
+class [[nodiscard(
+  "You must co_await aw_atomic_condvar_co_notify for it to have any effect."
+)]] aw_atomic_condvar_co_notify : tmc::detail::AwaitTagNoGroupAsIs {
+  atomic_condvar<T>* parent;
+  size_t notify_count;
+
+  friend class atomic_condvar<T>;
+
+  inline aw_atomic_condvar_co_notify(
+    atomic_condvar<T>* Parent, size_t NotifyCount
+  ) noexcept
+      : parent(Parent), notify_count(NotifyCount) {}
+
+public:
+  inline bool await_ready() noexcept { return notify_count == 0; }
+
+  inline std::coroutine_handle<> await_suspend(std::coroutine_handle<> Outer
+  ) noexcept {
+    std::vector<aw_atomic_condvar<T>*> wakeList =
+      parent->get_n_waiters(notify_count);
+    size_t sz = wakeList.size();
+    if (sz == 0) {
+      return Outer;
+    }
+    // Save the first / most recently added waiter for
+    // symmetric transfer.
+    for (ptrdiff_t i = 1; i < sz; ++i) {
+      wakeList[i]->waiter.resume();
+    }
+    return wakeList[0]->waiter.try_symmetric_transfer(Outer);
+  }
+
+  inline void await_resume() noexcept {}
+
+  // Cannot be moved or copied due to being pointed to by parent
+  aw_atomic_condvar_co_notify(aw_atomic_condvar_co_notify const&) = delete;
+  aw_atomic_condvar_co_notify&
+  operator=(aw_atomic_condvar_co_notify const&) = delete;
+  aw_atomic_condvar_co_notify(atomic_condvar<T>&&) = delete;
+  aw_atomic_condvar_co_notify&
+  operator=(aw_atomic_condvar_co_notify&&) = delete;
+};
+
+/// Wraps an atomic integral type. Exposes async analogues to
+/// `std::atomic<T>::wait()` and `std::atomic<T>::notify_*()`.
+template <typename T> class atomic_condvar {
+  std::mutex waiters_lock;
+  std::vector<aw_atomic_condvar<T>*> waiters;
+  std::atomic<T> value;
+
+  friend class aw_atomic_condvar<T>;
+  friend class aw_atomic_condvar_co_notify<T>;
+
+  // Returns the most recently added waiter that matches the expected
+  // condition.
+  inline aw_atomic_condvar<T>* get_one_waiter() {
+    aw_atomic_condvar<T>* toWake = nullptr;
+    {
+      std::scoped_lock l{waiters_lock};
+      auto v = value.load(std::memory_order_relaxed);
+      auto sz = static_cast<ptrdiff_t>(waiters.size());
+      for (ptrdiff_t i = sz - 1; i >= 0; --i) {
+        if (waiters[i]->expected != v) {
+          toWake = waiters[i];
+          waiters[i] = waiters[sz - 1];
+          waiters.pop_back();
+          break;
+        }
+      }
+    }
+    return toWake;
+  }
+
+  // Returns up to N waiters that match the expected condition. The most
+  // recently added waiters are at the front of the returned list.
+  inline std::vector<aw_atomic_condvar<T>*> get_n_waiters(size_t N) {
+    std::vector<aw_atomic_condvar<T>*> wakeList;
+    {
+      std::scoped_lock l{waiters_lock};
+      auto v = value.load(std::memory_order_relaxed);
+      auto sz = static_cast<ptrdiff_t>(waiters.size());
+      for (ptrdiff_t i = sz - 1; i >= 0; --i) {
+        if (waiters[i]->expected != v) {
+          wakeList.push_back(waiters[i]);
+          waiters[i] = waiters[sz - 1];
+          waiters.pop_back();
+          --sz;
+          --N;
+          if (0 == N) {
+            break;
+          }
+        }
+      }
+    }
+    return wakeList;
+  }
+
+public:
+  /// Sets the initial value of the contained atomic variable.
+  inline atomic_condvar(T InitialValue) noexcept : value{InitialValue} {}
+
+  /// Returns a reference to the contained atomic variable.
+  inline std::atomic<T>& ref() noexcept { return value; }
+
+  /// Wakes 1 awaiter that meet the criteria (expected != current value).
+  /// If it should run on the same executor and priority as the current task, it
+  /// will be woken by symmetric transfer. If the awaiter is resumed by
+  /// symmetric transfer, the caller will be posted to its executor.
+  inline aw_atomic_condvar_co_notify<T>
+  co_notify_one(size_t NotifyCount = 1) noexcept {
+    return aw_atomic_condvar_co_notify(this, NotifyCount);
+  }
+
+  /// Wakes up to NotifyCount awaiters that meet the criteria (expected !=
+  /// current value).
+  /// One of the awaiters may be woken by symmetric transfer if it should run
+  /// on the same executor and priority as the current task. If an awaiter is
+  /// resumed by symmetric transfer, the caller will be posted to its
+  /// executor.
+  inline aw_atomic_condvar_co_notify<T>
+  co_notify_n(size_t NotifyCount = 1) noexcept {
+    return aw_atomic_condvar_co_notify(this, NotifyCount);
+  }
+
+  /// Wakes all awaiters that meet the criteria (expected != current value).
+  /// One of the awaiters may be woken by symmetric transfer if it should run
+  /// on the same executor and priority as the current task. If an awaiter is
+  /// resumed by symmetric transfer, the caller will be posted to its
+  /// executor.
+  inline aw_atomic_condvar_co_notify<T> co_notify_all() noexcept {
+    return aw_atomic_condvar_co_notify(this, TMC_ALL_ONES);
+  }
+
+  /// Wakes 1 awaiter that meet the criteria (expected != current value).
+  inline void notify_one() {
+    aw_atomic_condvar<T>* toWake = get_one_waiter();
+    if (toWake != nullptr) {
+      toWake->waiter.resume();
+    }
+  }
+
+  /// Wakes up to NotifyCount awaiters that meet the criteria (expected !=
+  /// current value).
+  inline void notify_n(size_t NotifyCount = 1) {
+    if (NotifyCount == 0) {
+      return;
+    }
+    std::vector<aw_atomic_condvar<T>*> wakeList = get_n_waiters(NotifyCount);
+    for (size_t i = 0; i < wakeList.size(); ++i) {
+      wakeList[i]->waiter.resume();
+    }
+  }
+
+  /// Wakes all awaiters that meet the criteria (expected != current value).
+  inline void notify_all() {
+    std::vector<aw_atomic_condvar<T>*> wakeList = get_n_waiters(TMC_ALL_ONES);
+    for (size_t i = 0; i < wakeList.size(); ++i) {
+      wakeList[i]->waiter.resume();
+    }
+  }
+
+  /// Suspends until Expected != current value. If this condition is already
+  /// true, resumes immediately.
+  inline aw_atomic_condvar<T> await(T Expected) noexcept {
+    return aw_atomic_condvar(this, Expected);
+  }
+
+  /// On destruction, any waiting awaiters will be resumed.
+  inline ~atomic_condvar() {
+    std::scoped_lock l{waiters_lock};
+    // No need to unlock before resuming here - it's not valid for resumers to
+    // access the destroyed mutex anyway.
+    std::vector<aw_atomic_condvar<T>*> wakeList;
+    for (size_t i = 0; i < waiters.size(); ++i) {
+      waiters[i]->waiter.resume();
+    }
+  }
+};
+} // namespace tmc

--- a/include/tmc/detail/barrier.ipp
+++ b/include/tmc/detail/barrier.ipp
@@ -15,9 +15,9 @@
 namespace tmc {
 bool aw_barrier::await_suspend(std::coroutine_handle<> Outer) noexcept {
   // Configure this awaiter
-  me.continuation = Outer;
-  me.continuation_executor = tmc::detail::this_thread::executor;
-  me.continuation_priority = tmc::detail::this_thread::this_task.prio;
+  me.waiter.continuation = Outer;
+  me.waiter.continuation_executor = tmc::detail::this_thread::executor;
+  me.waiter.continuation_priority = tmc::detail::this_thread::this_task.prio;
 
   // Add this awaiter to the waiter list
   parent->waiters.add_waiter(me);
@@ -45,7 +45,7 @@ bool aw_barrier::await_suspend(std::coroutine_handle<> Outer) noexcept {
     if (curr != &me) {
       // Symmetric transfer to this coroutine.
       // Others are posted to the executor.
-      curr->resume();
+      curr->waiter.resume();
     }
     curr = next;
   }

--- a/include/tmc/detail/waiter_list.ipp
+++ b/include/tmc/detail/waiter_list.ipp
@@ -13,14 +13,14 @@
 
 namespace tmc {
 namespace detail {
-void waiter_list_node::resume() noexcept {
+void waiter_list_waiter::resume() noexcept {
   tmc::detail::post_checked(
     continuation_executor, std::move(continuation), continuation_priority
   );
 }
 
 std::coroutine_handle<>
-waiter_list_node::try_symmetric_transfer(std::coroutine_handle<> Outer
+waiter_list_waiter::try_symmetric_transfer(std::coroutine_handle<> Outer
 ) noexcept {
   if (tmc::detail::this_thread::exec_prio_is(
         continuation_executor, continuation_priority
@@ -50,7 +50,7 @@ void waiter_list::wake_all() noexcept {
   auto curr = head.exchange(nullptr, std::memory_order_acq_rel);
   while (curr != nullptr) {
     auto next = curr->next;
-    curr->resume();
+    curr->waiter.resume();
     curr = next;
   }
 }
@@ -68,7 +68,7 @@ void waiter_list::must_wake_n(size_t n) noexcept {
     } while (!head.compare_exchange_strong(
       toWake, toWake->next, std::memory_order_acq_rel, std::memory_order_acquire
     ));
-    toWake->resume();
+    toWake->waiter.resume();
   }
 }
 

--- a/include/tmc/mutex.hpp
+++ b/include/tmc/mutex.hpp
@@ -48,7 +48,7 @@ class [[nodiscard(
   inline aw_mutex_co_unlock(mutex* Parent) noexcept : parent(Parent) {}
 
 public:
-  inline bool await_ready() noexcept { return false; };
+  inline bool await_ready() noexcept { return false; }
 
   std::coroutine_handle<> await_suspend(std::coroutine_handle<> Outer) noexcept;
 

--- a/include/tmc/mutex.hpp
+++ b/include/tmc/mutex.hpp
@@ -5,7 +5,6 @@
 
 #pragma once
 
-#include "tmc/detail/compat.hpp"
 #include "tmc/detail/concepts_awaitable.hpp"
 #include "tmc/detail/waiter_list.hpp"
 
@@ -70,23 +69,8 @@ class mutex {
   friend class aw_mutex;
   friend class aw_mutex_co_unlock;
 
-  static inline constexpr size_t LOCKED = 0;
-  static inline constexpr size_t UNLOCKED = 1;
-
-  static inline constexpr size_t WAITERS_OFFSET = TMC_PLATFORM_BITS / 2;
-  static inline constexpr size_t HALF_MASK =
-    (TMC_ONE_BIT << (TMC_PLATFORM_BITS / 2)) - 1;
-
-  static inline void unpack_value(
-    size_t Value, size_t& State_out, size_t& WaiterCount_out
-  ) noexcept {
-    State_out = Value & HALF_MASK;
-    WaiterCount_out = (Value >> WAITERS_OFFSET) & HALF_MASK;
-  }
-
-  static inline size_t pack_value(size_t State, size_t WaiterCount) noexcept {
-    return (WaiterCount << WAITERS_OFFSET) | State;
-  }
+  static inline constexpr tmc::detail::half_word LOCKED = 0;
+  static inline constexpr tmc::detail::half_word UNLOCKED = 1;
 
   // Called after increasing State or WaiterCount.
   // If State > 0 && WaiterCount > 0, this will try to wake some number of
@@ -99,7 +83,8 @@ public:
 
   /// Returns true if some task is holding the mutex.
   inline bool is_locked() noexcept {
-    return 0 == (HALF_MASK & value.load(std::memory_order_relaxed));
+    return 0 ==
+           (tmc::detail::HALF_MASK & value.load(std::memory_order_relaxed));
   }
 
   /// Returns true if the mutex was unlocked and the lock was successfully

--- a/include/tmc/semaphore.hpp
+++ b/include/tmc/semaphore.hpp
@@ -50,7 +50,7 @@ class [[nodiscard(
   inline aw_semaphore_co_release(semaphore* Parent) noexcept : parent(Parent) {}
 
 public:
-  inline bool await_ready() noexcept { return false; };
+  inline bool await_ready() noexcept { return false; }
 
   std::coroutine_handle<> await_suspend(std::coroutine_handle<> Outer) noexcept;
 

--- a/include/tmc/semaphore.hpp
+++ b/include/tmc/semaphore.hpp
@@ -5,15 +5,12 @@
 
 #pragma once
 
-#include "tmc/detail/compat.hpp"
 #include "tmc/detail/concepts_awaitable.hpp"
 #include "tmc/detail/waiter_list.hpp"
 
 #include <atomic>
 #include <coroutine>
 #include <cstddef>
-#include <cstdint>
-#include <type_traits>
 
 namespace tmc {
 class semaphore;
@@ -72,21 +69,6 @@ class semaphore {
   friend class aw_semaphore;
   friend class aw_semaphore_co_release;
 
-  static inline constexpr size_t WAITERS_OFFSET = TMC_PLATFORM_BITS / 2;
-  static inline constexpr size_t HALF_MASK =
-    (TMC_ONE_BIT << (TMC_PLATFORM_BITS / 2)) - 1;
-
-  static inline void unpack_value(
-    size_t Value, size_t& Count_out, size_t& WaiterCount_out
-  ) noexcept {
-    Count_out = Value & HALF_MASK;
-    WaiterCount_out = (Value >> WAITERS_OFFSET) & HALF_MASK;
-  }
-
-  static inline size_t pack_value(size_t Count, size_t WaiterCount) noexcept {
-    return (WaiterCount << WAITERS_OFFSET) | Count;
-  }
-
   // Called after increasing Count or WaiterCount.
   // If Count > 0 && WaiterCount > 0, this will try to wake some number of
   // awaiters.
@@ -95,8 +77,7 @@ class semaphore {
 public:
   /// The count is packed into half a machine word along with the awaiter count.
   /// Thus it is only allowed half a machine word of bits.
-  using half_word =
-    std::conditional_t<TMC_PLATFORM_BITS == 64, uint32_t, uint16_t>;
+  using half_word = tmc::detail::half_word;
 
   /// Sets the initial number of resources available in the semaphore.
   /// This is only an initial value and not a maximum; by calling release(), the
@@ -109,7 +90,7 @@ public:
   /// Even if this returns non-zero, awaiting afterward may suspend.
   /// Even if this returns zero, awaiting afterward may not suspend.
   inline size_t count() noexcept {
-    return HALF_MASK & value.load(std::memory_order_relaxed);
+    return tmc::detail::HALF_MASK & value.load(std::memory_order_relaxed);
   }
 
   /// Returns true if the count was non-zero and was successfully decremented.


### PR DESCRIPTION
Wrapper around a std::atomic type that exposes operations similar to std::atomic::wait() and std::atomic::notify_one() / notify_all().

- constructor: sets the initial value
- ref() - access the underlying atomic value
- await(n) -> equivalent to std::atomic::wait(n), waits until value != n
- notify_one() -> std::atomic::notify_one()
- notify_all() -> std::atomic::notify_all()
- notify_n(n) - wakes up to n waiters that meet the criteria
- co_notify_one(), co_notify_all(), co_notify_n(n) - async symmetric transfer versions of the notify funcs
- destructor - resumes any remaining waiters

Closes https://github.com/tzcnt/TooManyCooks/issues/72