### PR TITLE
Save and restore priority in qu_inbox

### DIFF
--- a/include/tmc/aw_yield.hpp
+++ b/include/tmc/aw_yield.hpp
@@ -12,6 +12,29 @@
 #include <coroutine>
 
 namespace tmc {
+namespace detail {
+inline void yield_impl(std::coroutine_handle<> Outer) {
+  //   Mitigate a race condition where this thread is asked to yield by a higher
+  // priority task, but then that higher priority task is stolen by another
+  // thread, and this task resumes again at the same priority as its original.
+  //   Due to the priority diff check in ex_cpu which would see the current
+  // priority as the same as the previous one, this thread's yield_priority
+  // would not be reset under that condition, which would cause this task to
+  // possibly yield spuriously multiple times if yield_requested() is checked
+  // in a loop.
+  //   The simple solution here is to just reset the yield priority when we
+  // actually yield.
+  auto prio = tmc::detail::this_thread::this_task.prio;
+  tmc::detail::this_thread::this_task.yield_priority->store(
+    prio, std::memory_order_release
+  );
+
+  tmc::detail::post_checked(
+    tmc::detail::this_thread::executor, std::move(Outer), prio
+  );
+}
+} // namespace detail
+
 /// Returns true if a higher priority task is requesting to run on this thread.
 inline bool yield_requested() {
   // yield if the yield_priority value is smaller (higher priority)
@@ -32,10 +55,7 @@ public:
   /// task can run.
   TMC_FORCE_INLINE inline void await_suspend(std::coroutine_handle<> Outer
   ) const noexcept {
-    tmc::detail::post_checked(
-      tmc::detail::this_thread::executor, std::move(Outer),
-      tmc::detail::this_thread::this_task.prio
-    );
+    tmc::detail::yield_impl(Outer);
   }
 
   /// Does nothing.
@@ -59,10 +79,7 @@ public:
   /// task can run.
   TMC_FORCE_INLINE inline void await_suspend(std::coroutine_handle<> Outer
   ) const noexcept {
-    tmc::detail::post_checked(
-      tmc::detail::this_thread::executor, std::move(Outer),
-      tmc::detail::this_thread::this_task.prio
-    );
+    tmc::detail::yield_impl(Outer);
   }
 
   /// Does nothing.
@@ -108,10 +125,7 @@ public:
   /// task can run.
   TMC_FORCE_INLINE inline void await_suspend(std::coroutine_handle<> Outer
   ) const noexcept {
-    tmc::detail::post_checked(
-      tmc::detail::this_thread::executor, std::move(Outer),
-      tmc::detail::this_thread::this_task.prio
-    );
+    tmc::detail::yield_impl(Outer);
   }
 
   /// Does nothing.
@@ -156,10 +170,7 @@ public:
   /// task can run.
   TMC_FORCE_INLINE inline void await_suspend(std::coroutine_handle<> Outer
   ) const noexcept {
-    tmc::detail::post_checked(
-      tmc::detail::this_thread::executor, std::move(Outer),
-      tmc::detail::this_thread::this_task.prio
-    );
+    tmc::detail::yield_impl(Outer);
   }
 
   /// Does nothing.

--- a/include/tmc/detail/ex_cpu.ipp
+++ b/include/tmc/detail/ex_cpu.ipp
@@ -267,9 +267,6 @@ void ex_cpu::run_one(
 #endif
   {
     if (Prio != PrevPriority) {
-      // TODO RACE if a higher prio asked us to yield, but then
-      // got taken by another thread, and we resumed back on our
-      // previous prio, yield_priority will not be reset
       tmc::detail::this_thread::this_task.yield_priority->store(
         Prio, std::memory_order_release
       );

--- a/include/tmc/detail/qu_inbox.hpp
+++ b/include/tmc/detail/qu_inbox.hpp
@@ -6,7 +6,8 @@
 #pragma once
 
 // tmc::detail::qu_inbox is a fixed-size MPMC queue used to push data directly
-// to a thread group.
+// to a thread group. Stores and restores the priority by function parameters,
+// but does not actually implement a priority queue - it's just FIFO.
 
 // At the moment it uses a single block, thus Capacity == BlockSize.
 

--- a/include/tmc/detail/qu_lockfree.hpp
+++ b/include/tmc/detail/qu_lockfree.hpp
@@ -855,9 +855,7 @@ public:
 
   // TZCNT MODIFIED: New function, used only by ex_cpu threads. Uses
   // precalculated iteration order to check queues.
-  TMC_FORCE_INLINE bool try_dequeue_ex_cpu(
-    T& item, size_t prio, tmc::detail::qu_inbox<T, 4096>* inbox
-  ) {
+  TMC_FORCE_INLINE bool try_dequeue_ex_cpu(T& item, size_t prio) {
     auto dequeue_count = dequeueProducerCount;
     size_t baseOffset = prio * dequeue_count;
     ExplicitProducer** producers =
@@ -866,10 +864,6 @@ public:
     // CHECK this thread's work queue first
     // this thread's producer is always the first element of the producers array
     if (static_cast<ExplicitProducer*>(producers[0])->dequeue_lifo(item)) {
-      return true;
-    }
-
-    if (inbox != nullptr && inbox->try_pull(item)) {
       return true;
     }
 

--- a/include/tmc/detail/qu_lockfree.hpp
+++ b/include/tmc/detail/qu_lockfree.hpp
@@ -20,7 +20,6 @@
 #pragma once
 
 #include "tmc/detail/compat.hpp"
-#include "tmc/detail/qu_inbox.hpp"
 #include "tmc/detail/thread_locals.hpp"
 
 #if defined(__GNUC__) && !defined(__INTEL_COMPILER)

--- a/include/tmc/detail/qu_lockfree.hpp
+++ b/include/tmc/detail/qu_lockfree.hpp
@@ -852,20 +852,25 @@ public:
     return false;
   }
 
-  // TZCNT MODIFIED: New function, used only by ex_cpu threads. Uses
-  // precalculated iteration order to check queues.
-  TMC_FORCE_INLINE bool try_dequeue_ex_cpu(T& item, size_t prio) {
-    auto dequeue_count = dequeueProducerCount;
-    size_t baseOffset = prio * dequeue_count;
+  // TZCNT MODIFIED: New function, used only by ex_cpu threads.
+  // Checks only this thread's private work queue.
+  TMC_FORCE_INLINE bool try_dequeue_ex_cpu_private(T& item, size_t prio) {
+    size_t baseOffset = prio * dequeueProducerCount;
     ExplicitProducer** producers =
       static_cast<ExplicitProducer**>(tmc::detail::this_thread::producers) +
       baseOffset;
     // CHECK this thread's work queue first
     // this thread's producer is always the first element of the producers array
-    if (static_cast<ExplicitProducer*>(producers[0])->dequeue_lifo(item)) {
-      return true;
-    }
+    return static_cast<ExplicitProducer*>(producers[0])->dequeue_lifo(item);
+  }
 
+  // TZCNT MODIFIED: New function, used only by ex_cpu threads.
+  // Uses precalculated iteration order to check other queues to steal.
+  TMC_FORCE_INLINE bool try_dequeue_ex_cpu_steal(T& item, size_t prio) {
+    size_t baseOffset = prio * dequeueProducerCount;
+    ExplicitProducer** producers =
+      static_cast<ExplicitProducer**>(tmc::detail::this_thread::producers) +
+      baseOffset;
     // CHECK the implicit producers (main thread, I/O, etc)
     ImplicitProducer* implicit_prod = static_cast<ImplicitProducer*>(
       producerListTail.load(std::memory_order_acquire)
@@ -883,7 +888,7 @@ public:
     size_t pidx = producers[1] == nullptr ? 2 : 1;
 
     // CHECK the remaining threads in the predefined order
-    for (; pidx < dequeue_count; ++pidx) {
+    for (; pidx < dequeueProducerCount; ++pidx) {
       ExplicitProducer* prod = static_cast<ExplicitProducer*>(producers[pidx]);
       if (prod->dequeue(item)) {
         // update prev_prod

--- a/include/tmc/ex_cpu.hpp
+++ b/include/tmc/ex_cpu.hpp
@@ -92,9 +92,14 @@ class ex_cpu {
   // returns true if no tasks were found (caller should wait on cv)
   // returns false if thread stop requested (caller should exit)
   bool try_run_some(
-    std::stop_token& ThreadStopToken, const size_t Slot,
-    const size_t MinPriority, size_t& PreviousPrio
+    std::stop_token& ThreadStopToken, const size_t Slot, size_t& PrevPriority
   );
+
+  void run_one(
+    tmc::work_item& item, const size_t Slot, const size_t Prio,
+    size_t& PrevPriority, bool& WasSpinning
+  );
+
   size_t set_spin(size_t Slot);
   size_t clr_spin(size_t Slot);
   size_t set_work(size_t Slot);
@@ -199,7 +204,7 @@ public:
       tmc::detail::this_thread::executor == &type_erased_this;
     if (ThreadHint < thread_count()) {
       size_t enqueuedCount = thread_states[ThreadHint].inbox->try_push_bulk(
-        static_cast<It&&>(Items), Count
+        static_cast<It&&>(Items), Count, Priority
       );
       if (enqueuedCount != 0) {
         Count -= enqueuedCount;


### PR DESCRIPTION
Followup to [Save and restore priority across all awaitables and executors (#96)](https://github.com/tzcnt/TooManyCooks/pull/96)

One missed spot was the inbox used to implement ThreadHint in ex_cpu. This also needs to save and restore the priority of the task, since the inbox is implemented as a simple FIFO.

Queues need to be checked in the following order:
prio 0 private
inbox
prio 0 steal
prio 1 private
prio 1 steal
... etc

Originally this was implemented by passing the inbox into the try_dequeue_ex_cpu function. In this PR the "private" and "steal" parts of the dequeue have been split apart. They are now called separately in try_run_some. This also allows us to make it clear that the inbox is only checked once, and make the first private check likely, all of which lead to a small performance gain.

Additionally resolved a minor / unusual race condition which has been around for a long time, as documented in the change to aw_yield.