### PR TITLE
Fix TMC_WORK_ITEM=FUNC

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         PRESET: [clang-linux-debug]
-        WORK_ITEM: [CORO]
+        WORK_ITEM: [CORO,FUNCORO,FUNC]
     steps:
     - uses: actions/checkout@v4
       with:
@@ -38,7 +38,7 @@ jobs:
       continue-on-error: true
       run: cd submodules/tmc-asio && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DCMD_COMPILE_FLAGS='-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}};-fprofile-instr-generate;-fcoverage-mapping' -DCMD_LINK_FLAGS='-fprofile-instr-generate;-fcoverage-mapping' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DCMD_COMPILE_FLAGS='-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}}${{matrix.WORK_ITEM == 'FUNC' && ';-DTMC_TRIVIAL_TASK' || ''}};-fprofile-instr-generate;-fcoverage-mapping' -DCMD_LINK_FLAGS='-Wl,--build-id;-fprofile-instr-generate;-fcoverage-mapping' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests
@@ -50,12 +50,38 @@ jobs:
     - name: run test_fuzz_chan
       run: LLVM_PROFILE_FILE=test_fuzz_chan.profraw ./build/${{matrix.PRESET}}/tests/test_fuzz_chan
     - name: merge
-      run: llvm-profdata-18 merge -sparse tests.profraw test_exceptions.profraw -o coverage.profdata
-    - name: show
-      run: llvm-cov-18 export -format=lcov -instr-profile=coverage.profdata ./build/${{matrix.PRESET}}/tests/tests ./build/${{matrix.PRESET}}/tests/test_exceptions ./build/${{matrix.PRESET}}/tests/test_fuzz_chan ./submodules/TooManyCooks/ > ./submodules/TooManyCooks/coverage.info
+      run: |
+        llvm-profdata-18 merge -o coverage.profdata \
+        tests.profraw \
+        test_exceptions.profraw \
+        test_fuzz_chan.profraw 
+    - name: export
+      run: |
+        llvm-cov-18 export -format=lcov -instr-profile coverage.profdata \
+        -object ./build/${{matrix.PRESET}}/tests/tests \
+        -object ./build/${{matrix.PRESET}}/tests/test_exceptions \
+        -object ./build/${{matrix.PRESET}}/tests/test_fuzz_chan \
+        -sources ./submodules/TooManyCooks/ \
+        > coverage_${{matrix.WORK_ITEM}}_${{github.sha}}.txt
+    - uses: actions/upload-artifact@v4
+      with:
+        name: coverage_${{matrix.WORK_ITEM}}_${{github.sha}}.txt
+        path: coverage_${{matrix.WORK_ITEM}}_${{github.sha}}.txt
+        retention-days: 1
+        overwrite: true
+# generate coverage files in parallel for different TMC_WORK_ITEM configs
+# but upload them together; codecov.io will merge them and show overall coverage
+  upload:
+    needs: [build-and-test]
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/download-artifact@v4
+      with:
+        merge-multiple: true
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v5
       with:
         token: ${{secrets.CODECOV_TOKEN}}
         slug: tzcnt/TooManyCooks
-        working-directory: ./submodules/TooManyCooks

--- a/include/tmc/detail/concepts_awaitable.hpp
+++ b/include/tmc/detail/concepts_awaitable.hpp
@@ -20,6 +20,7 @@ using result_storage_t = std::conditional_t<
 
 template <typename Awaitable> struct unknown_awaitable_traits {
   // Try to guess at the awaiter type based on the expected function signatures.
+  // This function is normally unevaluated and only used to get the decltype.
   template <typename T> static decltype(auto) guess_awaiter(T&& value) {
     if constexpr (requires { static_cast<T&&>(value).operator co_await(); }) {
       return static_cast<T&&>(value).operator co_await();

--- a/include/tmc/spawn_func.hpp
+++ b/include/tmc/spawn_func.hpp
@@ -71,7 +71,7 @@ public:
     tmc::detail::post_checked(
       executor,
       [this, Outer,
-       ContinuationPrio = tmc::detail::this_thread::this_task.prio]() {
+       ContinuationPrio = tmc::detail::this_thread::this_task.prio]() mutable {
         if constexpr (std::is_void_v<Result>) {
           wrapped();
         } else {
@@ -84,7 +84,7 @@ public:
           Outer.resume();
         } else {
           tmc::detail::post_checked(
-            continuation_executor, Outer, ContinuationPrio
+            continuation_executor, std::move(Outer), ContinuationPrio
           );
         }
       },
@@ -145,7 +145,7 @@ template <typename Result> class aw_spawn_func_fork_impl {
     tmc::detail::post_checked(
       Executor,
       [this, Func,
-       ContinuationPrio = tmc::detail::this_thread::this_task.prio]() {
+       ContinuationPrio = tmc::detail::this_thread::this_task.prio]() mutable {
         if constexpr (std::is_void_v<Result>) {
           Func();
         } else {

--- a/include/tmc/spawn_tuple.hpp
+++ b/include/tmc/spawn_tuple.hpp
@@ -158,7 +158,11 @@ template <bool IsEach, typename... Awaitable> class aw_spawn_tuple_impl {
                     T>::result_type>) {
       tmc::detail::get_awaitable_traits<T>::set_result_ptr(Task, TaskResult);
     }
-    Task_out = std::move(Task);
+
+    // This type erasure is necessary when TMC_WORK_ITEM=FUNC,
+    // so that func.target <std::coroutine_handle<>>() works. Otherwise,
+    // the func target would be of the real type (tmc::task).
+    Task_out = std::coroutine_handle<>(std::move(Task));
   }
 
   // awaitables are submitted individually

--- a/include/tmc/sync.hpp
+++ b/include/tmc/sync.hpp
@@ -354,7 +354,7 @@ template <
     iter_adapter(
       static_cast<FuncIter&&>(Begin),
       [sharedState](FuncIter iter) mutable -> auto {
-        return [f = *iter, sharedState]() {
+        return [f = *iter, sharedState]() mutable {
           f();
           if (sharedState->done_count.fetch_sub(1, std::memory_order_acq_rel) ==
               0) {

--- a/include/tmc/work_item.hpp
+++ b/include/tmc/work_item.hpp
@@ -33,6 +33,12 @@ using work_item = std::coroutine_handle<>;
 }
 #define TMC_WORK_ITEM_AS_STD_CORO(x) (x)
 #elif TMC_WORK_ITEM_IS(FUNC)
+#ifndef TMC_TRIVIAL_TASK
+// This is because std::function requires its template type to be copyable.
+static_assert(
+  false, "If TMC_WORK_ITEM=FUNC, then TMC_TRIVIAL_TASK must also be defined."
+);
+#endif
 #include <functional>
 namespace tmc {
 using work_item = std::function<void()>;


### PR DESCRIPTION
This makes TMC_WORK_ITEM=FUNC (which uses `std::function<void()>` as the tmc::work_item) fully supported again. The only caveat is that TMC_TRIVIAL_TASK must also be defined when using this work item type, because `std::function` requires its parameter to be copyable.

The test coverage run has been expanded to cover all 3 work item types.