### PR TITLE
Standardize spawn function reference type handling rules

### DIFF
--- a/include/tmc/detail/concepts_work_item.hpp
+++ b/include/tmc/detail/concepts_work_item.hpp
@@ -111,10 +111,9 @@ task<void> into_task(Original FuncVoid) noexcept {
 // Moves-from Item and ensures that it is of a known awaitable type,
 // that is, after calling this, the mode will not be WRAPPER.
 template <bool IsFunc, typename Awaitable>
-inline auto into_known(Awaitable&& Item) {
-  using mov_t = std::remove_reference_t<Awaitable>&&;
+inline decltype(auto) into_known(Awaitable&& Item) {
   if constexpr (IsFunc) {
-    return into_task(static_cast<mov_t>(Item));
+    return into_task(static_cast<Awaitable&&>(Item));
   } else {
     if constexpr (tmc::detail::get_awaitable_traits<Awaitable>::mode ==
                     TMC_TASK ||
@@ -122,9 +121,9 @@ inline auto into_known(Awaitable&& Item) {
                     COROUTINE ||
                   tmc::detail::get_awaitable_traits<Awaitable>::mode ==
                     ASYNC_INITIATE) {
-      return static_cast<mov_t>(Item);
+      return static_cast<Awaitable&&>(Item);
     } else { // WRAPPER
-      return tmc::detail::safe_wrap(static_cast<mov_t>(Item));
+      return tmc::detail::safe_wrap(static_cast<Awaitable&&>(Item));
     }
   }
 }

--- a/include/tmc/detail/concepts_work_item.hpp
+++ b/include/tmc/detail/concepts_work_item.hpp
@@ -108,7 +108,7 @@ task<void> into_task(Original FuncVoid) noexcept {
   co_return;
 }
 
-// Moves-from Item and ensures that it is of a known awaitable type,
+// Ensures Item is of a known awaitable type,
 // that is, after calling this, the mode will not be WRAPPER.
 template <bool IsFunc, typename Awaitable>
 inline decltype(auto) into_known(Awaitable&& Item) {
@@ -128,7 +128,7 @@ inline decltype(auto) into_known(Awaitable&& Item) {
   }
 }
 
-// Moves-from k and converts into a coroutine handle, then into a work_item.
+// Converts k into a coroutine handle, then into a work_item.
 // This type erasure is necessary when TMC_WORK_ITEM=FUNC,
 // so that func.target <std::coroutine_handle<>>() works. Otherwise,
 // the func target would be of the real type (tmc::task).

--- a/include/tmc/detail/concepts_work_item.hpp
+++ b/include/tmc/detail/concepts_work_item.hpp
@@ -139,8 +139,7 @@ tmc::work_item into_initiate(Known&& k)
     tmc::detail::get_awaitable_traits<Known>::mode == COROUTINE
   )
 {
-  return std::coroutine_handle<>(static_cast<std::remove_reference_t<Known>&&>(k
-  ));
+  return std::coroutine_handle<>(static_cast<Known&&>(k));
 }
 
 // Returns the ASYNC_INITIATE type unchanged, so that it can be initiated.
@@ -148,7 +147,7 @@ template <typename Known>
 Known&& into_initiate(Known&& k)
   requires(tmc::detail::get_awaitable_traits<Known>::mode == ASYNC_INITIATE)
 {
-  return static_cast<std::remove_reference_t<Known>&&>(k);
+  return static_cast<Known&&>(k);
 }
 
 // todo how is task<Result> handled by caller?

--- a/include/tmc/detail/concepts_work_item.hpp
+++ b/include/tmc/detail/concepts_work_item.hpp
@@ -108,6 +108,51 @@ task<void> into_task(Original FuncVoid) noexcept {
   co_return;
 }
 
+// Moves-from Item and ensures that it is of a known awaitable type,
+// that is, after calling this, the mode will not be WRAPPER.
+template <bool IsFunc, typename Awaitable>
+inline auto into_known(Awaitable&& Item) {
+  using mov_t = std::remove_reference_t<Awaitable>&&;
+  if constexpr (IsFunc) {
+    return into_task(static_cast<mov_t>(Item));
+  } else {
+    if constexpr (tmc::detail::get_awaitable_traits<Awaitable>::mode ==
+                    TMC_TASK ||
+                  tmc::detail::get_awaitable_traits<Awaitable>::mode ==
+                    COROUTINE ||
+                  tmc::detail::get_awaitable_traits<Awaitable>::mode ==
+                    ASYNC_INITIATE) {
+      return static_cast<mov_t>(Item);
+    } else { // WRAPPER
+      return tmc::detail::safe_wrap(static_cast<mov_t>(Item));
+    }
+  }
+}
+
+// Moves-from k and converts into a coroutine handle, then into a work_item.
+// This type erasure is necessary when TMC_WORK_ITEM=FUNC,
+// so that func.target <std::coroutine_handle<>>() works. Otherwise,
+// the func target would be of the real type (tmc::task).
+template <typename Known>
+tmc::work_item into_initiate(Known&& k)
+  requires(
+    tmc::detail::get_awaitable_traits<Known>::mode == TMC_TASK ||
+    tmc::detail::get_awaitable_traits<Known>::mode == COROUTINE
+  )
+{
+  return std::coroutine_handle<>(static_cast<std::remove_reference_t<Known>&&>(k
+  ));
+}
+
+// Returns the ASYNC_INITIATE type unchanged, so that it can be initiated.
+template <typename Known>
+Known&& into_initiate(Known&& k)
+  requires(tmc::detail::get_awaitable_traits<Known>::mode == ASYNC_INITIATE)
+{
+  return static_cast<std::remove_reference_t<Known>&&>(k);
+}
+
+// todo how is task<Result> handled by caller?
 inline work_item into_work_item(task<void>&& Task) noexcept {
   return std::coroutine_handle<>(static_cast<task<void>&&>(Task));
 }

--- a/include/tmc/detail/task_wrapper.hpp
+++ b/include/tmc/detail/task_wrapper.hpp
@@ -279,11 +279,13 @@ template <
 [[nodiscard("You must await the return type of safe_wrap()"
 )]] tmc::detail::task_wrapper<Result>
 safe_wrap(Awaitable&& awaitable
-) noexcept(std::is_nothrow_move_constructible_v<Awaitable>)
-  // You must move your awaitables where possible.
-  // Passing lvalues is only allowed if there is no move constructor.
-  requires(std::is_rvalue_reference_v<Awaitable &&> || !std::is_move_constructible_v<std::decay_t<Awaitable>>)
-{
+) noexcept(std::is_nothrow_move_constructible_v<Awaitable>) {
+  static_assert(
+    std::is_rvalue_reference_v<Awaitable&&> ||
+      !std::is_move_constructible_v<std::decay_t<Awaitable>>,
+    "You must move your awaitables where possible. Passing lvalues is only "
+    "allowed if there is no move constructor."
+  );
   return [](
            Awaitable Aw, tmc::aw_resume_on TakeMeHome
          ) -> tmc::detail::task_wrapper<Result> {

--- a/include/tmc/detail/task_wrapper.hpp
+++ b/include/tmc/detail/task_wrapper.hpp
@@ -279,7 +279,11 @@ template <
 [[nodiscard("You must await the return type of safe_wrap()"
 )]] tmc::detail::task_wrapper<Result>
 safe_wrap(Awaitable&& awaitable
-) noexcept(std::is_nothrow_move_constructible_v<Awaitable>) {
+) noexcept(std::is_nothrow_move_constructible_v<Awaitable>)
+  // You must move your awaitables where possible.
+  // Passing lvalues is only allowed if there is no move constructor.
+  requires(std::is_rvalue_reference_v<Awaitable &&> || !std::is_move_constructible_v<std::decay_t<Awaitable>>)
+{
   return [](
            Awaitable Aw, tmc::aw_resume_on TakeMeHome
          ) -> tmc::detail::task_wrapper<Result> {

--- a/include/tmc/spawn_many.hpp
+++ b/include/tmc/spawn_many.hpp
@@ -971,8 +971,9 @@ public:
         }
         const size_t size = taskArr.size();
         for (size_t i = 0; i < size; ++i) {
-          taskArr[i] =
-            tmc::detail::into_initiate(tmc::detail::into_known<IsFunc>(*iter));
+          taskArr[i] = tmc::detail::into_initiate(
+            tmc::detail::into_known<IsFunc>(std::move(*iter))
+          );
           ++iter;
         }
         tmc::detail::post_bulk_checked(executor, taskArr.data(), size, prio);
@@ -994,18 +995,18 @@ public:
                       requires(IterEnd a, IterBegin b) { a - b; }) {
           const size_t size = taskArr.size();
           while (iter != sentinel && taskCount < size) {
-            taskArr[taskCount] =
-              tmc::detail::into_initiate(tmc::detail::into_known<IsFunc>(*iter)
-              );
+            taskArr[taskCount] = tmc::detail::into_initiate(
+              tmc::detail::into_known<IsFunc>(std::move(*iter))
+            );
             ++iter;
             ++taskCount;
           }
         } else {
           // We have no idea how many tasks there will be.
           while (iter != sentinel && taskCount < maxCount) {
-            taskArr.emplace_back(
-              tmc::detail::into_initiate(tmc::detail::into_known<IsFunc>(*iter))
-            );
+            taskArr.emplace_back(tmc::detail::into_initiate(
+              tmc::detail::into_known<IsFunc>(std::move(*iter))
+            ));
             ++iter;
             ++taskCount;
           }

--- a/include/tmc/spawn_many.hpp
+++ b/include/tmc/spawn_many.hpp
@@ -409,7 +409,7 @@ public:
       for (size_t i = 0; i < size; ++i) {
         auto t = tmc::detail::into_known<IsFunc>(std::move(*Iter));
         prepare_work(t, i, continuationPriority);
-        taskArr[i] = tmc::detail::into_initiate(t);
+        taskArr[i] = tmc::detail::into_initiate(std::move(t));
         ++Iter;
       }
 
@@ -515,7 +515,7 @@ public:
         while (Begin != End && taskCount < size) {
           auto t = tmc::detail::into_known<IsFunc>(std::move(*Begin));
           prepare_work(t, taskCount, continuationPriority);
-          taskArr[taskCount] = tmc::detail::into_initiate(t);
+          taskArr[taskCount] = tmc::detail::into_initiate(std::move(t));
           ++Begin;
           ++taskCount;
         }
@@ -653,7 +653,8 @@ public:
           size_t submitCount = 0;
           while (submitCount < workItemArr.size() && totalCount < postCount) {
             workItemArr[submitCount] =
-              tmc::detail::into_initiate(originalCoroArr[totalCount]);
+              tmc::detail::into_initiate(std::move(originalCoroArr[totalCount])
+              );
             ++totalCount;
             ++submitCount;
           }

--- a/include/tmc/spawn_tuple.hpp
+++ b/include/tmc/spawn_tuple.hpp
@@ -163,7 +163,7 @@ template <bool IsEach, typename... Awaitable> class aw_spawn_tuple_impl {
     // This type erasure is necessary when TMC_WORK_ITEM=FUNC,
     // so that func.target <std::coroutine_handle<>>() works. Otherwise,
     // the func target would be of the real type (tmc::task).
-    Task_out = std::coroutine_handle<>(std::move(Task));
+    Task_out = std::coroutine_handle<>(static_cast<T&&>(Task));
   }
 
   // awaitables are submitted individually

--- a/include/tmc/spawn_tuple.hpp
+++ b/include/tmc/spawn_tuple.hpp
@@ -11,7 +11,6 @@
 #include "tmc/detail/concepts_work_item.hpp"
 #include "tmc/detail/mixins.hpp"
 #include "tmc/detail/result_each.hpp"
-#include "tmc/detail/task_wrapper.hpp"
 #include "tmc/detail/thread_locals.hpp"
 #include "tmc/ex_any.hpp"
 #include "tmc/work_item.hpp"


### PR DESCRIPTION
This PR introduces some utility functions to convert awaitables into known types and initiate them. It also enhances the implementations of spawn(), spawn_many(), and spawn_tuple() to correctly propagate lvalue and rvalue-ness of the parameters. The intent is to further standardize the linear type rules - each awaitable should be moved into the co_await expression or the spawn wrapper that uses it.

Previously spawn_tuple() could always accept lvalue and rvalue reference parameters. And spawn() could only accept rvalue reference parameters. Now they are both allowed to accept rvalue reference parameters under all conditions. If (and only if) the parameter type does not have a move constructor, then an lvalue reference may be passed instead. This allows spawn types to be composed inside each other, as they don't have move constructors.

---
Future enhancements:

In the case of types that pass through safe_wrap() such as when composing the spawn types inside each other, a nice static_assert indicates the issue with the specific type. However, for types that don't use the wrapper, such as just passing in an lvalue task, the compiler output is not as nice. It would be worth investigating how to implement a static_assert that covers more ground here.

spawn_many() still has a loophole where it can move-from any pointer, whether that be to an array or simply to a task. This is something to revisit in a future PR.