### PR TITLE
implement `tmc::manual_reset_event`

### DIFF
--- a/include/tmc/all_headers.hpp
+++ b/include/tmc/all_headers.hpp
@@ -7,22 +7,23 @@
 
 // This header includes all of the TMC headers
 
-#include "tmc/atomic_condvar.hpp" // IWYU pragma: export
-#include "tmc/aw_resume_on.hpp"   // IWYU pragma: export
-#include "tmc/aw_yield.hpp"       // IWYU pragma: export
-#include "tmc/barrier.hpp"        // IWYU pragma: export
-#include "tmc/channel.hpp"        // IWYU pragma: export
-#include "tmc/current.hpp"        // IWYU pragma: export
-#include "tmc/ex_any.hpp"         // IWYU pragma: export
-#include "tmc/ex_braid.hpp"       // IWYU pragma: export
-#include "tmc/ex_cpu.hpp"         // IWYU pragma: export
-#include "tmc/external.hpp"       // IWYU pragma: export
-#include "tmc/mutex.hpp"          // IWYU pragma: export
-#include "tmc/semaphore.hpp"      // IWYU pragma: export
-#include "tmc/spawn.hpp"          // IWYU pragma: export
-#include "tmc/spawn_func.hpp"     // IWYU pragma: export
-#include "tmc/spawn_many.hpp"     // IWYU pragma: export
-#include "tmc/spawn_tuple.hpp"    // IWYU pragma: export
-#include "tmc/sync.hpp"           // IWYU pragma: export
-#include "tmc/task.hpp"           // IWYU pragma: export
-#include "tmc/work_item.hpp"      // IWYU pragma: export
+#include "tmc/atomic_condvar.hpp"     // IWYU pragma: export
+#include "tmc/aw_resume_on.hpp"       // IWYU pragma: export
+#include "tmc/aw_yield.hpp"           // IWYU pragma: export
+#include "tmc/barrier.hpp"            // IWYU pragma: export
+#include "tmc/channel.hpp"            // IWYU pragma: export
+#include "tmc/current.hpp"            // IWYU pragma: export
+#include "tmc/ex_any.hpp"             // IWYU pragma: export
+#include "tmc/ex_braid.hpp"           // IWYU pragma: export
+#include "tmc/ex_cpu.hpp"             // IWYU pragma: export
+#include "tmc/external.hpp"           // IWYU pragma: export
+#include "tmc/manual_reset_event.hpp" // IWYU pragma: export
+#include "tmc/mutex.hpp"              // IWYU pragma: export
+#include "tmc/semaphore.hpp"          // IWYU pragma: export
+#include "tmc/spawn.hpp"              // IWYU pragma: export
+#include "tmc/spawn_func.hpp"         // IWYU pragma: export
+#include "tmc/spawn_many.hpp"         // IWYU pragma: export
+#include "tmc/spawn_tuple.hpp"        // IWYU pragma: export
+#include "tmc/sync.hpp"               // IWYU pragma: export
+#include "tmc/task.hpp"               // IWYU pragma: export
+#include "tmc/work_item.hpp"          // IWYU pragma: export

--- a/include/tmc/detail/manual_reset_event.ipp
+++ b/include/tmc/detail/manual_reset_event.ipp
@@ -1,0 +1,73 @@
+// Copyright (c) 2023-2025 Logan McDougall
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include "tmc/detail/thread_locals.hpp"
+#include "tmc/detail/waiter_list.hpp"
+#include "tmc/manual_reset_event.hpp"
+
+#include <atomic>
+#include <coroutine>
+
+namespace tmc {
+bool aw_manual_reset_event::await_suspend(std::coroutine_handle<> Outer
+) noexcept {
+  me.waiter.continuation = Outer;
+  me.waiter.continuation_executor = tmc::detail::this_thread::executor;
+  me.waiter.continuation_priority = tmc::detail::this_thread::this_task.prio;
+  auto h = parent.head.load(std::memory_order_acquire);
+  do {
+    if (manual_reset_event::READY == h) {
+      // It was ready, don't wait
+      return false;
+    }
+    me.next = reinterpret_cast<tmc::detail::waiter_list_node*>(h);
+  } while (!parent.head.compare_exchange_strong(
+    h, reinterpret_cast<uintptr_t>(&me), std::memory_order_acq_rel,
+    std::memory_order_acquire
+  ));
+  return true;
+}
+
+std::coroutine_handle<>
+aw_manual_reset_event_co_set::await_suspend(std::coroutine_handle<> Outer
+) noexcept {
+  auto h =
+    parent.head.exchange(manual_reset_event::READY, std::memory_order_acq_rel);
+  if (manual_reset_event::READY == h || manual_reset_event::NOT_READY) {
+    // It was ready, or there are no waiters - just resume
+    return Outer;
+  }
+
+  // Save the first / most recently added waiter for symmetric transfer.
+  auto toWake = reinterpret_cast<tmc::detail::waiter_list_node*>(h);
+
+  auto curr = toWake->next;
+  while (curr != nullptr) {
+    auto next = curr->next;
+    curr->waiter.resume();
+    curr = next;
+  }
+
+  return toWake->waiter.try_symmetric_transfer(Outer);
+}
+
+void manual_reset_event::set() noexcept {
+  auto h = head.exchange(READY, std::memory_order_acq_rel);
+  if (READY == h) {
+    // It was ready, nothing to wake
+    return;
+  }
+  auto curr = reinterpret_cast<tmc::detail::waiter_list_node*>(h);
+  while (curr != nullptr) {
+    auto next = curr->next;
+    curr->waiter.resume();
+    curr = next;
+  }
+}
+
+manual_reset_event::~manual_reset_event() noexcept { set(); }
+} // namespace tmc

--- a/include/tmc/manual_reset_event.hpp
+++ b/include/tmc/manual_reset_event.hpp
@@ -1,0 +1,146 @@
+// Copyright (c) 2023-2025 Logan McDougall
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include "tmc/detail/concepts_awaitable.hpp"
+#include "tmc/detail/waiter_list.hpp"
+
+#include <atomic>
+#include <coroutine>
+
+namespace tmc {
+class manual_reset_event;
+
+class aw_manual_reset_event {
+  tmc::detail::waiter_list_node me;
+  manual_reset_event& parent;
+
+  friend class manual_reset_event;
+
+  inline aw_manual_reset_event(manual_reset_event& Parent) noexcept
+      : parent(Parent) {}
+
+public:
+  inline bool await_ready() noexcept { return false; }
+
+  bool await_suspend(std::coroutine_handle<> Outer) noexcept;
+
+  inline void await_resume() noexcept {}
+
+  // Cannot be moved or copied due to holding intrusive list pointer
+  aw_manual_reset_event(aw_manual_reset_event const&) = delete;
+  aw_manual_reset_event& operator=(aw_manual_reset_event const&) = delete;
+  aw_manual_reset_event(aw_manual_reset_event&&) = delete;
+  aw_manual_reset_event& operator=(aw_manual_reset_event&&) = delete;
+};
+
+class [[nodiscard(
+  "You must co_await aw_manual_reset_event_co_set for it to have any effect."
+)]] aw_manual_reset_event_co_set : tmc::detail::AwaitTagNoGroupAsIs {
+  manual_reset_event& parent;
+
+  friend class manual_reset_event;
+
+  inline aw_manual_reset_event_co_set(manual_reset_event& Parent) noexcept
+      : parent(Parent) {}
+
+public:
+  inline bool await_ready() noexcept { return false; }
+
+  std::coroutine_handle<> await_suspend(std::coroutine_handle<> Outer) noexcept;
+
+  inline void await_resume() noexcept {}
+
+  // Copy/move constructors *could* be implemented, but why?
+  aw_manual_reset_event_co_set(aw_manual_reset_event_co_set const&) = delete;
+  aw_manual_reset_event_co_set&
+  operator=(aw_manual_reset_event_co_set const&) = delete;
+  aw_manual_reset_event_co_set(aw_manual_reset_event&&) = delete;
+  aw_manual_reset_event_co_set&
+  operator=(aw_manual_reset_event_co_set&&) = delete;
+};
+
+class manual_reset_event {
+  // 3 states:
+  // 0 if not ready and no waiters
+  // 1 if ready
+  // (waiter_list_node*)(list_head) if not ready with waiters
+  std::atomic<uintptr_t> head;
+
+  static inline constexpr uintptr_t NOT_READY = 0;
+  static inline constexpr uintptr_t READY = 1;
+
+  friend class aw_manual_reset_event;
+  friend class aw_manual_reset_event_co_set;
+
+public:
+  /// The Ready parameter controls the initial state.
+  inline manual_reset_event(bool Ready) noexcept
+      : head(Ready ? READY : NOT_READY) {}
+
+  /// The initial state will be not-set / not-ready.
+  inline manual_reset_event() noexcept : manual_reset_event(false) {}
+
+  /// Returns true if the state is set / ready.
+  inline bool is_set() noexcept {
+    return manual_reset_event::READY == head.load(std::memory_order_acquire);
+  }
+
+  /// Any future awaiters will suspend.
+  /// If the event state is already reset, this will do nothing.
+  inline void reset() noexcept {
+    auto expected = READY;
+    head.compare_exchange_strong(
+      expected, NOT_READY, std::memory_order_acq_rel
+    );
+    // Don't need to check the result of the operation - it becomes not ready
+    // in any case. If there were already waiters, they will not be removed from
+    // the list.
+  }
+
+  /// All current awaiters will be resumed.
+  /// Any future awaiters will resume immediately.
+  /// If the event state is already set, this will do nothing.
+  void set() noexcept;
+
+  /// All current awaiters will be resumed.
+  /// Up to one awaiter will be resumed by symmetric transfer if it should run
+  /// on the same executor and priority as the current task. If an awaiter is
+  /// resumed by symmetric transfer, the caller will be posted to its executor.
+  /// Any future awaiters will resume immediately.
+  /// If the event state is already set, this will do nothing.
+  inline aw_manual_reset_event_co_set co_set() noexcept {
+    return aw_manual_reset_event_co_set(*this);
+  }
+
+  /// If the event state is set, resumes immediately.
+  /// Otherwise, waits until set() is called.
+  inline aw_manual_reset_event operator co_await() noexcept {
+    return aw_manual_reset_event(*this);
+  }
+
+  /// On destruction, any waiting awaiters will be resumed.
+  ~manual_reset_event() noexcept;
+};
+
+namespace detail {
+template <> struct awaitable_traits<tmc::manual_reset_event> {
+  static constexpr configure_mode mode = WRAPPER;
+
+  using result_type = void;
+  using self_type = tmc::manual_reset_event;
+  using awaiter_type = tmc::aw_manual_reset_event;
+
+  static awaiter_type get_awaiter(self_type& Awaitable) noexcept {
+    return Awaitable.operator co_await();
+  }
+};
+} // namespace detail
+} // namespace tmc
+
+#ifdef TMC_IMPL
+#include "tmc/detail/manual_reset_event.ipp"
+#endif


### PR DESCRIPTION
New type with API similar to Windows ManualResetEvent (https://learn.microsoft.com/en-us/dotnet/api/system.threading.manualresetevent?view=net-9.0)

- constructor: initializes the state to set or unset
- operator co_await: suspends if the state is unset, resumes once state becomes set
- set(): sets the state. if there were any awaiters, they are resumed.
- reset(): unsets the state. future callers of co_await will suspend
- co_set(): sets the state and symmetric transfers to up to 1 awaiter
- destructor: resumes any remaining awaiters