### PR TITLE
cleanups in async data types

### DIFF
--- a/include/tmc/barrier.hpp
+++ b/include/tmc/barrier.hpp
@@ -17,11 +17,11 @@ class barrier;
 
 class aw_barrier {
   tmc::detail::waiter_list_node me;
-  barrier* parent;
+  barrier& parent;
 
   friend class barrier;
 
-  inline aw_barrier(barrier* Parent) noexcept : parent(Parent) {}
+  inline aw_barrier(barrier& Parent) noexcept : parent(Parent) {}
 
 public:
   inline bool await_ready() noexcept {
@@ -62,11 +62,12 @@ public:
   /// count, and if the count reaches 0, wakes all awaiters, and resets the
   /// count to the original maximum as specified in the constructor. Otherwise,
   /// suspends until Count awaiters have reached this point.
-  inline aw_barrier operator co_await() noexcept { return aw_barrier(this); }
+  inline aw_barrier operator co_await() noexcept { return aw_barrier(*this); }
 
   /// On destruction, any awaiters will be resumed.
   ~barrier();
 };
+
 namespace detail {
 template <> struct awaitable_traits<tmc::barrier> {
   static constexpr configure_mode mode = WRAPPER;

--- a/include/tmc/detail/barrier.ipp
+++ b/include/tmc/detail/barrier.ipp
@@ -20,10 +20,10 @@ bool aw_barrier::await_suspend(std::coroutine_handle<> Outer) noexcept {
   me.waiter.continuation_priority = tmc::detail::this_thread::this_task.prio;
 
   // Add this awaiter to the waiter list
-  parent->waiters.add_waiter(me);
+  parent.waiters.add_waiter(me);
 
   // Decrement and check the barrier count
-  auto remaining = parent->done_count.fetch_sub(1, std::memory_order_acq_rel);
+  auto remaining = parent.done_count.fetch_sub(1, std::memory_order_acq_rel);
   if (remaining > 0) {
     return true;
   }
@@ -34,10 +34,10 @@ bool aw_barrier::await_suspend(std::coroutine_handle<> Outer) noexcept {
   // then resume the waiters.
 
   // Get the waiters
-  auto curr = parent->waiters.take_all();
+  auto curr = parent.waiters.take_all();
 
   // Reset this
-  parent->done_count = parent->start_count.load();
+  parent.done_count = parent.start_count.load();
 
   // Resume the waiters
   while (curr != nullptr) {

--- a/include/tmc/detail/coro_functor.hpp
+++ b/include/tmc/detail/coro_functor.hpp
@@ -25,8 +25,12 @@ class coro_functor {
   static constexpr uintptr_t IS_FUNC_BIT = TMC_ONE_BIT << 60;
   static_assert(sizeof(void*) == 8); // requires 64-bit
 
-  void* func; // coroutine address or function pointer. tagged via the above bit
-  void* obj;  // pointer to functor object. will be null if func is not a member
+  // coroutine address or function pointer. tagged via the above bit
+  void* func;
+
+  // pointer to functor object. will be null if func is not a class method,
+  // or if this holds a coroutine
+  void* obj;
 
 public:
   /// Resumes the provided coroutine, or calls the provided function/functor.


### PR DESCRIPTION
- use references instead of pointers where possible in awaitables of barrier, condvar, mutex, and semaphore
- add nodiscard attributes to co_release / co_unlock awaitable types
- remove impossible check in semaphore.co_release - the observed count will always be > 0
- remove impossible check in mutex.co_unlock - the observed state will always be unlocked
- cleanup doc comments