### PR TITLE
replace a few usages of std::move/forward with static_cast in ex_cpu

### DIFF
--- a/include/tmc/ex_cpu.hpp
+++ b/include/tmc/ex_cpu.hpp
@@ -237,7 +237,7 @@ template <> struct executor_traits<tmc::ex_cpu> {
     tmc::ex_cpu& ex, It&& Items, size_t Count, size_t Priority,
     size_t ThreadHint
   ) {
-    ex.post_bulk(std::forward<It>(Items), Count, Priority, ThreadHint);
+    ex.post_bulk(static_cast<It&&>(Items), Count, Priority, ThreadHint);
   }
 
   static tmc::ex_any* type_erased(tmc::ex_cpu& ex);


### PR DESCRIPTION
One step at a time toward reducing compile times and possibly standard header dependencies.

None of these actually need the remove_reference_t part of std::move (which allows moving-from lvalues). That functionality is even undesirable / conflicts with the linear awaitable type design of TMC, so I'm happy to have it gone from these usages.