### PR TITLE
implement `tmc::auto_reset_event`

### DIFF
--- a/include/tmc/all_headers.hpp
+++ b/include/tmc/all_headers.hpp
@@ -8,6 +8,7 @@
 // This header includes all of the TMC headers
 
 #include "tmc/atomic_condvar.hpp"     // IWYU pragma: export
+#include "tmc/auto_reset_event.hpp"   // IWYU pragma: export
 #include "tmc/aw_resume_on.hpp"       // IWYU pragma: export
 #include "tmc/aw_yield.hpp"           // IWYU pragma: export
 #include "tmc/barrier.hpp"            // IWYU pragma: export

--- a/include/tmc/auto_reset_event.hpp
+++ b/include/tmc/auto_reset_event.hpp
@@ -1,0 +1,143 @@
+// Copyright (c) 2023-2025 Logan McDougall
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include "tmc/detail/concepts_awaitable.hpp"
+#include "tmc/detail/waiter_list.hpp"
+
+#include <atomic>
+#include <coroutine>
+#include <cstddef>
+
+namespace tmc {
+class auto_reset_event;
+
+class aw_auto_reset_event {
+  tmc::detail::waiter_list_node me;
+  auto_reset_event& parent;
+
+  friend class auto_reset_event;
+
+  inline aw_auto_reset_event(auto_reset_event& Parent) noexcept
+      : parent(Parent) {}
+
+public:
+  bool await_ready() noexcept;
+
+  bool await_suspend(std::coroutine_handle<> Outer) noexcept;
+
+  inline void await_resume() noexcept {}
+
+  // Cannot be moved or copied due to holding intrusive list pointer
+  aw_auto_reset_event(aw_auto_reset_event const&) = delete;
+  aw_auto_reset_event& operator=(aw_auto_reset_event const&) = delete;
+  aw_auto_reset_event(aw_auto_reset_event&&) = delete;
+  aw_auto_reset_event& operator=(aw_auto_reset_event&&) = delete;
+};
+
+class [[nodiscard(
+  "You must co_await aw_auto_reset_event_co_unlock for it to have any effect."
+)]] aw_auto_reset_event_co_set : tmc::detail::AwaitTagNoGroupAsIs {
+  auto_reset_event& parent;
+
+  friend class auto_reset_event;
+
+  inline aw_auto_reset_event_co_set(auto_reset_event& Parent) noexcept
+      : parent(Parent) {}
+
+public:
+  inline bool await_ready() noexcept { return false; }
+
+  std::coroutine_handle<> await_suspend(std::coroutine_handle<> Outer) noexcept;
+
+  inline void await_resume() noexcept {}
+
+  // Copy/move constructors *could* be implemented, but why?
+  aw_auto_reset_event_co_set(aw_auto_reset_event_co_set const&) = delete;
+  aw_auto_reset_event_co_set&
+  operator=(aw_auto_reset_event_co_set const&) = delete;
+  aw_auto_reset_event_co_set(aw_auto_reset_event&&) = delete;
+  aw_auto_reset_event_co_set& operator=(aw_auto_reset_event_co_set&&) = delete;
+};
+
+/// An async version of Windows AutoResetEvent.
+class auto_reset_event {
+  tmc::detail::waiter_list waiters;
+  // Low half bits are the auto_reset_event value.
+  // High half bits are the number of waiters.
+  std::atomic<size_t> value;
+
+  friend class aw_auto_reset_event;
+  friend class aw_auto_reset_event_co_set;
+
+  // The implementation of this class is similar to tmc::semaphore, but
+  // saturates the state / count to a maximum of 1.
+
+  // Called after increasing Count or WaiterCount.
+  // If Count > 0 && WaiterCount > 0, this will try to wake some number of
+  // awaiters.
+  void maybe_wake(size_t v) noexcept;
+
+public:
+  /// The Ready parameter controls the initial state.
+  inline auto_reset_event(bool Ready) noexcept : value(Ready ? 1 : 0) {}
+
+  /// The initial state will be not-set / not-ready.
+  inline auto_reset_event() noexcept : auto_reset_event(false) {}
+
+  /// Returns true if the state is set / ready.
+  inline bool is_set() noexcept {
+    return 0 !=
+           (tmc::detail::HALF_MASK & value.load(std::memory_order_relaxed));
+  }
+
+  /// Any future awaiters will suspend.
+  /// If the event state is already reset, this will do nothing.
+  void reset() noexcept;
+
+  /// Makes the event state set. If there are any awaiters, the state will be
+  /// immediately reset and one awaiter will be resumed.
+  /// If the event state is already set, this will do nothing.
+  /// Does not symmetric transfer; awaiters will be posted to their executors.
+  void set() noexcept;
+
+  /// Makes the event state set. If there are any awaiters, the state will be
+  /// immediately reset and one awaiter will be resumed.
+  /// If the event state is already set, this will do nothing.
+  /// The awaiter may be resumed by symmetric transfer if it is eligible
+  /// (it resumes on the same executor and priority as the caller).
+  inline aw_auto_reset_event_co_set co_set() noexcept {
+    return aw_auto_reset_event_co_set(*this);
+  }
+
+  /// If the event state is set, resumes immediately.
+  /// Otherwise, waits until set() is called.
+  inline aw_auto_reset_event operator co_await() noexcept {
+    return aw_auto_reset_event(*this);
+  }
+
+  /// On destruction, any awaiters will be resumed.
+  ~auto_reset_event();
+};
+
+namespace detail {
+template <> struct awaitable_traits<tmc::auto_reset_event> {
+  static constexpr configure_mode mode = WRAPPER;
+
+  using result_type = void;
+  using self_type = tmc::auto_reset_event;
+  using awaiter_type = tmc::aw_auto_reset_event;
+
+  static awaiter_type get_awaiter(self_type& Awaitable) noexcept {
+    return Awaitable.operator co_await();
+  }
+};
+} // namespace detail
+} // namespace tmc
+
+#ifdef TMC_IMPL
+#include "tmc/detail/auto_reset_event.ipp"
+#endif

--- a/include/tmc/detail/auto_reset_event.ipp
+++ b/include/tmc/detail/auto_reset_event.ipp
@@ -1,0 +1,141 @@
+// Copyright (c) 2023-2025 Logan McDougall
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include "tmc/auto_reset_event.hpp"
+#include "tmc/detail/thread_locals.hpp"
+#include "tmc/detail/waiter_list.hpp"
+
+#include <atomic>
+#include <cassert>
+#include <coroutine>
+
+namespace tmc {
+bool aw_auto_reset_event::await_ready() noexcept {
+  auto v = parent.value.load(std::memory_order_relaxed);
+
+  tmc::detail::half_word count;
+  size_t waiterCount, newV;
+  do {
+    tmc::detail::unpack_value(v, count, waiterCount);
+    if (0 == count) {
+      return false;
+    }
+    newV = tmc::detail::pack_value(count - 1, waiterCount);
+  } while (!parent.value.compare_exchange_strong(
+    v, newV, std::memory_order_acq_rel, std::memory_order_acquire
+  ));
+  return true;
+}
+
+bool aw_auto_reset_event::await_suspend(std::coroutine_handle<> Outer
+) noexcept {
+  // Configure this awaiter
+  me.waiter.continuation = Outer;
+  me.waiter.continuation_executor = tmc::detail::this_thread::executor;
+  me.waiter.continuation_priority = tmc::detail::this_thread::this_task.prio;
+
+  // Add this awaiter to the waiter list
+  parent.waiters.add_waiter(me);
+
+  // Release the operation by increasing the waiter count
+  auto add = TMC_ONE_BIT << tmc::detail::WAITERS_OFFSET;
+  auto v = add + parent.value.fetch_add(add, std::memory_order_acq_rel);
+
+  // Using the fetched value, see if there are both resources available and
+  // waiters to wake.
+  parent.maybe_wake(v);
+  return true;
+}
+
+std::coroutine_handle<>
+aw_auto_reset_event_co_set::await_suspend(std::coroutine_handle<> Outer
+) noexcept {
+  // same as aw_semaphore_co_release::await_suspend, but saturates count to 1
+  size_t v = 1 + parent.value.fetch_add(1, std::memory_order_release);
+
+  tmc::detail::half_word count;
+  size_t waiterCount, newV, wakeCount;
+  do {
+    tmc::detail::unpack_value(v, count, waiterCount);
+    // By atomically subtracting from both values at once, this thread
+    // "takes ownership" of wakeCount number of resources and waiters
+    // simultaneously.
+    if (count <= waiterCount) {
+      newV = tmc::detail::pack_value(0, waiterCount - count);
+      wakeCount = count;
+    } else {
+      // Saturate the readiness to 1
+      newV = tmc::detail::pack_value(1, 0);
+      wakeCount = waiterCount;
+    }
+  } while (!parent.value.compare_exchange_strong(
+    v, newV, std::memory_order_acq_rel, std::memory_order_acquire
+  ));
+
+  // No early return in the do loop because we need to saturate the readiness.
+  if (wakeCount == 0) {
+    return Outer;
+  }
+
+  auto toWake = parent.waiters.must_take_1();
+  --wakeCount;
+  if (wakeCount != 0) {
+    parent.waiters.must_wake_n(wakeCount);
+  }
+  return toWake->waiter.try_symmetric_transfer(Outer);
+}
+
+void auto_reset_event::maybe_wake(size_t v) noexcept {
+  // same as aw_semaphore::maybe_wake, but saturates count to 1
+  tmc::detail::half_word count;
+  size_t waiterCount, newV, wakeCount;
+  do {
+    tmc::detail::unpack_value(v, count, waiterCount);
+    // By atomically subtracting from both values at once, this thread
+    // "takes ownership" of wakeCount number of resources and waiters
+    // simultaneously.
+    if (count <= waiterCount) {
+      newV = tmc::detail::pack_value(0, waiterCount - count);
+      wakeCount = count;
+    } else {
+      // Saturate the readiness to 1
+      newV = tmc::detail::pack_value(1, 0);
+      wakeCount = waiterCount;
+    }
+  } while (!value.compare_exchange_strong(
+    v, newV, std::memory_order_acq_rel, std::memory_order_acquire
+  ));
+
+  // No early return in the do loop because we need to saturate the readiness.
+  if (wakeCount == 0) {
+    return;
+  }
+
+  waiters.must_wake_n(wakeCount);
+}
+
+void auto_reset_event::reset() noexcept {
+  auto v = value.load(std::memory_order_relaxed);
+
+  tmc::detail::half_word count;
+  size_t waiterCount, newV;
+  do {
+    tmc::detail::unpack_value(v, count, waiterCount);
+    newV = tmc::detail::pack_value(0, waiterCount);
+  } while (!value.compare_exchange_strong(
+    v, newV, std::memory_order_acq_rel, std::memory_order_acquire
+  ));
+}
+
+void auto_reset_event::set() noexcept {
+  size_t v = 1 + value.fetch_add(1, std::memory_order_release);
+  maybe_wake(v);
+}
+
+auto_reset_event::~auto_reset_event() { waiters.wake_all(); }
+
+} // namespace tmc


### PR DESCRIPTION
Async version of Windows [AutoResetEvent](https://learn.microsoft.com/en-us/dotnet/api/system.threading.autoresetevent?view=net-9.0)

- constructor sets the initial state
- reset()
- set()
- co_set()
- destructor releases all waiters