### PR TITLE
Fix data race / unify implementation of mutex, semaphore, auto_reset_event

### DIFF
--- a/include/tmc/auto_reset_event.hpp
+++ b/include/tmc/auto_reset_event.hpp
@@ -10,33 +10,9 @@
 
 #include <atomic>
 #include <coroutine>
-#include <cstddef>
 
 namespace tmc {
 class auto_reset_event;
-
-class aw_auto_reset_event {
-  tmc::detail::waiter_list_node me;
-  auto_reset_event& parent;
-
-  friend class auto_reset_event;
-
-  inline aw_auto_reset_event(auto_reset_event& Parent) noexcept
-      : parent(Parent) {}
-
-public:
-  bool await_ready() noexcept;
-
-  void await_suspend(std::coroutine_handle<> Outer) noexcept;
-
-  inline void await_resume() noexcept {}
-
-  // Cannot be moved or copied due to holding intrusive list pointer
-  aw_auto_reset_event(aw_auto_reset_event const&) = delete;
-  aw_auto_reset_event& operator=(aw_auto_reset_event const&) = delete;
-  aw_auto_reset_event(aw_auto_reset_event&&) = delete;
-  aw_auto_reset_event& operator=(aw_auto_reset_event&&) = delete;
-};
 
 class [[nodiscard(
   "You must co_await aw_auto_reset_event_co_unlock for it to have any effect."
@@ -59,23 +35,18 @@ public:
   aw_auto_reset_event_co_set(aw_auto_reset_event_co_set const&) = delete;
   aw_auto_reset_event_co_set&
   operator=(aw_auto_reset_event_co_set const&) = delete;
-  aw_auto_reset_event_co_set(aw_auto_reset_event&&) = delete;
+  aw_auto_reset_event_co_set(aw_auto_reset_event_co_set&&) = delete;
   aw_auto_reset_event_co_set& operator=(aw_auto_reset_event_co_set&&) = delete;
 };
 
 /// An async version of Windows AutoResetEvent.
-class auto_reset_event {
-  tmc::detail::waiter_list waiters;
-  // Low half bits are the auto_reset_event value.
-  // High half bits are the number of waiters.
-  std::atomic<size_t> value;
-
-  friend class aw_auto_reset_event;
+class auto_reset_event : protected tmc::detail::waiter_data_base {
+  friend class aw_acquire;
   friend class aw_auto_reset_event_co_set;
 
 public:
   /// The Ready parameter controls the initial state.
-  inline auto_reset_event(bool Ready) noexcept : value(Ready ? 1 : 0) {}
+  inline auto_reset_event(bool Ready) noexcept { value = Ready ? 1 : 0; }
 
   /// The initial state will be not-set / not-ready.
   inline auto_reset_event() noexcept : auto_reset_event(false) {}
@@ -107,9 +78,7 @@ public:
 
   /// If the event state is set, resumes immediately.
   /// Otherwise, waits until set() is called.
-  inline aw_auto_reset_event operator co_await() noexcept {
-    return aw_auto_reset_event(*this);
-  }
+  inline aw_acquire operator co_await() noexcept { return aw_acquire(*this); }
 
   /// On destruction, any awaiters will be resumed.
   ~auto_reset_event();
@@ -121,7 +90,7 @@ template <> struct awaitable_traits<tmc::auto_reset_event> {
 
   using result_type = void;
   using self_type = tmc::auto_reset_event;
-  using awaiter_type = tmc::aw_auto_reset_event;
+  using awaiter_type = tmc::aw_acquire;
 
   static awaiter_type get_awaiter(self_type& Awaitable) noexcept {
     return Awaitable.operator co_await();

--- a/include/tmc/auto_reset_event.hpp
+++ b/include/tmc/auto_reset_event.hpp
@@ -27,7 +27,7 @@ class aw_auto_reset_event {
 public:
   bool await_ready() noexcept;
 
-  bool await_suspend(std::coroutine_handle<> Outer) noexcept;
+  void await_suspend(std::coroutine_handle<> Outer) noexcept;
 
   inline void await_resume() noexcept {}
 
@@ -72,14 +72,6 @@ class auto_reset_event {
 
   friend class aw_auto_reset_event;
   friend class aw_auto_reset_event_co_set;
-
-  // The implementation of this class is similar to tmc::semaphore, but
-  // saturates the state / count to a maximum of 1.
-
-  // Called after increasing Count or WaiterCount.
-  // If Count > 0 && WaiterCount > 0, this will try to wake some number of
-  // awaiters.
-  void maybe_wake(size_t v) noexcept;
 
 public:
   /// The Ready parameter controls the initial state.

--- a/include/tmc/auto_reset_event.hpp
+++ b/include/tmc/auto_reset_event.hpp
@@ -15,7 +15,7 @@ namespace tmc {
 class auto_reset_event;
 
 class [[nodiscard(
-  "You must co_await aw_auto_reset_event_co_unlock for it to have any effect."
+  "You must co_await aw_auto_reset_event_co_set for it to have any effect."
 )]] aw_auto_reset_event_co_set : tmc::detail::AwaitTagNoGroupAsIs {
   auto_reset_event& parent;
 

--- a/include/tmc/detail/auto_reset_event.ipp
+++ b/include/tmc/detail/auto_reset_event.ipp
@@ -6,134 +6,66 @@
 #pragma once
 
 #include "tmc/auto_reset_event.hpp"
-#include "tmc/detail/thread_locals.hpp"
 #include "tmc/detail/waiter_list.hpp"
 
 #include <atomic>
-#include <cassert>
 #include <coroutine>
+#include <cstddef>
 
 namespace tmc {
 bool aw_auto_reset_event::await_ready() noexcept {
-  auto v = parent.value.load(std::memory_order_relaxed);
-
-  tmc::detail::half_word count;
-  size_t waiterCount, newV;
-  do {
-    tmc::detail::unpack_value(v, count, waiterCount);
-    if (0 == count) {
-      return false;
-    }
-    newV = tmc::detail::pack_value(count - 1, waiterCount);
-  } while (!parent.value.compare_exchange_strong(
-    v, newV, std::memory_order_acq_rel, std::memory_order_acquire
-  ));
-  return true;
+  return tmc::detail::try_acquire(parent.value);
 }
 
-bool aw_auto_reset_event::await_suspend(std::coroutine_handle<> Outer
+void aw_auto_reset_event::await_suspend(std::coroutine_handle<> Outer
 ) noexcept {
-  // Configure this awaiter
-  me.waiter.continuation = Outer;
-  me.waiter.continuation_executor = tmc::detail::this_thread::executor;
-  me.waiter.continuation_priority = tmc::detail::this_thread::this_task.prio;
-
-  // Add this awaiter to the waiter list
-  parent.waiters.add_waiter(me);
-
-  // Release the operation by increasing the waiter count
-  auto add = TMC_ONE_BIT << tmc::detail::WAITERS_OFFSET;
-  auto v = add + parent.value.fetch_add(add, std::memory_order_acq_rel);
-
-  // Using the fetched value, see if there are both resources available and
-  // waiters to wake.
-  parent.maybe_wake(v);
-  return true;
+  me.suspend(parent.waiters, parent.value, Outer);
 }
 
 std::coroutine_handle<>
 aw_auto_reset_event_co_set::await_suspend(std::coroutine_handle<> Outer
 ) noexcept {
-  // same as aw_semaphore_co_release::await_suspend, but saturates count to 1
-  size_t v = 1 + parent.value.fetch_add(1, std::memory_order_release);
-
-  tmc::detail::half_word count;
-  size_t waiterCount, newV, wakeCount;
+  size_t old = parent.value.load(std::memory_order_acquire);
+  size_t v;
   do {
-    tmc::detail::unpack_value(v, count, waiterCount);
-    // By atomically subtracting from both values at once, this thread
-    // "takes ownership" of wakeCount number of resources and waiters
-    // simultaneously.
-    if (count <= waiterCount) {
-      newV = tmc::detail::pack_value(0, waiterCount - count);
-      wakeCount = count;
-    } else {
-      // Saturate the readiness to 1
-      newV = tmc::detail::pack_value(1, 0);
-      wakeCount = waiterCount;
+    tmc::detail::half_word oldCount;
+    size_t oldWaiterCount;
+    tmc::detail::unpack_value(old, oldCount, oldWaiterCount);
+    // count is only allowed to be 1 greater than waiterCount
+    if (oldCount >= oldWaiterCount + 1) {
+      return Outer;
     }
+    v = 1 + old;
   } while (!parent.value.compare_exchange_strong(
-    v, newV, std::memory_order_acq_rel, std::memory_order_acquire
+    old, v, std::memory_order_acq_rel, std::memory_order_acquire
   ));
 
-  // No early return in the do loop because we need to saturate the readiness.
-  if (wakeCount == 0) {
+  auto toWake = parent.waiters.maybe_wake(parent.value, v, old, true);
+  if (toWake == nullptr) {
     return Outer;
   }
 
-  auto toWake = parent.waiters.must_take_1();
-  --wakeCount;
-  if (wakeCount != 0) {
-    parent.waiters.must_wake_n(wakeCount);
-  }
-  return toWake->waiter.try_symmetric_transfer(Outer);
+  return toWake->try_symmetric_transfer(Outer);
 }
 
-void auto_reset_event::maybe_wake(size_t v) noexcept {
-  // same as aw_semaphore::maybe_wake, but saturates count to 1
-  tmc::detail::half_word count;
-  size_t waiterCount, newV, wakeCount;
-  do {
-    tmc::detail::unpack_value(v, count, waiterCount);
-    // By atomically subtracting from both values at once, this thread
-    // "takes ownership" of wakeCount number of resources and waiters
-    // simultaneously.
-    if (count <= waiterCount) {
-      newV = tmc::detail::pack_value(0, waiterCount - count);
-      wakeCount = count;
-    } else {
-      // Saturate the readiness to 1
-      newV = tmc::detail::pack_value(1, 0);
-      wakeCount = waiterCount;
-    }
-  } while (!value.compare_exchange_strong(
-    v, newV, std::memory_order_acq_rel, std::memory_order_acquire
-  ));
-
-  // No early return in the do loop because we need to saturate the readiness.
-  if (wakeCount == 0) {
-    return;
-  }
-
-  waiters.must_wake_n(wakeCount);
-}
-
-void auto_reset_event::reset() noexcept {
-  auto v = value.load(std::memory_order_relaxed);
-
-  tmc::detail::half_word count;
-  size_t waiterCount, newV;
-  do {
-    tmc::detail::unpack_value(v, count, waiterCount);
-    newV = tmc::detail::pack_value(0, waiterCount);
-  } while (!value.compare_exchange_strong(
-    v, newV, std::memory_order_acq_rel, std::memory_order_acquire
-  ));
-}
+void auto_reset_event::reset() noexcept { tmc::detail::try_acquire(value); }
 
 void auto_reset_event::set() noexcept {
-  size_t v = 1 + value.fetch_add(1, std::memory_order_release);
-  maybe_wake(v);
+  size_t old = value.load(std::memory_order_acquire);
+  size_t v;
+  do {
+    tmc::detail::half_word oldCount;
+    size_t oldWaiterCount;
+    tmc::detail::unpack_value(old, oldCount, oldWaiterCount);
+    // count is only allowed to be 1 greater than waiterCount
+    if (oldCount >= oldWaiterCount + 1) {
+      return;
+    }
+    v = 1 + old;
+  } while (!value.compare_exchange_strong(
+    old, v, std::memory_order_acq_rel, std::memory_order_acquire
+  ));
+  waiters.maybe_wake(value, v, old, false);
 }
 
 auto_reset_event::~auto_reset_event() { waiters.wake_all(); }

--- a/include/tmc/detail/auto_reset_event.ipp
+++ b/include/tmc/detail/auto_reset_event.ipp
@@ -13,15 +13,6 @@
 #include <cstddef>
 
 namespace tmc {
-bool aw_auto_reset_event::await_ready() noexcept {
-  return tmc::detail::try_acquire(parent.value);
-}
-
-void aw_auto_reset_event::await_suspend(std::coroutine_handle<> Outer
-) noexcept {
-  me.suspend(parent.waiters, parent.value, Outer);
-}
-
 std::coroutine_handle<>
 aw_auto_reset_event_co_set::await_suspend(std::coroutine_handle<> Outer
 ) noexcept {

--- a/include/tmc/detail/auto_reset_event.ipp
+++ b/include/tmc/detail/auto_reset_event.ipp
@@ -60,5 +60,4 @@ void auto_reset_event::set() noexcept {
 }
 
 auto_reset_event::~auto_reset_event() { waiters.wake_all(); }
-
 } // namespace tmc

--- a/include/tmc/detail/mutex.ipp
+++ b/include/tmc/detail/mutex.ipp
@@ -14,7 +14,6 @@
 #include <cstddef>
 
 namespace tmc {
-
 mutex_scope::~mutex_scope() {
   if (parent != nullptr) {
     parent->unlock();
@@ -53,5 +52,4 @@ void mutex::unlock() noexcept {
 }
 
 mutex::~mutex() { waiters.wake_all(); }
-
 } // namespace tmc

--- a/include/tmc/detail/mutex.ipp
+++ b/include/tmc/detail/mutex.ipp
@@ -14,13 +14,6 @@
 #include <cstddef>
 
 namespace tmc {
-bool aw_mutex::await_ready() noexcept {
-  return tmc::detail::try_acquire(parent.value);
-}
-
-void aw_mutex::await_suspend(std::coroutine_handle<> Outer) noexcept {
-  me.suspend(parent.waiters, parent.value, Outer);
-}
 
 mutex_scope::~mutex_scope() {
   if (parent != nullptr) {

--- a/include/tmc/detail/mutex.ipp
+++ b/include/tmc/detail/mutex.ipp
@@ -5,34 +5,21 @@
 
 #pragma once
 
-#include "tmc/detail/thread_locals.hpp"
 #include "tmc/detail/waiter_list.hpp"
 #include "tmc/mutex.hpp"
 
 #include <atomic>
 #include <cassert>
 #include <coroutine>
+#include <cstddef>
 
 namespace tmc {
-bool aw_mutex::await_ready() noexcept { return parent.try_lock(); }
+bool aw_mutex::await_ready() noexcept {
+  return tmc::detail::try_acquire(parent.value);
+}
 
-bool aw_mutex::await_suspend(std::coroutine_handle<> Outer) noexcept {
-  // Configure this awaiter
-  me.waiter.continuation = Outer;
-  me.waiter.continuation_executor = tmc::detail::this_thread::executor;
-  me.waiter.continuation_priority = tmc::detail::this_thread::this_task.prio;
-
-  // Add this awaiter to the waiter list
-  parent.waiters.add_waiter(me);
-
-  // Release the operation by increasing the waiter count
-  auto add = TMC_ONE_BIT << tmc::detail::WAITERS_OFFSET;
-  auto v = add + parent.value.fetch_add(add, std::memory_order_acq_rel);
-
-  // Using the fetched value, see if there are both resources available and
-  // waiters to wake.
-  parent.maybe_wake(v);
-  return true;
+void aw_mutex::await_suspend(std::coroutine_handle<> Outer) noexcept {
+  me.suspend(parent.waiters, parent.value, Outer);
 }
 
 mutex_scope::~mutex_scope() {
@@ -41,92 +28,35 @@ mutex_scope::~mutex_scope() {
   }
 }
 
-bool aw_mutex_lock_scope::await_ready() noexcept { return parent.try_lock(); }
+bool aw_mutex_lock_scope::await_ready() noexcept {
+  return tmc::detail::try_acquire(parent.value);
+}
 
-bool aw_mutex_lock_scope::await_suspend(std::coroutine_handle<> Outer
+void aw_mutex_lock_scope::await_suspend(std::coroutine_handle<> Outer
 ) noexcept {
-  // Configure this awaiter
-  me.waiter.continuation = Outer;
-  me.waiter.continuation_executor = tmc::detail::this_thread::executor;
-  me.waiter.continuation_priority = tmc::detail::this_thread::this_task.prio;
-
-  // Add this awaiter to the waiter list
-  parent.waiters.add_waiter(me);
-
-  // Release the operation by increasing the waiter count
-  auto add = TMC_ONE_BIT << tmc::detail::WAITERS_OFFSET;
-  auto v = add + parent.value.fetch_add(add, std::memory_order_acq_rel);
-
-  // Using the fetched value, see if there are both resources available and
-  // waiters to wake.
-  parent.maybe_wake(v);
-  return true;
+  me.suspend(parent.waiters, parent.value, Outer);
 }
 
 std::coroutine_handle<>
 aw_mutex_co_unlock::await_suspend(std::coroutine_handle<> Outer) noexcept {
   assert(parent.is_locked());
-  size_t v = mutex::UNLOCKED |
-             parent.value.fetch_or(mutex::UNLOCKED, std::memory_order_release);
-  tmc::detail::half_word state;
-  size_t waiterCount, newV, wakeCount;
-  do {
-    tmc::detail::unpack_value(v, state, waiterCount);
-    // assert(state == mutex::UNLOCKED);
-    if (waiterCount == 0) {
-      // No waiters - just resume
-      return Outer;
-    }
-    // By atomically modifying both values at once, this thread
-    // "takes ownership" of the lock and 1 waiter simultaneously.
-    newV = tmc::detail::pack_value(mutex::LOCKED, waiterCount - 1);
-  } while (!parent.value.compare_exchange_strong(
-    v, newV, std::memory_order_acq_rel, std::memory_order_acquire
-  ));
+  size_t old =
+    parent.value.fetch_or(mutex::UNLOCKED, std::memory_order_release);
+  size_t v = mutex::UNLOCKED | old;
 
-  auto toWake = parent.waiters.must_take_1();
-  return toWake->waiter.try_symmetric_transfer(Outer);
-}
+  auto toWake = parent.waiters.maybe_wake(parent.value, v, old, true);
+  if (toWake == nullptr) {
+    return Outer;
+  }
 
-void mutex::maybe_wake(size_t v) noexcept {
-  tmc::detail::half_word state;
-  size_t waiterCount, newV, wakeCount;
-  do {
-    tmc::detail::unpack_value(v, state, waiterCount);
-    if (state == LOCKED || waiterCount == 0) {
-      return;
-    }
-    // By atomically modifying both values at once, this thread
-    // "takes ownership" of the lock and 1 waiter simultaneously.
-    newV = tmc::detail::pack_value(LOCKED, waiterCount - 1);
-  } while (!value.compare_exchange_strong(
-    v, newV, std::memory_order_acq_rel, std::memory_order_acquire
-  ));
-
-  auto toWake = waiters.must_take_1();
-  toWake->waiter.resume();
-}
-
-bool mutex::try_lock() noexcept {
-  auto v = value.load(std::memory_order_relaxed);
-  tmc::detail::half_word state;
-  size_t waiterCount, newV;
-  do {
-    tmc::detail::unpack_value(v, state, waiterCount);
-    if (LOCKED == state) {
-      return false;
-    }
-    newV = tmc::detail::pack_value(LOCKED, waiterCount);
-  } while (!value.compare_exchange_strong(
-    v, newV, std::memory_order_acq_rel, std::memory_order_acquire
-  ));
-  return true;
+  return toWake->try_symmetric_transfer(Outer);
 }
 
 void mutex::unlock() noexcept {
   assert(is_locked());
-  size_t v = UNLOCKED | value.fetch_or(UNLOCKED, std::memory_order_release);
-  maybe_wake(v);
+  size_t old = value.fetch_or(UNLOCKED, std::memory_order_release);
+  size_t v = UNLOCKED | old;
+  waiters.maybe_wake(value, v, old, false);
 }
 
 mutex::~mutex() { waiters.wake_all(); }

--- a/include/tmc/detail/semaphore.ipp
+++ b/include/tmc/detail/semaphore.ipp
@@ -13,7 +13,6 @@
 #include <cstddef>
 
 namespace tmc {
-
 semaphore_scope::~semaphore_scope() {
   if (parent != nullptr) {
     parent->release(1);
@@ -50,5 +49,4 @@ void semaphore::release(size_t ReleaseCount) noexcept {
 }
 
 semaphore::~semaphore() { waiters.wake_all(); }
-
 } // namespace tmc

--- a/include/tmc/detail/semaphore.ipp
+++ b/include/tmc/detail/semaphore.ipp
@@ -13,13 +13,6 @@
 #include <cstddef>
 
 namespace tmc {
-bool aw_semaphore::await_ready() noexcept {
-  return tmc::detail::try_acquire(parent.value);
-}
-
-void aw_semaphore::await_suspend(std::coroutine_handle<> Outer) noexcept {
-  me.suspend(parent.waiters, parent.value, Outer);
-}
 
 semaphore_scope::~semaphore_scope() {
   if (parent != nullptr) {

--- a/include/tmc/detail/waiter_list.hpp
+++ b/include/tmc/detail/waiter_list.hpp
@@ -13,18 +13,20 @@
 namespace tmc {
 namespace detail {
 
+class waiter_list;
+
 struct waiter_list_waiter {
   std::coroutine_handle<> continuation;
   tmc::ex_any* continuation_executor;
   size_t continuation_priority;
 
-  // Submits this to the executor to be resumed
+  /// Submits this to the executor to be resumed
   void resume() noexcept;
 
-  // If this expects to resume on the same executor and priority as the Outer
-  // task, then returns this and posts the outer task to the exectutor. If this
-  // expects to resume on a different executor or priority, then posts this to
-  // its executor and returns the outer task.
+  /// If this expects to resume on the same executor and priority as the Outer
+  /// task, then returns this and posts the outer task to the exectutor. If this
+  /// expects to resume on a different executor or priority, then posts this to
+  /// its executor and returns the outer task.
   [[nodiscard]] std::coroutine_handle<>
   try_symmetric_transfer(std::coroutine_handle<> Outer) noexcept;
 };
@@ -32,6 +34,12 @@ struct waiter_list_waiter {
 struct waiter_list_node {
   waiter_list_node* next;
   waiter_list_waiter waiter;
+
+  /// Used by mutex and semaphore acquire awaitables.
+  void suspend(
+    tmc::detail::waiter_list& ParentList, std::atomic<size_t>& ParentValue,
+    std::coroutine_handle<> Outer
+  ) noexcept;
 };
 
 class waiter_list {
@@ -40,22 +48,36 @@ class waiter_list {
 public:
   waiter_list() : head{nullptr} {}
 
-  // Adds w to list. Head becomes w.
+  /// Adds w to list. Head becomes w.
+  /// Thread-safe.
   void add_waiter(waiter_list_node& w) noexcept;
 
-  // Wakes all waiters. Head becomes nullptr.
+  /// Wakes all waiters. Head becomes nullptr.
+  /// Thread-safe.
   void wake_all() noexcept;
 
-  // Returns head. Head becomes nullptr.
+  /// Returns head. Head becomes nullptr.
+  /// Thread-safe.
   [[nodiscard]] waiter_list_node* take_all() noexcept;
 
   /// Assumes at least n waiters are in the list.
   /// Wakes n waiters.
+  /// Not thread-safe.
   void must_wake_n(size_t n) noexcept;
 
-  /// Assumes at least 1 waiters is in the list.
+  /// Assumes at least 1 waiter is in the list.
   /// Takes 1 waiter.
+  /// Not thread-safe.
   [[nodiscard]] waiter_list_node* must_take_1() noexcept;
+
+  /// Used by mutex and semaphore.
+  /// Called after increasing Count or WaiterCount.
+  /// If Count > 0 && WaiterCount > 0, this will try to wake some number of
+  /// awaiters. If symmetric == true, may return a waiter for symmetric
+  /// transfer. If symmetric == false, always returns nullptr.
+  waiter_list_waiter* maybe_wake(
+    std::atomic<size_t>& value, size_t v, size_t old, bool symmetric
+  ) noexcept;
 };
 
 // Utilities used by various awaitables that hold a waiter_list
@@ -78,6 +100,11 @@ static inline void unpack_value(
 static inline size_t pack_value(half_word Count, size_t WaiterCount) noexcept {
   return (WaiterCount << WAITERS_OFFSET) | static_cast<size_t>(Count);
 }
+
+/// Used by mutex and semaphore.
+/// Returns true if the count was non-zero and was successfully decremented.
+/// Returns false if the count was zero.
+bool try_acquire(std::atomic<size_t>& Value) noexcept;
 
 } // namespace detail
 } // namespace tmc

--- a/include/tmc/detail/waiter_list.hpp
+++ b/include/tmc/detail/waiter_list.hpp
@@ -49,7 +49,7 @@ class waiter_list {
   std::atomic<waiter_list_node*> head;
 
 public:
-  waiter_list() : head{nullptr} {}
+  inline waiter_list() noexcept : head{nullptr} {}
 
   /// Adds w to list. Head becomes w.
   /// Thread-safe.
@@ -111,7 +111,6 @@ struct waiter_data_base {
   // High half bits are the number of waiters.
   std::atomic<size_t> value;
 };
-
 } // namespace detail
 
 /// Common awaitable type returned by `operator co_await()` of

--- a/include/tmc/detail/waiter_list.hpp
+++ b/include/tmc/detail/waiter_list.hpp
@@ -35,7 +35,7 @@ struct waiter_list_node {
   waiter_list_node* next;
   waiter_list_waiter waiter;
 
-  /// Used by mutex and semaphore acquire awaitables.
+  /// Used by mutex, semaphore, and auto_reset_event acquire awaitables.
   void suspend(
     tmc::detail::waiter_list& ParentList, std::atomic<size_t>& ParentValue,
     std::coroutine_handle<> Outer
@@ -60,11 +60,6 @@ public:
   /// Thread-safe.
   [[nodiscard]] waiter_list_node* take_all() noexcept;
 
-  /// Assumes at least n waiters are in the list.
-  /// Wakes n waiters.
-  /// Not thread-safe.
-  void must_wake_n(size_t n) noexcept;
-
   /// Assumes at least 1 waiter is in the list.
   /// Takes 1 waiter.
   /// Not thread-safe.
@@ -81,7 +76,7 @@ public:
 };
 
 // Utilities used by various awaitables that hold a waiter_list
-// such as mutex, semaphore, atomic_condvar
+// such as mutex, semaphore, and auto_reset_event.
 
 static inline constexpr size_t WAITERS_OFFSET = TMC_PLATFORM_BITS / 2;
 static inline constexpr size_t HALF_MASK =
@@ -101,7 +96,7 @@ static inline size_t pack_value(half_word Count, size_t WaiterCount) noexcept {
   return (WaiterCount << WAITERS_OFFSET) | static_cast<size_t>(Count);
 }
 
-/// Used by mutex and semaphore.
+/// Used by co_await of mutex, semaphore, and auto_reset_event.
 /// Returns true if the count was non-zero and was successfully decremented.
 /// Returns false if the count was zero.
 bool try_acquire(std::atomic<size_t>& Value) noexcept;

--- a/include/tmc/detail/waiter_list.ipp
+++ b/include/tmc/detail/waiter_list.ipp
@@ -145,16 +145,17 @@ waiter_list_waiter* waiter_list::maybe_wake(
       v = newV;
     }
 
-    // wakeHead is a dummy object; its next pointer is the first real waiter
-    auto toWake = wakeHead.next;
-    if (toWake == nullptr) {
+    if (totalWakeCount == 0) {
       return nullptr;
     }
 
-    // Capture the first element of the list for symmetric transfer.
-    // Caller will handle it.
+    // wakeHead is a dummy object; its next pointer is the first real waiter
+    auto toWake = wakeHead.next;
+
     tmc::detail::waiter_list_waiter* symmetric_task = nullptr;
     if (symmetric) {
+      // Capture the first element of the list for symmetric transfer.
+      // Caller will handle it.
       symmetric_task = &toWake->waiter;
       toWake = toWake->next;
       --totalWakeCount;

--- a/include/tmc/detail/waiter_list.ipp
+++ b/include/tmc/detail/waiter_list.ipp
@@ -13,6 +13,29 @@
 
 namespace tmc {
 namespace detail {
+
+void waiter_list_node::suspend(
+  tmc::detail::waiter_list& ParentList, std::atomic<size_t>& ParentValue,
+  std::coroutine_handle<> Outer
+) noexcept {
+  // Configure this awaiter
+  waiter.continuation = Outer;
+  waiter.continuation_executor = tmc::detail::this_thread::executor;
+  waiter.continuation_priority = tmc::detail::this_thread::this_task.prio;
+
+  // Add this awaiter to the waiter list
+  ParentList.add_waiter(*this);
+
+  // Release the operation by increasing the waiter count
+  size_t add = TMC_ONE_BIT << tmc::detail::WAITERS_OFFSET;
+  size_t old = ParentValue.fetch_add(add, std::memory_order_acq_rel);
+  size_t v = add + old;
+
+  // Using the fetched value, see if there are both resources available and
+  // waiters to wake.
+  ParentList.maybe_wake(ParentValue, v, old, false);
+}
+
 void waiter_list_waiter::resume() noexcept {
   tmc::detail::post_checked(
     continuation_executor, std::move(continuation), continuation_priority
@@ -63,7 +86,7 @@ void waiter_list::must_wake_n(size_t n) noexcept {
   auto toWake = head.load(std::memory_order_acquire);
   for (size_t i = 0; i < n; ++i) {
     do {
-      // should be guaranteed to see at least wakeCount waiters
+      // should be guaranteed to see at least n waiters
       assert(toWake != nullptr);
     } while (!head.compare_exchange_strong(
       toWake, toWake->next, std::memory_order_acq_rel, std::memory_order_acquire
@@ -72,15 +95,122 @@ void waiter_list::must_wake_n(size_t n) noexcept {
   }
 }
 
+waiter_list_waiter* waiter_list::maybe_wake(
+  std::atomic<size_t>& value, size_t v, size_t old, bool symmetric
+) noexcept {
+  {
+    tmc::detail::half_word oldCount;
+    size_t oldWaiterCount;
+    tmc::detail::unpack_value(old, oldCount, oldWaiterCount);
+    // 4 possible prior states:
+    // - count == 0 && waitercount == 0 -> nothing to wake
+    // - count > 0 && waiterCount > 0 -> another thread is already executing a
+    // wake operation
+    // - count == 0 && waiterCount > 0 -> can wake if count++
+    // - count > 0 && waitercount == 0 -> can wake if waiterCount++
+    if ((oldCount == 0) == (oldWaiterCount == 0)) {
+      return nullptr;
+    }
+  }
+  {
+    tmc::detail::half_word count;
+    size_t waiterCount, wakeCount;
+    size_t totalWakeCount = 0;
+    tmc::detail::waiter_list_node wakeHead;
+    wakeHead.next = nullptr;
+    tmc::detail::waiter_list_node* wakeTail = &wakeHead;
+    // Only one thread can enter the below section at a time.
+    // Transitioning from 0/N or N/0 to N/N state acquires the critical section.
+    // Transitioning back to 0/0, 0/N, or N/0 state releases the critical
+    // section. The critical section is only needed to control access to the
+    // `next` pointer of the shared waiters list, which occurs in must_take_n.
+    while (true) {
+      tmc::detail::unpack_value(v, count, waiterCount);
+      wakeCount = count < waiterCount ? count : waiterCount;
+      if (wakeCount == 0) {
+        break;
+      }
+      totalWakeCount += wakeCount;
+
+      // Take N waiters
+      for (size_t i = 0; i < wakeCount; ++i) {
+        auto toWake = must_take_1();
+        wakeTail->next = toWake;
+        wakeTail = toWake;
+      }
+
+      // (maybe) release the critical section
+      size_t newV =
+        tmc::detail::pack_value(count - wakeCount, waiterCount - wakeCount);
+      while (!value.compare_exchange_strong(
+        v, newV, std::memory_order_acq_rel, std::memory_order_acquire
+      )) {
+        tmc::detail::unpack_value(v, count, waiterCount);
+        assert(count >= wakeCount);
+        assert(waiterCount >= wakeCount);
+        newV =
+          tmc::detail::pack_value(count - wakeCount, waiterCount - wakeCount);
+      };
+
+      // Update the value of v and run again. If both values are still non-zero,
+      // then the critical section was not actually released and we should
+      // continue to take more waiters.
+      v = newV;
+    }
+
+    // wakeHead is a dummy object; its next pointer is the first real waiter
+    auto toWake = wakeHead.next;
+    if (toWake == nullptr) {
+      return nullptr;
+    }
+
+    // Capture the first element of the list for symmetric transfer.
+    // Caller will handle it.
+    tmc::detail::waiter_list_waiter* symmetric_task = nullptr;
+    if (symmetric) {
+      symmetric_task = &toWake->waiter;
+      toWake = toWake->next;
+      --totalWakeCount;
+    }
+
+    // Resume the rest of the waiters.
+    for (size_t i = 0; i < totalWakeCount; ++i) {
+      auto next = toWake->next;
+      toWake->waiter.resume();
+      toWake = next;
+    }
+
+    return symmetric_task;
+  }
+}
+
 waiter_list_node* waiter_list::must_take_1() noexcept {
   auto toWake = head.load(std::memory_order_acquire);
   do {
-    // should be guaranteed to see at least wakeCount waiters
+    // should be guaranteed to see at least 1 waiter
     assert(toWake != nullptr);
   } while (!head.compare_exchange_strong(
     toWake, toWake->next, std::memory_order_acq_rel, std::memory_order_acquire
   ));
   return toWake;
 }
+
+bool try_acquire(std::atomic<size_t>& Value) noexcept {
+  auto v = Value.load(std::memory_order_relaxed);
+
+  tmc::detail::half_word count;
+  size_t waiterCount, newV;
+  do {
+    tmc::detail::unpack_value(v, count, waiterCount);
+    if (count <= waiterCount) {
+      return false;
+    }
+    newV = tmc::detail::pack_value(count - 1, waiterCount);
+  } while (!Value.compare_exchange_strong(
+    v, newV, std::memory_order_acq_rel, std::memory_order_acquire
+  ));
+  return true;
+}
+
 } // namespace detail
 } // namespace tmc

--- a/include/tmc/detail/waiter_list.ipp
+++ b/include/tmc/detail/waiter_list.ipp
@@ -200,4 +200,12 @@ bool try_acquire(std::atomic<size_t>& Value) noexcept {
 }
 
 } // namespace detail
+
+bool aw_acquire::await_ready() noexcept {
+  return tmc::detail::try_acquire(parent.value);
+}
+
+void aw_acquire::await_suspend(std::coroutine_handle<> Outer) noexcept {
+  me.suspend(parent.waiters, parent.value, Outer);
+}
 } // namespace tmc

--- a/include/tmc/manual_reset_event.hpp
+++ b/include/tmc/manual_reset_event.hpp
@@ -58,7 +58,7 @@ public:
   aw_manual_reset_event_co_set(aw_manual_reset_event_co_set const&) = delete;
   aw_manual_reset_event_co_set&
   operator=(aw_manual_reset_event_co_set const&) = delete;
-  aw_manual_reset_event_co_set(aw_manual_reset_event&&) = delete;
+  aw_manual_reset_event_co_set(aw_manual_reset_event_co_set&&) = delete;
   aw_manual_reset_event_co_set&
   operator=(aw_manual_reset_event_co_set&&) = delete;
 };

--- a/include/tmc/mutex.hpp
+++ b/include/tmc/mutex.hpp
@@ -10,7 +10,6 @@
 
 #include <atomic>
 #include <coroutine>
-#include <cstddef>
 
 namespace tmc {
 class mutex;
@@ -28,7 +27,7 @@ public:
   // Movable but not copyable
   mutex_scope(mutex_scope const&) = delete;
   mutex_scope& operator=(mutex_scope const&) = delete;
-  inline mutex_scope(mutex_scope&& Other) {
+  inline mutex_scope(mutex_scope&& Other) noexcept {
     parent = Other.parent;
     Other.parent = nullptr;
   }

--- a/include/tmc/mutex.hpp
+++ b/include/tmc/mutex.hpp
@@ -26,7 +26,7 @@ class aw_mutex {
 public:
   bool await_ready() noexcept;
 
-  bool await_suspend(std::coroutine_handle<> Outer) noexcept;
+  void await_suspend(std::coroutine_handle<> Outer) noexcept;
 
   inline void await_resume() noexcept {}
 
@@ -75,7 +75,7 @@ class [[nodiscard(
 public:
   bool await_ready() noexcept;
 
-  bool await_suspend(std::coroutine_handle<> Outer) noexcept;
+  void await_suspend(std::coroutine_handle<> Outer) noexcept;
 
   inline mutex_scope await_resume() noexcept { return mutex_scope(&parent); }
 
@@ -123,11 +123,6 @@ class mutex {
   static inline constexpr tmc::detail::half_word LOCKED = 0;
   static inline constexpr tmc::detail::half_word UNLOCKED = 1;
 
-  // Called after increasing State or WaiterCount.
-  // If State > 0 && WaiterCount > 0, this will try to wake some number of
-  // awaiters.
-  void maybe_wake(size_t v) noexcept;
-
 public:
   /// Mutex begins in the unlocked state.
   inline mutex() noexcept : value{UNLOCKED} {}
@@ -137,10 +132,6 @@ public:
     return 0 ==
            (tmc::detail::HALF_MASK & value.load(std::memory_order_relaxed));
   }
-
-  /// Returns true if the mutex was unlocked and the lock was successfully
-  /// acquired. Returns false if the mutex was locked. Not re-entrant.
-  bool try_lock() noexcept;
 
   /// Unlocks the mutex. If there are any awaiters, an awaiter will be resumed
   /// and the lock will be re-locked and transferred to that awaiter.

--- a/include/tmc/semaphore.hpp
+++ b/include/tmc/semaphore.hpp
@@ -26,7 +26,7 @@ class aw_semaphore {
 public:
   bool await_ready() noexcept;
 
-  bool await_suspend(std::coroutine_handle<> Outer) noexcept;
+  void await_suspend(std::coroutine_handle<> Outer) noexcept;
 
   inline void await_resume() noexcept {}
 
@@ -76,7 +76,7 @@ class [[nodiscard(
 public:
   bool await_ready() noexcept;
 
-  bool await_suspend(std::coroutine_handle<> Outer) noexcept;
+  void await_suspend(std::coroutine_handle<> Outer) noexcept;
 
   inline semaphore_scope await_resume() noexcept {
     return semaphore_scope(&parent);
@@ -124,11 +124,6 @@ class semaphore {
   friend class aw_semaphore_acquire_scope;
   friend class aw_semaphore_co_release;
 
-  // Called after increasing Count or WaiterCount.
-  // If Count > 0 && WaiterCount > 0, this will try to wake some number of
-  // awaiters.
-  void maybe_wake(size_t v) noexcept;
-
 public:
   /// The count is packed into half a machine word along with the awaiter count.
   /// Thus it is only allowed half a machine word of bits.
@@ -147,10 +142,6 @@ public:
   inline size_t count() noexcept {
     return tmc::detail::HALF_MASK & value.load(std::memory_order_relaxed);
   }
-
-  /// Returns true if the count was non-zero and was successfully decremented.
-  /// Returns false if the count was zero.
-  bool try_acquire() noexcept;
 
   /// Increases the available resources by ReleaseCount. If there are awaiters,
   /// they will be awoken until all resources have been consumed.

--- a/include/tmc/semaphore.hpp
+++ b/include/tmc/semaphore.hpp
@@ -15,28 +15,6 @@
 namespace tmc {
 class semaphore;
 
-class aw_semaphore {
-  tmc::detail::waiter_list_node me;
-  semaphore& parent;
-
-  friend class semaphore;
-
-  inline aw_semaphore(semaphore& Parent) noexcept : parent(Parent) {}
-
-public:
-  bool await_ready() noexcept;
-
-  void await_suspend(std::coroutine_handle<> Outer) noexcept;
-
-  inline void await_resume() noexcept {}
-
-  // Cannot be moved or copied due to holding intrusive list pointer
-  aw_semaphore(aw_semaphore const&) = delete;
-  aw_semaphore& operator=(aw_semaphore const&) = delete;
-  aw_semaphore(aw_semaphore&&) = delete;
-  aw_semaphore& operator=(aw_semaphore&&) = delete;
-};
-
 /// The semaphore will be released when this goes out of scope.
 class [[nodiscard("The semaphore will be released when this goes out of scope."
 )]] semaphore_scope {
@@ -109,18 +87,13 @@ public:
   // Copy/move constructors *could* be implemented, but why?
   aw_semaphore_co_release(aw_semaphore_co_release const&) = delete;
   aw_semaphore_co_release& operator=(aw_semaphore_co_release const&) = delete;
-  aw_semaphore_co_release(aw_semaphore&&) = delete;
+  aw_semaphore_co_release(aw_semaphore_co_release&&) = delete;
   aw_semaphore_co_release& operator=(aw_semaphore_co_release&&) = delete;
 };
 
 /// An async version of std::counting_semaphore.
-class semaphore {
-  tmc::detail::waiter_list waiters;
-  // Low half bits are the semaphore value.
-  // High half bits are the number of waiters.
-  std::atomic<size_t> value;
-
-  friend class aw_semaphore;
+class semaphore : protected tmc::detail::waiter_data_base {
+  friend class aw_acquire;
   friend class aw_semaphore_acquire_scope;
   friend class aw_semaphore_co_release;
 
@@ -132,8 +105,9 @@ public:
   /// Sets the initial number of resources available in the semaphore.
   /// This is only an initial value and not a maximum; by calling release(), the
   /// number of resources available may exceed this initial value.
-  inline semaphore(half_word InitialCount) noexcept
-      : value{static_cast<size_t>(InitialCount)} {}
+  inline semaphore(half_word InitialCount) noexcept {
+    value = static_cast<size_t>(InitialCount);
+  }
 
   /// Returns an estimate of the current number of available resources.
   /// This value is not guaranteed to be consistent with any other operation.
@@ -158,9 +132,7 @@ public:
 
   /// Tries to acquire the semaphore. If no resources are ready, will
   /// suspend until a resource becomes ready.
-  inline aw_semaphore operator co_await() noexcept {
-    return aw_semaphore(*this);
-  }
+  inline aw_acquire operator co_await() noexcept { return aw_acquire(*this); }
 
   /// Tries to acquire the semaphore. If no resources are ready, will
   /// suspend until a resource becomes ready, then transfer the
@@ -181,7 +153,7 @@ template <> struct awaitable_traits<tmc::semaphore> {
 
   using result_type = void;
   using self_type = tmc::semaphore;
-  using awaiter_type = tmc::aw_semaphore;
+  using awaiter_type = tmc::aw_acquire;
 
   static awaiter_type get_awaiter(self_type& Awaitable) noexcept {
     return Awaitable.operator co_await();

--- a/include/tmc/semaphore.hpp
+++ b/include/tmc/semaphore.hpp
@@ -28,7 +28,7 @@ public:
   // Movable but not copyable
   semaphore_scope(semaphore_scope const&) = delete;
   semaphore_scope& operator=(semaphore_scope const&) = delete;
-  inline semaphore_scope(semaphore_scope&& Other) {
+  inline semaphore_scope(semaphore_scope&& Other) noexcept {
     parent = Other.parent;
     Other.parent = nullptr;
   }


### PR DESCRIPTION
As previously implemented, all of `tmc::mutex`, `tmc::semaphore`, and `tmc::auto_reset_event` were prone to a data race when multiple threads would attempt to wake awaiters simultaneously. Although the atomic waiter list head could be manipulated safely, the `next` pointer of each waiter was not safe to read.

This fix ensures that only 1 thread at a time is allowed to read the waiter list `next` pointer, and if more than one waiter needs to be awoken (due to multiple simultaneous calls to release() or set() for example), that thread is responsible for waking all of the waiters.

These 3 classes are now based on a common base class and reuse much of the same logic, allowing this PR to reduce the line count :tada: