### PR TITLE
Properly preserve and enforce value categories of awaitables

### DIFF
--- a/include/tmc/detail/concepts_awaitable.hpp
+++ b/include/tmc/detail/concepts_awaitable.hpp
@@ -199,5 +199,14 @@ template <IsRange R> struct range_iter {
   using type = decltype(std::declval<R>().begin());
 };
 
+/// Given T&  -> holds T&
+/// Given T&& -> holds T if T is move-constructible
+/// Given T&& -> holds T&& if T is not move-constructible
+template <typename T>
+using forward_awaitable = std::conditional_t<
+  std::is_rvalue_reference_v<T&&> &&
+    std::is_move_constructible_v<std::decay_t<T>>,
+  std::decay_t<T>, T&&>;
+
 } // namespace detail
 } // namespace tmc

--- a/include/tmc/detail/task_wrapper.hpp
+++ b/include/tmc/detail/task_wrapper.hpp
@@ -280,26 +280,42 @@ template <
 )]] tmc::detail::task_wrapper<Result>
 safe_wrap(Awaitable&& awaitable
 ) noexcept(std::is_nothrow_move_constructible_v<Awaitable>) {
-  static_assert(
-    std::is_rvalue_reference_v<Awaitable&&> ||
-      !std::is_move_constructible_v<std::decay_t<Awaitable>>,
-    "You must move your awaitables where possible. Passing lvalues is only "
-    "allowed if there is no move constructor."
-  );
-  return [](
-           Awaitable Aw, tmc::aw_resume_on TakeMeHome
-         ) -> tmc::detail::task_wrapper<Result> {
-    if constexpr (std::is_void_v<Result>) {
-      co_await std::move(Aw);
-      co_await TakeMeHome;
-      co_return;
-    } else {
-      auto result = co_await std::move(Aw);
-      co_await TakeMeHome;
-      co_return result;
-    }
-  }(std::forward<Awaitable>(awaitable),
-           tmc::resume_on(tmc::detail::this_thread::executor));
+  if constexpr (std::is_rvalue_reference_v<Awaitable&&>) {
+    // Pass movable types into the coroutine by value.
+    // Pass non-movable types as rvalue references. This allows wrapping types
+    // that must be move-awaited but don't have move constructors.
+    using AwParam = std::conditional_t<
+      std::is_move_constructible_v<Awaitable>, Awaitable, Awaitable&&>;
+    return [](
+             AwParam Aw, tmc::aw_resume_on TakeMeHome
+           ) -> tmc::detail::task_wrapper<Result> {
+      if constexpr (std::is_void_v<Result>) {
+        co_await std::move(Aw);
+        co_await TakeMeHome;
+        co_return;
+      } else {
+        auto result = co_await std::move(Aw);
+        co_await TakeMeHome;
+        co_return result;
+      }
+    }(static_cast<Awaitable&&>(awaitable),
+             tmc::resume_on(tmc::detail::this_thread::executor));
+  } else {
+    // Pass lvalue references into the coroutine as lvalue references.
+    return [](
+             Awaitable& Aw, tmc::aw_resume_on TakeMeHome
+           ) -> tmc::detail::task_wrapper<Result> {
+      if constexpr (std::is_void_v<Result>) {
+        co_await Aw;
+        co_await TakeMeHome;
+        co_return;
+      } else {
+        auto result = co_await Aw;
+        co_await TakeMeHome;
+        co_return result;
+      }
+    }(awaitable, tmc::resume_on(tmc::detail::this_thread::executor));
+  }
 }
 } // namespace detail
 } // namespace tmc

--- a/include/tmc/detail/task_wrapper.hpp
+++ b/include/tmc/detail/task_wrapper.hpp
@@ -147,8 +147,8 @@ struct awaitable_traits<tmc::detail::task_wrapper<Result>> {
   using awaiter_type = tmc::detail::aw_task_wrapper<Result>;
 
   // Values controlling the behavior when awaited directly in a tmc::task
-  static awaiter_type get_awaiter(self_type& Awaitable) noexcept {
-    return awaiter_type(Awaitable);
+  static awaiter_type get_awaiter(self_type&& Awaitable) noexcept {
+    return awaiter_type(static_cast<self_type&&>(Awaitable));
   }
 
   // Values controlling the behavior when wrapped by a utility function

--- a/include/tmc/spawn.hpp
+++ b/include/tmc/spawn.hpp
@@ -196,7 +196,7 @@ template <typename Awaitable, typename Result> class aw_spawn_impl {
   friend aw_spawn<Awaitable>;
 
   aw_spawn_impl(
-    Awaitable Task, tmc::ex_any* Executor, tmc::ex_any* ContinuationExecutor,
+    Awaitable&& Task, tmc::ex_any* Executor, tmc::ex_any* ContinuationExecutor,
     size_t Prio
   )
       : wrapped{static_cast<Awaitable&&>(Task)}, executor{Executor},
@@ -378,8 +378,11 @@ struct awaitable_traits<aw_spawn<Awaitable, Result>> {
 /// `run_on()`, `resume_on()`, `with_priority()`. The task must then be
 /// submitted for execution by calling exactly one of: `co_await`, `fork()`
 /// or `detach()`.
-template <typename Awaitable> aw_spawn<Awaitable> spawn(Awaitable&& Task) {
-  return aw_spawn<Awaitable>(static_cast<Awaitable&&>(Task));
+template <typename Awaitable>
+aw_spawn<tmc::detail::forward_awaitable<Awaitable>> spawn(Awaitable&& Task) {
+  return aw_spawn<tmc::detail::forward_awaitable<Awaitable>>(
+    static_cast<Awaitable&&>(Task)
+  );
 }
 
 } // namespace tmc

--- a/include/tmc/spawn_many.hpp
+++ b/include/tmc/spawn_many.hpp
@@ -811,7 +811,8 @@ using aw_spawn_many_fork = tmc::detail::rvalue_only_awaitable<
   aw_spawn_many_impl<Result, Count, false, IsFunc>>;
 
 template <typename Result, size_t Count, bool IsFunc>
-using aw_spawn_many_each = aw_spawn_many_impl<Result, Count, true, IsFunc>;
+using aw_spawn_many_each = tmc::detail::lvalue_only_awaitable<
+  aw_spawn_many_impl<Result, Count, true, IsFunc>>;
 
 template <
   typename Result, size_t Count, typename IterBegin, typename IterEnd,
@@ -1087,7 +1088,6 @@ public:
 };
 
 namespace detail {
-
 template <
   typename Result, size_t Count, typename IterBegin, typename IterEnd,
   bool IsFunc>
@@ -1106,20 +1106,5 @@ struct awaitable_traits<
     return std::forward<self_type>(Awaitable).operator co_await();
   }
 };
-
-template <typename Result, size_t Count, bool IsFunc>
-struct awaitable_traits<aw_spawn_many_each<Result, Count, IsFunc>> {
-  static constexpr configure_mode mode = WRAPPER;
-
-  using result_type = size_t;
-  using self_type = aw_spawn_many_each<Result, Count, IsFunc>;
-  using awaiter_type = self_type;
-
-  static awaiter_type& get_awaiter(self_type& Awaitable) noexcept {
-    return Awaitable;
-  }
-};
-
 } // namespace detail
-
 } // namespace tmc

--- a/include/tmc/spawn_tuple.hpp
+++ b/include/tmc/spawn_tuple.hpp
@@ -23,9 +23,6 @@
 
 namespace tmc {
 namespace detail {
-// template <typename... T>
-// using forward_awaitable_tuple = std::tuple<forward_awaitable<T>...>;
-
 // Replace void with std::monostate (void is not a valid tuple element type)
 template <typename T>
 using void_to_monostate =
@@ -401,7 +398,8 @@ using aw_spawn_tuple_fork =
   tmc::detail::rvalue_only_awaitable<aw_spawn_tuple_impl<false, Result...>>;
 
 template <typename... Result>
-using aw_spawn_tuple_each = aw_spawn_tuple_impl<true, Result...>;
+using aw_spawn_tuple_each =
+  tmc::detail::lvalue_only_awaitable<aw_spawn_tuple_impl<true, Result...>>;
 
 template <typename... Awaitable>
 class [[nodiscard("You must await or initiate the result of spawn_tuple()."
@@ -607,7 +605,6 @@ aw_spawn_tuple<Awaitable...> spawn_tuple(std::tuple<Awaitable...>&& Tasks) {
 }
 
 namespace detail {
-
 template <typename... Awaitables>
 struct awaitable_traits<aw_spawn_tuple<Awaitables...>> {
   static constexpr configure_mode mode = WRAPPER;
@@ -621,20 +618,5 @@ struct awaitable_traits<aw_spawn_tuple<Awaitables...>> {
     return static_cast<self_type&&>(Awaitable).operator co_await();
   }
 };
-
-template <typename... Result>
-struct awaitable_traits<aw_spawn_tuple_each<Result...>> {
-  static constexpr configure_mode mode = WRAPPER;
-
-  using result_type = size_t;
-  using self_type = aw_spawn_tuple_each<Result...>;
-  using awaiter_type = self_type;
-
-  static awaiter_type& get_awaiter(self_type& Awaitable) noexcept {
-    return Awaitable;
-  }
-};
-
 } // namespace detail
-
 } // namespace tmc

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -430,7 +430,7 @@ template <typename Result> struct awaitable_traits<tmc::task<Result>> {
 
   // Values controlling the behavior when awaited directly in a tmc::task
   static awaiter_type get_awaiter(self_type&& Awaitable) noexcept {
-    return awaiter_type(std::move(Awaitable));
+    return awaiter_type(static_cast<self_type&&>(Awaitable));
   }
 
   // Values controlling the behavior when wrapped by a utility function


### PR DESCRIPTION
The awaitables provided by TMC generally fall into two categories.

### rvalue awaitables
Single-use awaitables that should be discarded after use. This behavior is represented by requiring that the value category of the co_await expression or spawn wrapper be an rvalue. Most of the TMC awaitables fall into this category and are produced on-demand by a factory function.
```cpp
// temporary rvalue
co_await expr();

// explicit rvalue cast required
auto t = expr();
co_await std::move(t);

// wrappers have the same rules - temporary rvalue
co_await spawn_tuple(expr());

// explicit rvalue cast required
auto t = expr();
co_await tmc::spawn_tuple(std::move(t));
```

### lvalue awaitables
Awaitables that are designed to be awaited multiple times (typically to produce a sequence of values). This behavior is represented by requiring that the value category of the co_await expression or spawn wrapper be an lvalue. This applies to a small number of awaitables such as result_each() but will be expanded in the future for result_share() / result_ref().
```cpp
// temporary rvalue not allowed, an lvalue must be created
auto t = expr();
co_await t;
co_await t;

// wrappers have the same rules
auto t = expr();
co_await tmc::spawn_tuple(t);
co_await tmc::spawn_tuple(t);
```

This PR enhances the value category propagation logic to ensure that all of the above syntaxes are valid, and that attempting to await or wrap an expression that is of the wrong value category for its type will be a compiler error. This is not to restrict the user, but to help them ensure correct behavior and not runtime surprises. Thus, the category restriction should only be applied in cases where using the wrong category could lead to crashing (if rvalue was used as lvalue) or leaked/dropped results (if lvalue was used as rvalue).

The category restriction can be applied on a per-awaitable basis by customizing the co_await expression, or deriving from `tmc::detail::rvalue_only_awaitable<Awaitable>` or `tmc::detail::lvalue_only_awaitable<Awaitable>`. lvalue is new in this PR and has been applied to `result_each()` - which is intended to produce a sequence of results, and should be awaited until the value returned is equal to `end()`.

This PR builds on the work of https://github.com/tzcnt/TooManyCooks/pull/105 but is more refined - rather than enforcing the type be moved inside of safe_wrap, or using static_assert based on the constructor type, by instead propagating the value category all the way through to the co_await expression, the awaitable can tell us whether or not the value category is correct.

---

This is technically a breaking change for code that relies on the (incorrect / undocumented) behavior of always being able to pass lvalues into spawn_tuple(). This code can be fixed by just applying std::move() to the parameters of the spawn_tuple call as needed.

---

This change only works for co_await(), spawn(), and spawn_tuple(). spawn_many() has its own set of challenges to be possibly solved in a future PR. Currently it always moves-from the elements of the iterator. Doing it properly would require deducing whether or not the type received from dereferencing the iterator should be treated as an lvalue or rvalue.