### PR TITLE
implement `tmc::latch`

### DIFF
--- a/include/tmc/all_headers.hpp
+++ b/include/tmc/all_headers.hpp
@@ -18,6 +18,7 @@
 #include "tmc/ex_braid.hpp"           // IWYU pragma: export
 #include "tmc/ex_cpu.hpp"             // IWYU pragma: export
 #include "tmc/external.hpp"           // IWYU pragma: export
+#include "tmc/latch.hpp"              // IWYU pragma: export
 #include "tmc/manual_reset_event.hpp" // IWYU pragma: export
 #include "tmc/mutex.hpp"              // IWYU pragma: export
 #include "tmc/semaphore.hpp"          // IWYU pragma: export

--- a/include/tmc/barrier.hpp
+++ b/include/tmc/barrier.hpp
@@ -58,10 +58,10 @@ public:
       : start_count{static_cast<ptrdiff_t>(Count - 1)},
         done_count{static_cast<ptrdiff_t>(Count - 1)} {}
 
-  /// Equivalent to `std::barrier::arrive_and_wait`. Decrements the barrier
-  /// count, and if the count reaches 0, wakes all awaiters, and resets the
-  /// count to the original maximum as specified in the constructor. Otherwise,
-  /// suspends until Count awaiters have reached this point.
+  /// Equivalent to `std::barrier::arrive_and_wait`. Decrements the counter, and
+  /// if the counter reaches 0, wakes all awaiters, and resets the counter to
+  /// the original maximum as specified in the constructor. Otherwise, suspends
+  /// until Count awaiters have reached this point.
   inline aw_barrier operator co_await() noexcept { return aw_barrier(*this); }
 
   /// On destruction, any awaiters will be resumed.

--- a/include/tmc/latch.hpp
+++ b/include/tmc/latch.hpp
@@ -1,0 +1,75 @@
+// Copyright (c) 2023-2025 Logan McDougall
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include "tmc/detail/concepts_awaitable.hpp"
+#include "tmc/manual_reset_event.hpp"
+
+#include <atomic>
+#include <cstddef>
+
+namespace tmc {
+/// Similar semantics to std::latch, exposing all operations except
+/// `arrive_and_wait()`.
+class latch {
+  tmc::manual_reset_event event;
+  std::atomic<ptrdiff_t> count;
+
+public:
+  /// Sets the initial value of Count. After `count_down()` has been called
+  /// Count times, all future waiters will resume.
+  inline latch(size_t Count) noexcept
+      : event{static_cast<ptrdiff_t>(Count) <= 0},
+        count{static_cast<ptrdiff_t>(Count - 1)} {
+    // The internal counter is 1 less than the constructor counter so that all
+    // of the comparison operations can be against 0 (which is cheap).
+  }
+
+  /// Returns true after `count_down()` has been called `Count` times. After
+  /// this returns true, all subsequent calls to `co_await` will resume
+  /// immediately. Equivalent to `std::latch::try_wait()`.
+  inline bool is_ready() noexcept {
+    auto remaining = count.load(std::memory_order_acquire);
+    return remaining < 0;
+  }
+
+  /// Decrements the counter and returns the value of `is_ready()` after the
+  /// counter is decremented. If this becomes ready after this call to
+  /// `count_down()`, all awaiters will be resumed immediately.
+  /// Equivalent to `std::latch::count_down()`.
+  inline bool count_down() noexcept {
+    auto remaining = count.fetch_sub(1, std::memory_order_acq_rel);
+    bool ready = remaining <= 0;
+    if (ready) {
+      event.set();
+    }
+    return ready;
+  }
+
+  /// Waits until the counter becomes zero.
+  /// Does not decrement the counter - you must call `count_down()` separately.
+  /// Equivalent to `std::latch::wait()`.
+  inline tmc::aw_manual_reset_event operator co_await() noexcept {
+    return event.operator co_await();
+  }
+
+  /// On destruction, any awaiters will be resumed.
+  ~latch() = default;
+};
+namespace detail {
+template <> struct awaitable_traits<tmc::latch> {
+  static constexpr configure_mode mode = WRAPPER;
+
+  using result_type = void;
+  using self_type = tmc::latch;
+  using awaiter_type = tmc::aw_manual_reset_event;
+
+  static awaiter_type get_awaiter(self_type& Awaitable) noexcept {
+    return Awaitable.operator co_await();
+  }
+};
+} // namespace detail
+} // namespace tmc


### PR DESCRIPTION
Similar to [std::latch](https://en.cppreference.com/w/cpp/thread/latch)

- constructor sets the max count
- `count_down()` decrements the count and wakes all waiters when it hits 0
- `co_await` suspends until the count hits 0
- `is_ready()` returns true if the count is already 0
- destructor wakes any remaining waiters
- 

There is no analogue to the `std::latch::arrive_and_wait()` convenience function - you need to first call `count_down()`, then `co_await`.