### PR TITLE
block unevaluated coro ramp in post_waitable()

### DIFF
--- a/include/tmc/sync.hpp
+++ b/include/tmc/sync.hpp
@@ -107,6 +107,12 @@ template <
 )
   requires(!std::is_void_v<Result> && tmc::detail::is_func_result_v<FuncResult, Result>)
 {
+  static_assert(
+    !requires { typename std::coroutine_traits<Result>::promise_type; },
+    "You passed an unevaluated coroutine function - this is probably a bug. "
+    "You should call the function before passing to post_waitable."
+  );
+
 #if TMC_WORK_ITEM_IS(FUNC)
   std::promise<Result>* promise = new std::promise<Result>();
   std::future<Result> future = promise->get_future();


### PR DESCRIPTION
The following snippet is nearly always a bug:
```cpp
tmc::task<void> some_task() { co_return; }

tmc::post_waitable(some_task).wait();
```

The some_task ramp function inside post_waitable isn't evaluated - it's missing the `()`. This would result in a future that returns a tmc::task<void>, which will then be leaked.

What the user almost certainly meant to write is `tmc::post_waitable(some_task()).wait();` which first evaluates the ramp function to produce a coroutine, and then submits that coroutine for execution.

Previously this would have been detected by a runtime assert (see test now being removed in https://github.com/tzcnt/TooManyCooks/pull/113). This PR adds a static_assert to detect and prevent this condition instead.

If the user *really* needs to do the "probably a bug" thing, they can work around it by passing data out of the function by reference instead of by return.