### PR TITLE
implement `tmc::detail::executor_traits` for `tmc::ex_any*`

### DIFF
--- a/include/tmc/aw_resume_on.hpp
+++ b/include/tmc/aw_resume_on.hpp
@@ -58,22 +58,17 @@ public:
 /// Returns an awaitable that moves this task onto the requested executor. If
 /// this task is already running on the requested executor, the co_await will do
 /// nothing.
-inline aw_resume_on resume_on(tmc::ex_any* Executor) {
-  return aw_resume_on(Executor);
-}
-
-/// Returns an awaitable that moves this task onto the requested executor. If
-/// this task is already running on the requested executor, the co_await will do
-/// nothing.
 template <typename Exec> inline aw_resume_on resume_on(Exec& Executor) {
-  return resume_on(tmc::detail::executor_traits<Exec>::type_erased(Executor));
+  return aw_resume_on(tmc::detail::executor_traits<Exec>::type_erased(Executor)
+  );
 }
 
 /// Returns an awaitable that moves this task onto the requested executor. If
 /// this task is already running on the requested executor, the co_await will do
 /// nothing.
 template <typename Exec> inline aw_resume_on resume_on(Exec* Executor) {
-  return resume_on(tmc::detail::executor_traits<Exec>::type_erased(*Executor));
+  return aw_resume_on(tmc::detail::executor_traits<Exec>::type_erased(*Executor)
+  );
 }
 
 /// Equivalent to `resume_on(tmc::current_executor()).with_priority(Priority);`

--- a/include/tmc/detail/ex_braid.ipp
+++ b/include/tmc/detail/ex_braid.ipp
@@ -13,6 +13,7 @@
 #include "tmc/work_item.hpp"
 
 #include <atomic>
+#include <coroutine>
 
 namespace tmc {
 tmc::task<void> ex_braid::try_run_loop(

--- a/include/tmc/detail/ex_cpu.ipp
+++ b/include/tmc/detail/ex_cpu.ipp
@@ -18,6 +18,7 @@
 #include "tmc/work_item.hpp"
 
 #include <bit>
+#include <coroutine>
 
 #ifdef TMC_USE_HWLOC
 #include <hwloc.h>

--- a/include/tmc/detail/mixins.hpp
+++ b/include/tmc/detail/mixins.hpp
@@ -6,7 +6,6 @@
 #pragma once
 
 #include "tmc/detail/concepts_awaitable.hpp"
-#include "tmc/ex_any.hpp"
 
 namespace tmc {
 namespace detail {
@@ -15,11 +14,6 @@ namespace detail {
 
 template <typename Derived> class run_on_mixin {
 public:
-  /// The wrapped task will run on the provided executor.
-  [[nodiscard]] inline Derived& run_on(tmc::ex_any* Executor) & {
-    static_cast<Derived*>(this)->executor = Executor;
-    return static_cast<Derived&>(*this);
-  }
   /// The wrapped task will run on the provided executor.
   template <typename Exec> [[nodiscard]] Derived& run_on(Exec& Executor) & {
     static_cast<Derived*>(this)->executor =
@@ -33,11 +27,6 @@ public:
     return static_cast<Derived&>(*this);
   }
 
-  /// The wrapped task will run on the provided executor.
-  [[nodiscard]] inline Derived&& run_on(tmc::ex_any* Executor) && {
-    static_cast<Derived*>(this)->executor = Executor;
-    return static_cast<Derived&&>(*this);
-  }
   /// The wrapped task will run on the provided executor.
   template <typename Exec> [[nodiscard]] Derived&& run_on(Exec& Executor) && {
     static_cast<Derived*>(this)->executor =
@@ -55,11 +44,6 @@ public:
 template <typename Derived> class resume_on_mixin {
 public:
   /// The wrapped task will run on the provided executor.
-  [[nodiscard]] inline Derived& resume_on(tmc::ex_any* Executor) & {
-    static_cast<Derived*>(this)->continuation_executor = Executor;
-    return static_cast<Derived&>(*this);
-  }
-  /// The wrapped task will run on the provided executor.
   template <typename Exec> [[nodiscard]] Derived& resume_on(Exec& Executor) & {
     static_cast<Derived*>(this)->continuation_executor =
       tmc::detail::executor_traits<Exec>::type_erased(Executor);
@@ -72,11 +56,6 @@ public:
     return static_cast<Derived&>(*this);
   }
 
-  /// The wrapped task will run on the provided executor.
-  [[nodiscard]] inline Derived&& resume_on(tmc::ex_any* Executor) && {
-    static_cast<Derived*>(this)->continuation_executor = Executor;
-    return static_cast<Derived&&>(*this);
-  }
   /// The wrapped task will run on the provided executor.
   template <typename Exec>
   [[nodiscard]] Derived&& resume_on(Exec& Executor) && {

--- a/include/tmc/ex_any.hpp
+++ b/include/tmc/ex_any.hpp
@@ -6,8 +6,11 @@
 #pragma once
 
 #include "tmc/detail/compat.hpp"
+#include "tmc/detail/concepts_awaitable.hpp"
+#include "tmc/detail/tiny_vec.hpp"
 #include "tmc/work_item.hpp"
 
+#include <coroutine>
 #include <cstddef>
 
 namespace tmc {
@@ -63,5 +66,85 @@ public:
     };
   }
 };
+
+namespace detail {
+template <> struct executor_traits<tmc::ex_any> {
+  static inline void post(
+    tmc::ex_any& ex, tmc::work_item&& Item, size_t Priority, size_t ThreadHint
+  ) {
+    ex.post(static_cast<tmc::work_item&&>(Item), Priority, ThreadHint);
+  }
+
+  template <typename It>
+  static inline void post_bulk(
+    tmc::ex_any& ex, It&& Items, size_t Count, size_t Priority,
+    size_t ThreadHint
+  ) {
+    // ex_any only accepts work_item* as the post_bulk type
+    if constexpr (std::is_convertible_v<It&&, tmc::work_item*>) {
+      ex.post_bulk(
+        static_cast<tmc::work_item*>(static_cast<It&&>(Items)), Count, Priority,
+        ThreadHint
+      );
+    } else {
+      tmc::detail::tiny_vec<tmc::work_item> workItems;
+      workItems.resize(Count);
+      for (size_t i = 0; i < Count; ++i) {
+        workItems.emplace_at(i, *(static_cast<It&&>(Items)));
+        ++(static_cast<It&&>(Items));
+      }
+      ex.post_bulk(&workItems[0], Count, Priority, ThreadHint);
+    }
+  }
+
+  static inline tmc::ex_any* type_erased(tmc::ex_any& ex) { return &ex; }
+
+  static inline std::coroutine_handle<> task_enter_context(
+    tmc::ex_any& ex, std::coroutine_handle<> Outer, size_t Priority
+  ) {
+    ex.post(static_cast<std::coroutine_handle<>&&>(Outer), Priority);
+    return std::noop_coroutine();
+  }
+};
+
+template <> struct executor_traits<tmc::ex_any*> {
+  static inline void post(
+    tmc::ex_any* ex, tmc::work_item&& Item, size_t Priority, size_t ThreadHint
+  ) {
+    ex->post(static_cast<tmc::work_item&&>(Item), Priority, ThreadHint);
+  }
+
+  template <typename It>
+  static inline void post_bulk(
+    tmc::ex_any* ex, It&& Items, size_t Count, size_t Priority,
+    size_t ThreadHint
+  ) {
+    // ex_any only accepts work_item* as the post_bulk type
+    if constexpr (std::is_convertible_v<It&&, tmc::work_item*>) {
+      ex->post_bulk(
+        static_cast<tmc::work_item*>(static_cast<It&&>(Items)), Count, Priority,
+        ThreadHint
+      );
+    } else {
+      tmc::detail::tiny_vec<tmc::work_item> workItems;
+      workItems.resize(Count);
+      for (size_t i = 0; i < Count; ++i) {
+        workItems.emplace_at(i, *(static_cast<It&&>(Items)));
+        ++(static_cast<It&&>(Items));
+      }
+      ex->post_bulk(&workItems[0], Count, Priority, ThreadHint);
+    }
+  }
+
+  static inline tmc::ex_any* type_erased(tmc::ex_any* ex) { return ex; }
+
+  static inline std::coroutine_handle<> task_enter_context(
+    tmc::ex_any* ex, std::coroutine_handle<> Outer, size_t Priority
+  ) {
+    ex->post(static_cast<std::coroutine_handle<>&&>(Outer), Priority);
+    return std::noop_coroutine();
+  }
+};
+} // namespace detail
 
 } // namespace tmc

--- a/include/tmc/ex_any.hpp
+++ b/include/tmc/ex_any.hpp
@@ -90,7 +90,9 @@ template <> struct executor_traits<tmc::ex_any> {
       tmc::detail::tiny_vec<tmc::work_item> workItems;
       workItems.resize(Count);
       for (size_t i = 0; i < Count; ++i) {
-        workItems.emplace_at(i, *(static_cast<It&&>(Items)));
+        workItems.emplace_at(
+          i, static_cast<tmc::work_item&&>(*(static_cast<It&&>(Items)))
+        );
         ++(static_cast<It&&>(Items));
       }
       ex.post_bulk(&workItems[0], Count, Priority, ThreadHint);
@@ -129,7 +131,9 @@ template <> struct executor_traits<tmc::ex_any*> {
       tmc::detail::tiny_vec<tmc::work_item> workItems;
       workItems.resize(Count);
       for (size_t i = 0; i < Count; ++i) {
-        workItems.emplace_at(i, *(static_cast<It&&>(Items)));
+        workItems.emplace_at(
+          i, static_cast<tmc::work_item&&>(*(static_cast<It&&>(Items)))
+        );
         ++(static_cast<It&&>(Items));
       }
       ex->post_bulk(&workItems[0], Count, Priority, ThreadHint);

--- a/include/tmc/ex_cpu.hpp
+++ b/include/tmc/ex_cpu.hpp
@@ -18,6 +18,7 @@
 
 #include <atomic>
 #include <cassert>
+#include <coroutine>
 #include <functional>
 #include <stop_token>
 #include <thread>

--- a/include/tmc/sync.hpp
+++ b/include/tmc/sync.hpp
@@ -349,7 +349,7 @@ template <
             SharedState->promise.set_value();
           }
           co_return;
-        }(*iter, sharedState);
+        }(std::move(*iter), sharedState);
       }
     ),
     Count, Priority, ThreadHint
@@ -360,7 +360,7 @@ template <
     iter_adapter(
       static_cast<FuncIter&&>(Begin),
       [sharedState](FuncIter iter) mutable -> auto {
-        return [f = *iter, sharedState]() mutable {
+        return [f = std::move(*iter), sharedState]() mutable {
           f();
           if (sharedState->done_count.fetch_sub(1, std::memory_order_acq_rel) ==
               0) {


### PR DESCRIPTION
This allows it to be used with the `post()` family of functions and a few other things that depend on this.

Implementation is provided for both `tmc::ex_any&` and `tmc::ex_any*` which makes it a bit easier for users.