### PR TITLE
Implement `ex_braid` on `channel` instead of `qu_lockfree`

### DIFF
--- a/include/tmc/detail/ex_braid.ipp
+++ b/include/tmc/detail/ex_braid.ipp
@@ -7,6 +7,7 @@
 // anywhere TMC_IMPL is defined. If you prefer to manually separate compilation
 // units, you can instead include this file directly in a CPP file.
 
+#include "tmc/channel.hpp"
 #include "tmc/detail/thread_locals.hpp"
 #include "tmc/ex_any.hpp"
 #include "tmc/ex_braid.hpp"
@@ -14,131 +15,69 @@
 
 #include <atomic>
 #include <coroutine>
+#include <memory>
 
 namespace tmc {
-tmc::task<void> ex_braid::try_run_loop(
-  std::shared_ptr<tiny_lock> ThisBraidLock, bool* DestroyedByThisThread
+tmc::task<void> ex_braid::run_loop(
+  tmc::chan_tok<tmc::detail::braid_work_item, tmc::detail::braid_chan_config>
+    Chan
 ) {
-  // parameters make a ref-counted copy of lock in case this braid is destroyed
-  // also make a copy of destroyed_by_this_thread pointer for the same reason
-  do {
-    if (!ThisBraidLock->try_lock()) {
+  auto parentExecutor = tmc::detail::this_thread::executor;
+  while (true) {
+    auto data = co_await Chan.pull();
+    if (!data.has_value()) {
       co_return;
     }
-    tmc::detail::braid_work_item item;
-    if (queue.try_dequeue(item)) {
-      thread_enter_context();
-      do {
-        tmc::detail::this_thread::this_task.prio = item.prio;
-        item.item();
-        if (*DestroyedByThisThread) [[unlikely]] {
-          // It's not safe to access any member variables at this point
-          // DON'T unlock after this - keep threads from entering the runloop
-          delete DestroyedByThisThread;
-          co_return;
-        }
-      } while (queue.try_dequeue(item));
-      thread_exit_context();
-    }
-    ThisBraidLock->unlock();
-    tmc::detail::memory_barrier(); // pairs with barrier in post_runloop_task
-    // check queue again after unlocking to prevent missing work items
-  } while (!queue.empty());
-}
 
-void ex_braid::thread_enter_context() {
-  // save
-  stored_context = tmc::detail::this_thread::this_task;
+    auto& item = data.value();
 
-  // enter
-  tmc::detail::this_thread::this_task.yield_priority =
-    &tmc::detail::never_yield;
-  tmc::detail::this_thread::executor = &type_erased_this;
-}
+    auto oldYieldPrio = tmc::detail::this_thread::this_task.yield_priority;
+    tmc::detail::this_thread::this_task.prio = item.prio;
+    tmc::detail::this_thread::this_task.yield_priority =
+      &tmc::detail::never_yield;
+    tmc::detail::this_thread::executor = &type_erased_this;
 
-void ex_braid::thread_exit_context() {
-  // restore
-  // the priority that is restored here is that of the try_run_loop() call
-  // individual tasks are resumed on parent according to their own priority
-  // values
-  tmc::detail::this_thread::this_task = stored_context;
-  tmc::detail::this_thread::executor = parent_executor;
+    item.item();
+
+    // Don't need to reset prio - it should be set by the parent executor before
+    // running any work from its own queue.
+    tmc::detail::this_thread::this_task.yield_priority = oldYieldPrio;
+    tmc::detail::this_thread::executor = parentExecutor;
+  }
 }
 
 void ex_braid::post(
   work_item&& Item, size_t Priority, [[maybe_unused]] size_t ThreadHint
 ) {
-  queue.enqueue(
-    tmc::detail::braid_work_item{static_cast<work_item&&>(Item), Priority}
+  auto* haz = queue->get_hazard_ptr();
+  queue->post(
+    haz, tmc::detail::braid_work_item{static_cast<work_item&&>(Item), Priority}
   );
-
-  if (tmc::detail::this_thread::exec_is(&type_erased_this)) {
-    // we are already inside of try_run_loop() - don't need to do anything
-    // don't need to check priority, as it will be restored by each work item
-    return;
-  }
-  post_runloop_task(Priority);
+  haz->release_ownership();
 }
 
-void ex_braid::post_runloop_task(size_t Priority) {
-  // This is always called after an enqueue. Make sure that the queue store
-  // is globally visible before checking if someone has the lock.
-  tmc::detail::memory_barrier(); // pairs with barrier in try_run_loop
-
-  // If someone already has the lock, we don't need to post, as they will see
-  // this item in queue.
-  if (!lock->is_locked()) {
-    // executor check not needed, it happened in braid constructor
-    parent_executor->post(
-      std::coroutine_handle<>(try_run_loop(lock, destroyed_by_this_thread)),
-      Priority
-    );
-  }
-}
-
-ex_braid::ex_braid(tmc::ex_any* Parent)
-    : queue(1), lock{std::make_shared<tiny_lock>()},
-      destroyed_by_this_thread{new bool(false)}, type_erased_this(this),
-      parent_executor(Parent) {
+ex_braid::ex_braid(tmc::ex_any* Parent) : type_erased_this(this) {
   if (Parent == nullptr) {
-    parent_executor = tmc::detail::g_ex_default.load(std::memory_order_acquire);
+    Parent = tmc::detail::g_ex_default.load(std::memory_order_acquire);
   }
+  auto chan = tmc::make_channel<
+    tmc::detail::braid_work_item, tmc::detail::braid_chan_config>();
+  queue = chan.get_raw_channel_ptr();
+  Parent->post(run_loop(chan));
 }
 
 ex_braid::ex_braid() : ex_braid(tmc::detail::this_thread::executor) {}
 
-ex_braid::~ex_braid() {
-  if (tmc::detail::this_thread::exec_is(&type_erased_this)) {
-    // we are inside of run_one_func() inside of try_run_loop(); we already have
-    // the lock
-    thread_exit_context();
-    *destroyed_by_this_thread = true;
-    // release fence is required to prevent object deallocation to be moved
-    // before this
-    std::atomic_thread_fence(std::memory_order_release);
-  } else {
-    lock->spin_lock();
-    // DON'T unlock after this - keep threads from entering the runloop
-    delete destroyed_by_this_thread;
-    // release fence is required to prevent object deallocation to be moved
-    // before this
-    std::atomic_thread_fence(std::memory_order_release);
-  }
-}
+ex_braid::~ex_braid() { queue->close(); }
 
 /// Post this task to the braid queue, and attempt to take the lock and
 /// start executing tasks on the braid.
 std::coroutine_handle<>
 ex_braid::task_enter_context(std::coroutine_handle<> Outer, size_t Priority) {
-  queue.enqueue(std::move(Outer));
-  if (tmc::detail::this_thread::exec_is(parent_executor)) {
-    // rather than posting to exec, we can just run the queue directly
-    // priority check not needed - tasks in the braid could be of any priority
-    return try_run_loop(lock, destroyed_by_this_thread);
-  } else {
-    post_runloop_task(Priority);
-    return std::noop_coroutine();
-  }
+  auto* haz = queue->get_hazard_ptr();
+  queue->post(haz, std::move(Outer));
+  haz->release_ownership();
+  return std::noop_coroutine();
 }
 
 namespace detail {

--- a/include/tmc/detail/ex_braid.ipp
+++ b/include/tmc/detail/ex_braid.ipp
@@ -68,7 +68,7 @@ ex_braid::ex_braid(tmc::ex_any* Parent) : type_erased_this(this) {
 
 ex_braid::ex_braid() : ex_braid(tmc::detail::this_thread::executor) {}
 
-ex_braid::~ex_braid() { queue->close(); }
+ex_braid::~ex_braid() { queue->drain_wait(); }
 
 /// Post this task to the braid queue, and attempt to take the lock and
 /// start executing tasks on the braid.

--- a/include/tmc/detail/ex_cpu.ipp
+++ b/include/tmc/detail/ex_cpu.ipp
@@ -628,10 +628,7 @@ ex_cpu& ex_cpu::set_priority_count(size_t PriorityCount) {
   init_params->priority_count = PriorityCount;
   return *this;
 }
-size_t ex_cpu::priority_count() {
-  assert(is_initialized());
-  return PRIORITY_COUNT;
-}
+size_t ex_cpu::priority_count() { return PRIORITY_COUNT; }
 #endif
 #ifdef TMC_USE_HWLOC
 ex_cpu& ex_cpu::set_thread_occupancy(float ThreadOccupancy) {
@@ -675,10 +672,7 @@ ex_cpu& ex_cpu::set_thread_teardown_hook(std::function<void(size_t)> Hook) {
   return *this;
 }
 
-size_t ex_cpu::thread_count() {
-  assert(is_initialized());
-  return threads.size();
-}
+size_t ex_cpu::thread_count() { return threads.size(); }
 
 void ex_cpu::teardown() {
   bool expected = true;


### PR DESCRIPTION
The motivation for this is to mitigate a race condition that occurs between 2 threads T1 and T2 when:

1. T1 (ex_cpu thread) executes a coroutine that creates an ex_braid in its local scope.
2. T2 (ex_braid thread - another thread from the ex_cpu pool) enters the runloop.
3. T1 posts work to ex_braid and co_awaits for it to finish.
4. T2 completes the work and signals to T1 that the work is done.
5. T1 runs to the end of its scope and destroys the ex_braid.
6. T2 exits the work item function and re-enters the runloop which is running on the now-destroyed ex_braid.
7. T2 attempts to access the ex_braid's queue member variable.

This had previously been mitigated by a few other approaches, including a lock. However this lock did not cover the final step of the runloop which double checks if the queue is empty. In order to mitigate this, another lock would have to be created explicitly to prevent the destructor from running before the end of the runloop. This would also add additional overhead and complexity since this lock would also have to be checked by each parent executor thread that attempts to enter the runloop.

Rather than continue with this patchwork of fixes, I have rewritten `ex_braid` to be implemented on top of `channel` instead of on `qu_lockfree`. This has several advantages:
- `channel` uses a pull model rather than a push model, so there is a single runloop task that suspends when there is no work. This task will be submitted to the parent executor when there is work waiting to run, exactly once. By contrast, the old implementation could post the runloop task to the parent executor multiple times, and then those task instances would race to be the one that was allowed to take the lock and execute work.
- There is no need to "double check" if the queue is actually empty to prevent lost wakeups. Rather, the channel implementation guarantees that the waiting task will be awoken atomically with respect to work submission.
- `channel` is already implemented as a refcounted data structure. A copy of its shared_ptr can be captured into the runloop task, rather than relying on the member variable of the braid. This means that, in the scenario described at the top of the issue, the runloop can safely access the channel again after the braid has been destroyed, see that it is closed, and then return.
- `channel` is linearizable, which is a desirable property for a serializing executor. By contrast, `qu_lockfree` was not.

The performance implications as measured by the `braid` and `braid_bench` tests range from mildly negative (-6%) on my AMD Ryzen 5900HX to mildly positive (+10%) on my AMD EPYC 7742. I'm a bit surprised by this actually - I would expect the opposite (that a sharded queue would perform better on a machine with more, slower cores), but overall I'm happy with the results.

----

In order to implement this in an efficient manner, I have created an escape hatch to break the encapsulation of `chan_tok`: the `chan_tok::get_raw_channel_ptr()` function now allows the user to access the underlying `shared_ptr<channel>` directly. As documented in the doc comment, this requires the user to manage hazard pointers manually. As used in `ex_braid`, this allows some reduction in unnecessary copies of the shared_ptr, which would otherwise be required as each call to `ex_braid.post()` is unsynchronized and cannot be allowed to use the same hazard pointer - so instead each call must acquire and release its own hazard pointer.

Additionally, I have implemented `channel::post_bulk()` which is a more efficient bulk submission algorithm that avoids multiple increments to the shared atomic variable. Currently, this is only part of the private API, but will be exposed publicly in a followup PR.

An additional followup that I have considered would be to add `channel::co_post()` which would allow symmetric transfer from aproducer to any waiting consumer, if they would run on the same executor and priority. This would improve the performance of the `tmc::enter()` call when used on `ex_braid`.