### PR TITLE
remove TMC_FORCE_INLINE from await_suspend functions

### DIFF
--- a/include/tmc/aw_resume_on.hpp
+++ b/include/tmc/aw_resume_on.hpp
@@ -32,8 +32,7 @@ public:
   }
 
   /// Post the outer task to the requested executor.
-  TMC_FORCE_INLINE inline void await_suspend(std::coroutine_handle<> Outer
-  ) const noexcept {
+  inline void await_suspend(std::coroutine_handle<> Outer) const noexcept {
     // executor check not needed, this function is explicit
     executor->post(std::move(Outer), prio);
   }
@@ -110,7 +109,7 @@ public:
   }
 
   /// Post this task to the continuation executor.
-  TMC_FORCE_INLINE inline void await_suspend(std::coroutine_handle<> Outer) {
+  inline void await_suspend(std::coroutine_handle<> Outer) {
     tmc::detail::post_checked(continuation_executor, std::move(Outer), prio);
   }
 
@@ -170,8 +169,7 @@ public:
   }
 
   /// Switch this task to the target executor.
-  TMC_FORCE_INLINE inline std::coroutine_handle<>
-  await_suspend(std::coroutine_handle<> Outer) {
+  inline std::coroutine_handle<> await_suspend(std::coroutine_handle<> Outer) {
     return tmc::detail::executor_traits<E>::task_enter_context(
       scope_executor, Outer, prio
     );

--- a/include/tmc/aw_yield.hpp
+++ b/include/tmc/aw_yield.hpp
@@ -53,8 +53,7 @@ public:
 
   /// Post the outer task to its current executor, so that a higher priority
   /// task can run.
-  TMC_FORCE_INLINE inline void await_suspend(std::coroutine_handle<> Outer
-  ) const noexcept {
+  inline void await_suspend(std::coroutine_handle<> Outer) const noexcept {
     tmc::detail::yield_impl(Outer);
   }
 
@@ -79,8 +78,7 @@ public:
 
   /// Post the outer task to its current executor, so that a higher priority
   /// task can run.
-  TMC_FORCE_INLINE inline void await_suspend(std::coroutine_handle<> Outer
-  ) const noexcept {
+  inline void await_suspend(std::coroutine_handle<> Outer) const noexcept {
     tmc::detail::yield_impl(Outer);
   }
 
@@ -125,8 +123,7 @@ public:
 
   /// Post the outer task to its current executor, so that a higher priority
   /// task can run.
-  TMC_FORCE_INLINE inline void await_suspend(std::coroutine_handle<> Outer
-  ) const noexcept {
+  inline void await_suspend(std::coroutine_handle<> Outer) const noexcept {
     tmc::detail::yield_impl(Outer);
   }
 
@@ -170,8 +167,7 @@ public:
 
   /// Post the outer task to its current executor, so that a higher priority
   /// task can run.
-  TMC_FORCE_INLINE inline void await_suspend(std::coroutine_handle<> Outer
-  ) const noexcept {
+  inline void await_suspend(std::coroutine_handle<> Outer) const noexcept {
     tmc::detail::yield_impl(Outer);
   }
 

--- a/include/tmc/detail/awaitable_customizer.hpp
+++ b/include/tmc/detail/awaitable_customizer.hpp
@@ -160,7 +160,7 @@ template <typename Promise> struct mt1_continuation_resumer {
   // This is never called - tasks are destroyed at the final_suspend instead.
   [[maybe_unused]] inline void await_resume() const noexcept {}
 
-  TMC_FORCE_INLINE inline std::coroutine_handle<>
+  inline std::coroutine_handle<>
   await_suspend(std::coroutine_handle<Promise> Handle) const noexcept {
     auto& p = Handle.promise();
     auto continuation = p.customizer.resume_continuation();

--- a/include/tmc/detail/task_wrapper.hpp
+++ b/include/tmc/detail/task_wrapper.hpp
@@ -197,8 +197,8 @@ template <typename Result> class aw_task_wrapper {
 
 public:
   inline bool await_ready() const noexcept { return handle.done(); }
-  TMC_FORCE_INLINE inline std::coroutine_handle<>
-  await_suspend(std::coroutine_handle<> Outer) noexcept {
+  inline std::coroutine_handle<> await_suspend(std::coroutine_handle<> Outer
+  ) noexcept {
     tmc::detail::get_awaitable_traits<Awaitable>::set_continuation(
       handle, Outer.address()
     );
@@ -247,8 +247,8 @@ template <> class aw_task_wrapper<void> {
 
 public:
   inline bool await_ready() const noexcept { return handle.done(); }
-  TMC_FORCE_INLINE inline std::coroutine_handle<>
-  await_suspend(std::coroutine_handle<> Outer) noexcept {
+  inline std::coroutine_handle<> await_suspend(std::coroutine_handle<> Outer
+  ) noexcept {
     tmc::detail::get_awaitable_traits<Awaitable>::set_continuation(
       handle, Outer.address()
     );

--- a/include/tmc/spawn.hpp
+++ b/include/tmc/spawn.hpp
@@ -112,8 +112,7 @@ public:
 
   /// Suspends the outer coroutine, submits the wrapped task to the
   /// executor, and waits for it to complete.
-  TMC_FORCE_INLINE inline bool await_suspend(std::coroutine_handle<> Outer
-  ) noexcept {
+  inline bool await_suspend(std::coroutine_handle<> Outer) noexcept {
 
 #ifndef NDEBUG
     assert(done_count.load() >= 0 && "You may only co_await this once.");
@@ -223,8 +222,7 @@ public:
 
   /// Suspends the outer coroutine, submits the wrapped task to the
   /// executor, and waits for it to complete.
-  TMC_FORCE_INLINE inline void await_suspend(std::coroutine_handle<> Outer
-  ) noexcept {
+  inline void await_suspend(std::coroutine_handle<> Outer) noexcept {
     initiate(
       tmc::detail::into_known<false>(static_cast<Awaitable&&>(wrapped)), Outer
     );

--- a/include/tmc/spawn_func.hpp
+++ b/include/tmc/spawn_func.hpp
@@ -57,8 +57,7 @@ public:
 
   /// Suspends the outer coroutine, submits the wrapped task to the
   /// executor, and waits for it to complete.
-  TMC_FORCE_INLINE inline void await_suspend(std::coroutine_handle<> Outer
-  ) noexcept {
+  inline void await_suspend(std::coroutine_handle<> Outer) noexcept {
 #if TMC_WORK_ITEM_IS(CORO)
     tmc::detail::task_unsafe<Result> t(tmc::detail::into_task(wrapped));
     AwaitableTraits::set_continuation(t, Outer.address());
@@ -179,8 +178,7 @@ public:
 
   /// Suspends the outer coroutine, submits the wrapped task to the
   /// executor, and waits for it to complete.
-  TMC_FORCE_INLINE inline bool await_suspend(std::coroutine_handle<> Outer
-  ) noexcept {
+  inline bool await_suspend(std::coroutine_handle<> Outer) noexcept {
 #ifndef NDEBUG
     assert(done_count.load() >= 0 && "You may only co_await this once.");
 #endif

--- a/include/tmc/spawn_many.hpp
+++ b/include/tmc/spawn_many.hpp
@@ -678,8 +678,8 @@ public:
 
   /// Suspends the outer coroutine, submits the wrapped task to the
   /// executor, and waits for it to complete.
-  TMC_FORCE_INLINE inline std::coroutine_handle<>
-  await_suspend(std::coroutine_handle<> Outer) noexcept
+  inline std::coroutine_handle<> await_suspend(std::coroutine_handle<> Outer
+  ) noexcept
     requires(!IsEach)
   {
 #ifndef NDEBUG
@@ -742,8 +742,7 @@ public:
   }
 
   /// Suspends if there are no ready results.
-  TMC_FORCE_INLINE inline bool await_suspend(std::coroutine_handle<> Outer
-  ) noexcept
+  inline bool await_suspend(std::coroutine_handle<> Outer) noexcept
     requires(IsEach)
   {
     return tmc::detail::result_each_await_suspend(

--- a/include/tmc/spawn_tuple.hpp
+++ b/include/tmc/spawn_tuple.hpp
@@ -279,8 +279,8 @@ public:
 
   /// Suspends the outer coroutine, submits the wrapped task to the
   /// executor, and waits for it to complete.
-  TMC_FORCE_INLINE inline std::coroutine_handle<>
-  await_suspend(std::coroutine_handle<> Outer) noexcept
+  inline std::coroutine_handle<> await_suspend(std::coroutine_handle<> Outer
+  ) noexcept
     requires(!IsEach)
   {
 #ifndef NDEBUG
@@ -339,8 +339,7 @@ public:
 
   /// Suspends the outer coroutine, submits the wrapped task to the
   /// executor, and waits for it to complete.
-  TMC_FORCE_INLINE inline bool await_suspend(std::coroutine_handle<> Outer
-  ) noexcept
+  inline bool await_suspend(std::coroutine_handle<> Outer) noexcept
     requires(IsEach)
   {
     return tmc::detail::result_each_await_suspend(

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -364,8 +364,8 @@ template <typename Awaitable, typename Result> class aw_task {
 
 public:
   inline bool await_ready() const noexcept { return handle.done(); }
-  TMC_FORCE_INLINE inline std::coroutine_handle<>
-  await_suspend(std::coroutine_handle<> Outer) noexcept {
+  inline std::coroutine_handle<> await_suspend(std::coroutine_handle<> Outer
+  ) noexcept {
     tmc::detail::get_awaitable_traits<Awaitable>::set_continuation(
       handle, Outer.address()
     );
@@ -405,8 +405,8 @@ template <typename Awaitable> class aw_task<Awaitable, void> {
 
 public:
   inline bool await_ready() const noexcept { return handle.done(); }
-  TMC_FORCE_INLINE inline std::coroutine_handle<>
-  await_suspend(std::coroutine_handle<> Outer) noexcept {
+  inline std::coroutine_handle<> await_suspend(std::coroutine_handle<> Outer
+  ) noexcept {
     tmc::detail::get_awaitable_traits<Awaitable>::set_continuation(
       handle, Outer.address()
     );


### PR DESCRIPTION
On versions of Clang prior to 19 (when Clang MR 79712 was merged), await_suspend functions were decorated with `noinline` as a workaround for a codegen issue that would incorrectly store scratch space in the coroutine frame. Lately I've been experiencing some strange failures that show up as race conditions (some detected by TSan, some not) that I've been able to nail down using Clang 18 on one of my older machines. This is due to TMC_FORCE_INLINE overriding this internal compiler workaround.

By removing the forceinline attribute, the compiler will now be allowed to apply the correct mitigation on older compiler versions. On newer compiler versions, the inlining should be applied appropriately anyway - performance seems to be unchanged.