### PR TITLE
Restore priority in ex_braid

### DIFF
--- a/include/tmc/aw_resume_on.hpp
+++ b/include/tmc/aw_resume_on.hpp
@@ -5,7 +5,6 @@
 
 #pragma once
 
-#include "tmc/detail/compat.hpp"
 #include "tmc/detail/concepts_awaitable.hpp" // IWYU pragma: keep
 #include "tmc/detail/thread_locals.hpp"
 #include "tmc/ex_any.hpp"

--- a/include/tmc/aw_resume_on.hpp
+++ b/include/tmc/aw_resume_on.hpp
@@ -113,10 +113,7 @@ public:
     tmc::detail::post_checked(continuation_executor, std::move(Outer), prio);
   }
 
-  /// Restores the original priority.
-  inline void await_resume() {
-    tmc::detail::this_thread::this_task.prio = prio;
-  }
+  inline void await_resume() {}
 
   /// When awaited, the outer coroutine will be resumed on the provided
   /// executor.
@@ -178,9 +175,6 @@ public:
   /// Returns an `aw_ex_scope_exit` with an `exit()` method that can be called
   /// to exit the executor, and resume this task back on its original executor.
   inline aw_ex_scope_exit<E> await_resume() {
-    // This set is not necessary for conforming executors, but may be useful for
-    // external executors that don't track priority.
-    tmc::detail::this_thread::this_task.prio = prio;
     return aw_ex_scope_exit<E>(continuation_executor, prio);
   }
 

--- a/include/tmc/detail/ex_braid.ipp
+++ b/include/tmc/detail/ex_braid.ipp
@@ -31,7 +31,7 @@ tmc::task<void> ex_braid::run_loop(
 
     auto& item = data.value();
 
-    auto oldYieldPrio = tmc::detail::this_thread::this_task.yield_priority;
+    auto storedContext = tmc::detail::this_thread::this_task;
     tmc::detail::this_thread::this_task.prio = item.prio;
     tmc::detail::this_thread::this_task.yield_priority =
       &tmc::detail::never_yield;
@@ -39,9 +39,7 @@ tmc::task<void> ex_braid::run_loop(
 
     item.item();
 
-    // Don't need to reset prio - it should be set by the parent executor before
-    // running any work from its own queue.
-    tmc::detail::this_thread::this_task.yield_priority = oldYieldPrio;
+    tmc::detail::this_thread::this_task = storedContext;
     tmc::detail::this_thread::executor = parentExecutor;
   }
 }

--- a/include/tmc/detail/ex_cpu.ipp
+++ b/include/tmc/detail/ex_cpu.ipp
@@ -283,7 +283,13 @@ void ex_cpu::run_one(
       PrevPriority = Prio;
     }
   }
+
   item();
+  assert(
+    Prio == tmc::current_priority() &&
+    "Tasks should not modify the priority directly. Use tmc::change_priority() "
+    "or .with_priority() instead."
+  );
 }
 
 // returns true if no tasks were found (caller should wait on cv)


### PR DESCRIPTION
When the braid runloop task suspends in `Chan.pull()`, it returns to the parent executor (possibly ex_cpu) and should restore with the original priority that it was initiated with. Additionally, an assert was added to ex_cpu to detect any future issues of this kind.