### PR TITLE
fix a race condition when shutting down ex_braid

### DIFF
--- a/include/tmc/detail/ex_braid.ipp
+++ b/include/tmc/detail/ex_braid.ipp
@@ -47,34 +47,36 @@ tmc::task<void> ex_braid::run_loop(
 void ex_braid::post(
   work_item&& Item, size_t Priority, [[maybe_unused]] size_t ThreadHint
 ) {
-  auto* haz = queue->get_hazard_ptr();
-  queue->post(
-    haz, tmc::detail::braid_work_item{static_cast<work_item&&>(Item), Priority}
+  // This may be called from multiple threads. Thus, each call must
+  // maintain its own refcount / hazard pointer.
+  auto tok = queue.new_token();
+  tok.post(
+    tmc::detail::braid_work_item{static_cast<work_item&&>(Item), Priority}
   );
-  haz->release_ownership();
 }
 
-ex_braid::ex_braid(tmc::ex_any* Parent) : type_erased_this(this) {
+ex_braid::ex_braid(tmc::ex_any* Parent)
+    : queue{tmc::make_channel<
+        tmc::detail::braid_work_item, tmc::detail::braid_chan_config>()},
+      type_erased_this(this) {
   if (Parent == nullptr) {
     Parent = tmc::detail::g_ex_default.load(std::memory_order_acquire);
   }
-  auto chan = tmc::make_channel<
-    tmc::detail::braid_work_item, tmc::detail::braid_chan_config>();
-  queue = chan.get_raw_channel_ptr();
-  Parent->post(run_loop(chan));
+  Parent->post(run_loop(queue));
 }
 
 ex_braid::ex_braid() : ex_braid(tmc::detail::this_thread::executor) {}
 
-ex_braid::~ex_braid() { queue->drain_wait(); }
+ex_braid::~ex_braid() { queue.drain_wait(); }
 
 /// Post this task to the braid queue, and attempt to take the lock and
 /// start executing tasks on the braid.
 std::coroutine_handle<>
 ex_braid::task_enter_context(std::coroutine_handle<> Outer, size_t Priority) {
-  auto* haz = queue->get_hazard_ptr();
-  queue->post(haz, tmc::detail::braid_work_item{std::move(Outer), Priority});
-  haz->release_ownership();
+  // This may be called from multiple threads. Thus, each call must
+  // maintain its own refcount / hazard pointer.
+  auto tok = queue.new_token();
+  tok.post(tmc::detail::braid_work_item{std::move(Outer), Priority});
   return std::noop_coroutine();
 }
 

--- a/include/tmc/detail/ex_braid.ipp
+++ b/include/tmc/detail/ex_braid.ipp
@@ -15,7 +15,6 @@
 
 #include <atomic>
 #include <coroutine>
-#include <memory>
 
 namespace tmc {
 tmc::task<void> ex_braid::run_loop(

--- a/include/tmc/ex_braid.hpp
+++ b/include/tmc/ex_braid.hpp
@@ -14,7 +14,6 @@
 #include "tmc/work_item.hpp"
 
 #include <coroutine>
-#include <memory>
 
 namespace tmc {
 namespace detail {

--- a/include/tmc/ex_braid.hpp
+++ b/include/tmc/ex_braid.hpp
@@ -34,9 +34,9 @@ class ex_braid {
   friend tmc::detail::executor_traits<ex_braid>;
 
   using task_queue_t =
-    tmc::channel<tmc::detail::braid_work_item, tmc::detail::braid_chan_config>;
+    tmc::chan_tok<tmc::detail::braid_work_item, tmc::detail::braid_chan_config>;
 
-  std::shared_ptr<task_queue_t> queue;
+  task_queue_t queue;
 
   tmc::ex_any type_erased_this;
 
@@ -69,9 +69,10 @@ public:
     It&& Items, size_t Count, size_t Priority = 0,
     [[maybe_unused]] size_t ThreadHint = NO_HINT
   ) {
-    auto* haz = queue->get_hazard_ptr();
-    queue->post_bulk(
-      haz,
+    // This may be called from multiple threads. Thus, each call must
+    // maintain its own refcount / hazard pointer.
+    auto tok = queue.new_token();
+    tok.post_bulk(
       tmc::iter_adapter(
         std::forward<It>(Items),
         [Priority](auto Item) -> tmc::detail::braid_work_item {
@@ -80,7 +81,6 @@ public:
       ),
       Count
     );
-    haz->release_ownership();
   }
 
   /// Returns a pointer to the type erased `ex_any` version of this executor.


### PR DESCRIPTION
In the following situation:
T1: post() to ex_braid, acquires a hazard ptr but yields before releasing it
T2: runs the task from ex_braid, then returns back to the outer scope and destroys the ex_braid
T1: resumes and releases the hazard pointer

The channel is destroyed while a hazard pointer is still active, which then results in a use-after-free from T1 when it releases the hazard pointer. In debug mode this is detected by the `assert(!curr->owned);`. This behavior could be triggered by the `test_ex_cpu.nested_ex_braid` test.

This is resolved by getting a real chan_tok in every ex_braid member function. I had previously tried to be smart and avoid the overhead of the shared_ptr increment per-member-function-invocation (by calling `get_raw_channel_ptr`), but actually the shared_ptr is necessary to extend the lifetime of the channel in order to free the hazard pointer used by the member function before the channel is destroyed. Since `get_raw_channel_ptr` is too unsafe for even me to use internally, I have removed it.

I also added a `new_token` function to make it clear why I'm copying the token. This allows me to write `auto tok = queue.new_token();` which is sort of reasonable, as opposed to `auto tok = queue;` which is very non-obvious. The 2nd syntax is still valid, this is just a nice to have function for readability.