### PR TITLE
hwloc.h is only required in ex_cpu.ipp (can be used in TMC_IMPL file only)

### DIFF
--- a/include/tmc/detail/thread_layout.hpp
+++ b/include/tmc/detail/thread_layout.hpp
@@ -24,7 +24,7 @@ struct L3CacheSet {
 // Use l3 cache groupings instead
 // TODO handle non-uniform core layouts (Intel/ARM hybrid architecture)
 // https://utcc.utoronto.ca/~cks/space/blog/linux/IntelHyperthreadingSurprise
-std::vector<L3CacheSet> group_cores_by_l3c(hwloc_topology_t& Topology);
+std::vector<L3CacheSet> group_cores_by_l3c(hwloc_topology_t Topology);
 
 // Modifies GroupedCores according to the number of found cores and requested
 // values. Also modifies Lasso to determine whether thread lassoing should be

--- a/include/tmc/detail/thread_layout.ipp
+++ b/include/tmc/detail/thread_layout.ipp
@@ -134,7 +134,7 @@ get_group_iteration_order(size_t GroupCount, size_t StartGroup) {
 }
 
 #ifdef TMC_USE_HWLOC
-std::vector<L3CacheSet> group_cores_by_l3c(hwloc_topology_t& Topology) {
+std::vector<L3CacheSet> group_cores_by_l3c(hwloc_topology_t Topology) {
   // discover the cache groupings
   int l3CacheCount = hwloc_get_nbobjs_by_type(Topology, HWLOC_OBJ_L3CACHE);
   std::vector<L3CacheSet> coresByL3;

--- a/include/tmc/ex_cpu.hpp
+++ b/include/tmc/ex_cpu.hpp
@@ -22,9 +22,6 @@
 #include <functional>
 #include <stop_token>
 #include <thread>
-#ifdef TMC_USE_HWLOC
-#include <hwloc.h>
-#endif
 
 namespace tmc {
 class ex_cpu {
@@ -64,7 +61,7 @@ class ex_cpu {
 
 #ifdef TMC_USE_HWLOC
   tmc::detail::tiny_vec<size_t> pu_to_thread;
-  hwloc_topology_t topology;
+  void* topology; // actually a hwloc_topology_t
 #endif
 
   // capitalized variables are constant while ex_cpu is initialized & running


### PR DESCRIPTION
Now, hwloc.h only needs to be made available for include in the implementation file (wherever TMC_IMPL is defined) and not needed for the rest of the application's includes.

Closes https://github.com/tzcnt/TooManyCooks/issues/126