### PR TITLE
Expand API of `tmc::channel::post_bulk` to support iterator pairs and ranges

### DIFF
--- a/include/tmc/channel.hpp
+++ b/include/tmc/channel.hpp
@@ -1895,7 +1895,9 @@ public:
   /// Will not suspend or block.
   template <typename TIter> bool post_bulk(TIter&& Begin, TIter&& End) {
     hazard_ptr* haz = get_hazard_ptr();
-    return chan->post_bulk(haz, static_cast<TIter&&>(Begin), End - Begin);
+    return chan->post_bulk(
+      haz, static_cast<TIter&&>(Begin), static_cast<size_t>(End - Begin)
+    );
   }
 
   /// Calculates the number of elements via
@@ -1918,7 +1920,7 @@ public:
     hazard_ptr* haz = get_hazard_ptr();
     auto begin = static_cast<TRange&&>(Range).begin();
     auto end = static_cast<TRange&&>(Range).end();
-    return chan->post_bulk(haz, begin, end - begin);
+    return chan->post_bulk(haz, begin, static_cast<size_t>(end - begin));
   }
 
   /// All future producers will return false.

--- a/include/tmc/detail/qu_lockfree.hpp
+++ b/include/tmc/detail/qu_lockfree.hpp
@@ -1749,8 +1749,8 @@ public:
 
     template <typename It>
     void MOODYCAMEL_NO_TSAN enqueue_bulk(It itemFirst, size_t count) {
-      static constexpr bool HasMoveConstructor = std::is_constructible_v<
-        T, std::add_rvalue_reference_t<std::iter_value_t<It>>>;
+      // static constexpr bool HasMoveConstructor = std::is_constructible_v<
+      //   T, std::add_rvalue_reference_t<std::iter_value_t<It>>>;
       static constexpr bool HasNoexceptMoveConstructor =
         std::is_nothrow_constructible_v<
           T, std::add_rvalue_reference_t<std::iter_value_t<It>>>;
@@ -2251,10 +2251,9 @@ private:
 
   struct alignas(64) ImplicitProducer {
     ImplicitProducer(ConcurrentQueue* parent_)
-        : tailIndex(0), headIndex(0), dequeueOptimisticCount(0),
-          dequeueOvercommit(0), tailBlock(nullptr), parent(parent_),
-          next(nullptr), inactive(false),
-          nextBlockIndexCapacity(IMPLICIT_INITIAL_INDEX_SIZE),
+        : next(nullptr), inactive(false), tailIndex(0), headIndex(0),
+          dequeueOptimisticCount(0), dequeueOvercommit(0), tailBlock(nullptr),
+          parent(parent_), nextBlockIndexCapacity(IMPLICIT_INITIAL_INDEX_SIZE),
           blockIndex(nullptr) {
       new_block_index();
     }
@@ -2459,8 +2458,8 @@ private:
     }
 
     template <typename It> void enqueue_bulk(It itemFirst, size_t count) {
-      static constexpr bool HasMoveConstructor = std::is_constructible_v<
-        T, std::add_rvalue_reference_t<std::iter_value_t<It>>>;
+      // static constexpr bool HasMoveConstructor = std::is_constructible_v<
+      //   T, std::add_rvalue_reference_t<std::iter_value_t<It>>>;
       static constexpr bool HasNoexceptMoveConstructor =
         std::is_nothrow_constructible_v<
           T, std::add_rvalue_reference_t<std::iter_value_t<It>>>;


### PR DESCRIPTION
There are now 3 overloads of `tmc::channel::post_bulk`. This also supports post_bulk where `Count == 0` or `Begin == End` (still returns `true` if the channel is open, but no items were enqueued).

- `bool post_bulk(TIter&& Begin, size_t Count)`
- `bool post_bulk(TIter&& Begin, TIter&& End)`
- `bool post_bulk(TRange&& Range)`