### PR TITLE
Update channel loop syntax

### DIFF
--- a/include/tmc/detail/ex_braid.ipp
+++ b/include/tmc/detail/ex_braid.ipp
@@ -22,12 +22,7 @@ tmc::task<void> ex_braid::run_loop(
     Chan
 ) {
   auto parentExecutor = tmc::detail::this_thread::executor;
-  while (true) {
-    auto data = co_await Chan.pull();
-    if (!data.has_value()) {
-      co_return;
-    }
-
+  while (auto data = co_await Chan.pull()) {
     auto& item = data.value();
 
     auto storedContext = tmc::detail::this_thread::this_task;


### PR DESCRIPTION
This is a much cleaner way to handle the channel pull loop. Replaced
```cpp
auto data = co_await chan.pull();
while (data.has_value()) {
  // process
  data = co_await chan.pull();
}
```

with

```cpp
while(auto data = co_await chan.pull()) {
  // process
}
```

This works because `std::optional` exposes `operator bool`.