### PR TITLE
make `tmc::task::operator bool` explicit

### DIFF
--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -248,7 +248,7 @@ struct [[nodiscard(
 #endif
   }
 
-  operator bool() const noexcept { return handle.operator bool(); }
+  explicit operator bool() const noexcept { return handle.operator bool(); }
 
   auto& promise() const noexcept { return handle.promise(); }
 };


### PR DESCRIPTION
This operator being implicit was a footgun. For example, it was possible to implicitly convert a task into a number and then pass it into a `channel<int>`.
```cpp

tmc::task<int> some_coro() {
  co_return 5;
}

auto chan = tmc::make_channel<int>();

// We meant to write
chan.post(co_await some_coro());

// But we accidentally wrote this.
// This should not compile! But it does with implicit operator bool
chan.post(some_coro());
```

Making operator bool explicit doesn't break any legit use cases, like checking if a coroutine is non-null:
```cpp
auto t = some_coro();
// This still works with explicit operator bool
if (t) {
  // do something
}
```