### PR TITLE
Remove tmc::task::done()

### DIFF
--- a/include/tmc/detail/task_wrapper.hpp
+++ b/include/tmc/detail/task_wrapper.hpp
@@ -59,9 +59,7 @@ template <typename Result> struct task_wrapper {
     return t;
   }
 
-  bool done() const noexcept { return handle.done(); }
-
-  inline void* address() const noexcept { return handle.address(); }
+  void* address() const noexcept { return handle.address(); }
 
   void destroy() noexcept { handle.destroy(); }
 
@@ -196,7 +194,7 @@ template <typename Result> class aw_task_wrapper {
   }
 
 public:
-  inline bool await_ready() const noexcept { return handle.done(); }
+  inline constexpr bool await_ready() const noexcept { return false; }
   inline std::coroutine_handle<>
   await_suspend(std::coroutine_handle<> Outer) noexcept {
     tmc::detail::get_awaitable_traits<Awaitable>::set_continuation(
@@ -246,7 +244,7 @@ template <> class aw_task_wrapper<void> {
   }
 
 public:
-  inline bool await_ready() const noexcept { return handle.done(); }
+  inline constexpr bool await_ready() const noexcept { return false; }
   inline std::coroutine_handle<>
   await_suspend(std::coroutine_handle<> Outer) noexcept {
     tmc::detail::get_awaitable_traits<Awaitable>::set_continuation(

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -219,9 +219,7 @@ struct [[nodiscard(
     return t;
   }
 
-  bool done() const noexcept { return handle.done(); }
-
-  inline void* address() const noexcept { return handle.address(); }
+  void* address() const noexcept { return handle.address(); }
 
   // std::coroutine_handle::destroy() is const, but this isn't - it nulls the
   // pointer afterward
@@ -465,7 +463,7 @@ template <typename Awaitable, typename Result> class aw_task {
   }
 
 public:
-  inline bool await_ready() const noexcept { return handle.done(); }
+  inline constexpr bool await_ready() const noexcept { return false; }
   inline std::coroutine_handle<>
   await_suspend(std::coroutine_handle<> Outer) noexcept {
     tmc::detail::get_awaitable_traits<Awaitable>::set_continuation(
@@ -506,7 +504,7 @@ template <typename Awaitable> class aw_task<Awaitable, void> {
   }
 
 public:
-  inline bool await_ready() const noexcept { return handle.done(); }
+  inline constexpr bool await_ready() const noexcept { return false; }
   inline std::coroutine_handle<>
   await_suspend(std::coroutine_handle<> Outer) noexcept {
     tmc::detail::get_awaitable_traits<Awaitable>::set_continuation(


### PR DESCRIPTION
This function can only safely return false if the coroutine is still executing. It can never safely return true. The condition for the underlying std::coroutine_handle::done() to return true is "the coroutine is suspended at the final suspend point". However, `tmc::task` destroys itself upon reaching the final suspend point, so attempting to check if the coroutine is done at this point would be UB.

I considered leaving this function in, and having it always return false; however that might be confusing and cause unexpected behavior in other ways if an API was waiting for it to return true. The truth is that this function is not a valid way to check if a `tmc::task` is done; use of the awaitable_customizer's atomic done_count pointer is the only valid way. So I've removed the function entirely to prevent any accidental misuse.