### PR TITLE
strengthen atomics in mutex/semaphore

### DIFF
--- a/include/tmc/auto_reset_event.hpp
+++ b/include/tmc/auto_reset_event.hpp
@@ -52,6 +52,8 @@ public:
   inline auto_reset_event() noexcept : auto_reset_event(false) {}
 
   /// Returns true if the state is set / ready.
+  /// This value is not guaranteed to be consistent with any other operation.
+  /// Even if this returns true, awaiting afterward may suspend.
   inline bool is_set() noexcept {
     return 0 !=
            (tmc::detail::HALF_MASK & value.load(std::memory_order_relaxed));

--- a/include/tmc/detail/mutex.ipp
+++ b/include/tmc/detail/mutex.ipp
@@ -34,7 +34,7 @@ std::coroutine_handle<>
 aw_mutex_co_unlock::await_suspend(std::coroutine_handle<> Outer) noexcept {
   assert(parent.is_locked());
   size_t old =
-    parent.value.fetch_or(mutex::UNLOCKED, std::memory_order_release);
+    parent.value.fetch_or(mutex::UNLOCKED, std::memory_order_acq_rel);
   size_t v = mutex::UNLOCKED | old;
 
   auto toWake = parent.waiters.maybe_wake(parent.value, v, old, true);
@@ -47,7 +47,7 @@ aw_mutex_co_unlock::await_suspend(std::coroutine_handle<> Outer) noexcept {
 
 void mutex::unlock() noexcept {
   assert(is_locked());
-  size_t old = value.fetch_or(UNLOCKED, std::memory_order_release);
+  size_t old = value.fetch_or(UNLOCKED, std::memory_order_acq_rel);
   size_t v = UNLOCKED | old;
   waiters.maybe_wake(value, v, old, false);
 }

--- a/include/tmc/detail/semaphore.ipp
+++ b/include/tmc/detail/semaphore.ipp
@@ -31,7 +31,7 @@ void aw_semaphore_acquire_scope::await_suspend(
 
 std::coroutine_handle<>
 aw_semaphore_co_release::await_suspend(std::coroutine_handle<> Outer) noexcept {
-  size_t old = parent.value.fetch_add(1, std::memory_order_release);
+  size_t old = parent.value.fetch_add(1, std::memory_order_acq_rel);
   size_t v = 1 + old;
 
   auto toWake = parent.waiters.maybe_wake(parent.value, v, old, true);
@@ -43,7 +43,7 @@ aw_semaphore_co_release::await_suspend(std::coroutine_handle<> Outer) noexcept {
 }
 
 void semaphore::release(size_t ReleaseCount) noexcept {
-  size_t old = value.fetch_add(ReleaseCount, std::memory_order_release);
+  size_t old = value.fetch_add(ReleaseCount, std::memory_order_acq_rel);
   size_t v = ReleaseCount + old;
 
   waiters.maybe_wake(value, v, old, false);

--- a/include/tmc/mutex.hpp
+++ b/include/tmc/mutex.hpp
@@ -103,6 +103,8 @@ public:
   inline mutex() noexcept { value = UNLOCKED; }
 
   /// Returns true if some task is holding the mutex.
+  /// This value is not guaranteed to be consistent with any other operation.
+  /// Even if this returns false, awaiting afterward may suspend.
   inline bool is_locked() noexcept {
     return 0 ==
            (tmc::detail::HALF_MASK & value.load(std::memory_order_relaxed));


### PR DESCRIPTION
[backported to v1.0]

Upgraded unlock atomics in `tmc::mutex` / `tmc::semaphore` from release to acq_rel. Given these two threads:

- Waiting thread:
  - Adds self to waiter list
  - Releases state value

Waking thread:
  - Releases state value --> this has been upgraded to acquire/release
  - Acquires waiter list

The waking thread also needs to acquire on the state value so that it is guaranteed to see the waiter list entry added by the waiting thread.