### PR TITLE
tweak barrier/latch constructor cast order

### DIFF
--- a/include/tmc/barrier.hpp
+++ b/include/tmc/barrier.hpp
@@ -57,8 +57,8 @@ public:
   /// Sets the number of awaiters for the barrier. Setting this to 0, 1, or a
   /// negative number will cause awaiters to resume immediately.
   inline barrier(size_t Count) noexcept
-      : start_count{static_cast<ptrdiff_t>(Count - 1)},
-        done_count{static_cast<ptrdiff_t>(Count - 1)} {}
+      : start_count{static_cast<ptrdiff_t>(Count) - 1},
+        done_count{static_cast<ptrdiff_t>(Count) - 1} {}
 
   /// Equivalent to `std::barrier::arrive_and_wait`. Decrements the counter, and
   /// if the counter reaches 0, wakes all awaiters, and resets the counter to

--- a/include/tmc/latch.hpp
+++ b/include/tmc/latch.hpp
@@ -24,7 +24,7 @@ public:
   /// negative number will cause awaiters to resume immediately.
   inline latch(size_t Count) noexcept
       : event{static_cast<ptrdiff_t>(Count) <= 0},
-        count{static_cast<ptrdiff_t>(Count - 1)} {
+        count{static_cast<ptrdiff_t>(Count) - 1} {
     // The internal counter is 1 less than the constructor counter so that all
     // of the comparison operations can be against 0 (which is cheap).
   }


### PR DESCRIPTION
This only makes a difference if `sizeof(ptrdiff_t) != sizeof(size_t)`. In practice they are the same but casting to a signed type before subtracting is the technically correct behavior.