### PR TITLE
fix: missing comparison in manual_reset_event::co_set

### DIFF
--- a/include/tmc/detail/manual_reset_event.ipp
+++ b/include/tmc/detail/manual_reset_event.ipp
@@ -38,7 +38,7 @@ std::coroutine_handle<> aw_manual_reset_event_co_set::await_suspend(
 ) noexcept {
   auto h =
     parent.head.exchange(manual_reset_event::READY, std::memory_order_acq_rel);
-  if (manual_reset_event::READY == h || manual_reset_event::NOT_READY) {
+  if (manual_reset_event::READY == h || manual_reset_event::NOT_READY == h) {
     // It was ready, or there are no waiters - just resume
     return Outer;
   }


### PR DESCRIPTION
This missing comparison would cause a crash if `co_set()` was called while there were no waiters.