### PR TITLE
preload waiter list in mutex/semaphore/auto_reset_event to avoid potential race condition

### DIFF
--- a/include/tmc/detail/mutex.ipp
+++ b/include/tmc/detail/mutex.ipp
@@ -21,13 +21,25 @@ mutex_scope::~mutex_scope() {
 }
 
 bool aw_mutex_lock_scope::await_ready() noexcept {
-  return tmc::detail::try_acquire(parent.value);
+  return tmc::detail::try_acquire(
+    parent.load(std::memory_order_relaxed)->value
+  );
 }
 
 void aw_mutex_lock_scope::await_suspend(
   std::coroutine_handle<> Outer
 ) noexcept {
-  me.suspend(parent.waiters, parent.value, Outer);
+  // This may be resumed immediately after we call add_waiter(). Access to
+  // any member variable after that point is UB. However we need to use the
+  // value of parent after calling add_waiter(). Thus we need to ensure that
+  // we have loaded it into a local variable prior.
+
+  // The simplest way to ensure this is to make parent atomic (to guarantee
+  // the load actually happens now) and use acquire-acquire ordering to ensure
+  // the load cannot be moved past the cmpxchg in add_waiter().
+
+  // In practice this results in identical codegen on Clang.
+  me.suspend(parent.load(std::memory_order_acquire), Outer);
 }
 
 std::coroutine_handle<>

--- a/include/tmc/detail/waiter_list.ipp
+++ b/include/tmc/detail/waiter_list.ipp
@@ -10,30 +10,33 @@
 
 #include <cassert>
 #include <cstddef>
+#include <cstdio>
 
 namespace tmc {
 namespace detail {
 
 void waiter_list_node::suspend(
-  tmc::detail::waiter_list& ParentList, std::atomic<size_t>& ParentValue,
-  std::coroutine_handle<> Outer
+  tmc::detail::waiter_data_base* Parent, std::coroutine_handle<> Outer
 ) noexcept {
+  auto& parentList = Parent->waiters;
+  auto& parentValue = Parent->value;
+
   // Configure this awaiter
   waiter.continuation = Outer;
   waiter.continuation_executor = tmc::detail::this_thread::executor;
   waiter.continuation_priority = tmc::detail::this_thread::this_task.prio;
 
   // Add this awaiter to the waiter list
-  ParentList.add_waiter(*this);
+  Parent->waiters.add_waiter(*this);
 
   // Release the operation by increasing the waiter count
   size_t add = TMC_ONE_BIT << tmc::detail::WAITERS_OFFSET;
-  size_t old = ParentValue.fetch_add(add, std::memory_order_acq_rel);
+  size_t old = parentValue.fetch_add(add, std::memory_order_acq_rel);
   size_t v = add + old;
 
   // Using the fetched value, see if there are both resources available and
   // waiters to wake.
-  ParentList.maybe_wake(ParentValue, v, old, false);
+  parentList.maybe_wake(parentValue, v, old, false);
 }
 
 void waiter_list_waiter::resume() noexcept {
@@ -205,10 +208,22 @@ bool try_acquire(std::atomic<size_t>& Value) noexcept {
 } // namespace detail
 
 bool aw_acquire::await_ready() noexcept {
-  return tmc::detail::try_acquire(parent.value);
+  return tmc::detail::try_acquire(
+    parent.load(std::memory_order_relaxed)->value
+  );
 }
 
 void aw_acquire::await_suspend(std::coroutine_handle<> Outer) noexcept {
-  me.suspend(parent.waiters, parent.value, Outer);
+  // This may be resumed immediately after we call add_waiter(). Access to
+  // any member variable after that point is UB. However we need to use the
+  // value of parent after calling add_waiter(). Thus we need to ensure that
+  // we have loaded it into a local variable prior.
+
+  // The simplest way to ensure this is to make parent atomic (to guarantee
+  // the load actually happens now) and use acquire-acquire ordering to ensure
+  // the load cannot be moved past the cmpxchg in add_waiter().
+
+  // In practice this results in identical codegen on Clang.
+  me.suspend(parent.load(std::memory_order_acquire), Outer);
 }
 } // namespace tmc

--- a/include/tmc/semaphore.hpp
+++ b/include/tmc/semaphore.hpp
@@ -46,12 +46,12 @@ class [[nodiscard(
   "You must co_await aw_semaphore_acquire_scope for it to have any effect."
 )]] aw_semaphore_acquire_scope : tmc::detail::AwaitTagNoGroupAsIs {
   tmc::detail::waiter_list_node me;
-  semaphore& parent;
+  std::atomic<semaphore*> parent;
 
   friend class semaphore;
 
   inline aw_semaphore_acquire_scope(semaphore& Parent) noexcept
-      : parent(Parent) {}
+      : parent(&Parent) {}
 
 public:
   bool await_ready() noexcept;
@@ -59,7 +59,7 @@ public:
   void await_suspend(std::coroutine_handle<> Outer) noexcept;
 
   TMC_AWAIT_RESUME inline semaphore_scope await_resume() noexcept {
-    return semaphore_scope(&parent);
+    return semaphore_scope(parent.load(std::memory_order_relaxed));
   }
 
   // Cannot be moved or copied due to holding intrusive list pointer


### PR DESCRIPTION
This may be resumed immediately after we call `add_waiter()`. Access to any member variable after that point is UB. However we need to use the value of `parent` after calling `add_waiter()`. Thus we need to ensure that we have loaded it into a local variable prior.

The simplest way to ensure this is to make parent atomic (to guarantee the load actually happens now) and use acquire-acquire ordering to ensure the load cannot be moved past the cmpxchg in `add_waiter()`.

This seems to be a theoretical issue at this point. The generated code for `await_suspend()` is identical before and after the change. However, without this fix, there's nothing preventing the compiler from inlining `me.suspend` and sinking the load of `parent` to later in the function (where it may refer to a member variable of a destroyed object).