### PR TITLE
fix: awaitable_traits::result_type for spawn_group with dynamic size

### DIFF
--- a/include/tmc/spawn_group.hpp
+++ b/include/tmc/spawn_group.hpp
@@ -263,7 +263,9 @@ struct awaitable_traits<aw_spawn_group<MaxCount, Awaitable>> {
   using Result = tmc::detail::awaitable_result_t<Awaitable>;
   using result_type = std::conditional_t<
     std::is_void_v<Result>, void,
-    std::array<tmc::detail::result_storage_t<Result>, MaxCount>>;
+    std::conditional_t<
+      MaxCount == 0, std::vector<tmc::detail::result_storage_t<Result>>,
+      std::array<tmc::detail::result_storage_t<Result>, MaxCount>>>;
   using self_type = aw_spawn_group<MaxCount, Awaitable>;
   using awaiter_type = aw_spawn_group<MaxCount, Awaitable>&&;
 


### PR DESCRIPTION
When MaxCount is 0 and Result is non-void, the result is a std::vector. This trait was returning std::array<Result, 0> instead.

This didn't cause an issue in normal await, but the trait result_type is used for composition, e.g. when this is composed into a spawn_tuple with other awaitables. In that case it would cause a compilation error.