### PR TITLE
document that `spawn_group::add*()` and `fork_group::fork*()` are not thread-safe

### DIFF
--- a/include/tmc/fork_group.hpp
+++ b/include/tmc/fork_group.hpp
@@ -351,7 +351,7 @@ public:
   ///
   /// If the capacity is unlimited, this will return
   /// `std::numeric_limits<size_t>::max()`, i.e. `static_cast<size_t>(-1)`.
-  size_t capacity() noexcept {
+  size_t capacity() const noexcept {
     if constexpr (std::is_void_v<Result>) {
       return static_cast<size_t>(-1);
     } else {
@@ -362,7 +362,7 @@ public:
 
   /// Returns the number of awaitables actually posted to the fork_group.
   /// This value will be reset to 0 when `reset()` is called.
-  size_t size() noexcept { return task_count; }
+  size_t size() const noexcept { return task_count; }
 };
 
 /// Constructs an empty fork group with default template parameters.

--- a/include/tmc/spawn_group.hpp
+++ b/include/tmc/spawn_group.hpp
@@ -226,7 +226,7 @@ public:
   ///
   /// If the capacity is unlimited, this will return
   /// `std::numeric_limits<size_t>::max()`, i.e. `static_cast<size_t>(-1)`.
-  size_t capacity() noexcept {
+  size_t capacity() const noexcept {
     if constexpr (MaxCount == 0) {
       return static_cast<size_t>(-1);
     } else {
@@ -236,7 +236,7 @@ public:
 
   /// Returns the number of awaitables actually posted to the spawn_group.
   /// This value will be reset to 0 when `reset()` is called.
-  size_t size() noexcept { return task_count; }
+  size_t size() const noexcept { return task_count; }
 };
 
 /// Constructs an empty spawn group with default template parameters.


### PR DESCRIPTION
The below methods are not thread safe. If multiple threads need to submit work in parallel to these, they must be externally synchronized:
- spawn_group::add()
- spawn_group::add_clang()
- fork_group::fork()
- fork_group::fork_clang()