### PR TITLE
topology: make the methods of tmc::topology::cpu_topology const

### DIFF
--- a/include/tmc/detail/topology.ipp
+++ b/include/tmc/detail/topology.ipp
@@ -26,9 +26,9 @@
 namespace tmc {
 namespace topology {
 
-bool cpu_topology::is_hybrid() { return cpu_kind_counts.size() > 1; }
+bool cpu_topology::is_hybrid() const { return cpu_kind_counts.size() > 1; }
 
-size_t cpu_topology::pu_count() {
+size_t cpu_topology::pu_count() const {
   size_t count = 0;
   for (auto& group : groups) {
     count += group.core_indexes.size() * group.smt_level;
@@ -36,13 +36,13 @@ size_t cpu_topology::pu_count() {
   return count;
 }
 
-size_t cpu_topology::core_count() {
+size_t cpu_topology::core_count() const {
   return groups.back().core_indexes.back() + 1;
 }
 
-size_t cpu_topology::group_count() { return groups.size(); }
+size_t cpu_topology::group_count() const { return groups.size(); }
 
-size_t cpu_topology::numa_count() { return groups.back().numa_index + 1; }
+size_t cpu_topology::numa_count() const { return groups.back().numa_index + 1; }
 
 cpu_topology query() {
   hwloc_topology_t unused;

--- a/include/tmc/topology.hpp
+++ b/include/tmc/topology.hpp
@@ -145,22 +145,22 @@ struct cpu_topology {
   float container_cpu_quota;
 
   /// Returns true if this machine has more than one CPU kind.
-  bool is_hybrid();
+  bool is_hybrid() const;
 
   /// The total number of logical processors (including SMT/hyperthreading).
-  size_t pu_count();
+  size_t pu_count() const;
 
   /// The total number of physical processors (not including
   /// SMT/hyperthreading).
-  size_t core_count();
+  size_t core_count() const;
 
   /// The total number of core groups that TMC sees. These groups are based on
   /// shared caches and CPU kinds. For more detail on the group construction
   /// rules, see the documentation.
-  size_t group_count();
+  size_t group_count() const;
 
   /// The total number of NUMA nodes.
-  size_t numa_count();
+  size_t numa_count() const;
 };
 
 /// Query the system CPU topology. Returns a copy of the topology; modifications


### PR DESCRIPTION
Make all the methods of tmc::topology::cpu_topology const since they don't change any data in the struct but only return the topology properties.