### PR TITLE
hoist continuation/continuation_executor to top of awaitable customizer

### DIFF
--- a/include/tmc/detail/awaitable_customizer.hpp
+++ b/include/tmc/detail/awaitable_customizer.hpp
@@ -75,14 +75,16 @@ struct awaitable_customizer_base {
   // complete and any results are ready.
   TMC_FORCE_INLINE inline std::coroutine_handle<>
   resume_continuation() noexcept {
+    void* vContinuationExecutor = continuation_executor;
+    void* vContinuation = continuation;
+    tmc::ex_any* continuationExecutor =
+      static_cast<tmc::ex_any*>(vContinuationExecutor);
     std::coroutine_handle<> finalContinuation;
-    tmc::ex_any* continuationExecutor = nullptr;
     if (done_count == nullptr) {
       // being awaited alone, or detached
       // continuation is a std::coroutine_handle<>
       // continuation_executor is a tmc::ex_any*
-      continuationExecutor = static_cast<tmc::ex_any*>(continuation_executor);
-      finalContinuation = std::coroutine_handle<>::from_address(continuation);
+      finalContinuation = std::coroutine_handle<>::from_address(vContinuation);
     } else {
       // being awaited as part of a group
       bool shouldResume;
@@ -111,9 +113,9 @@ struct awaitable_customizer_base {
       }
       if (shouldResume) {
         continuationExecutor =
-          *static_cast<tmc::ex_any**>(continuation_executor);
+          *static_cast<tmc::ex_any**>(vContinuationExecutor);
         finalContinuation =
-          *(static_cast<std::coroutine_handle<>*>(continuation));
+          *(static_cast<std::coroutine_handle<>*>(vContinuation));
       } else {
         finalContinuation = nullptr;
       }


### PR DESCRIPTION
This is purely a performance optimization. These members need to be loaded in both the single-task and multi-task paths. In multi-task path it's double indirected. This value was being loaded in the multi-task path after the fetch_sub, but the first indirection can always be loaded pre-fetch-sub which slightly reduces latency. Additionally 1 branch can be removed since we don't need to initialize the value of continuation_executor to nullptr. This reduces the total number of generated x86 instructions by 5. This code runs at the end of every task, so this is a meaningful amount.