### PR TITLE
[v1.3 backport] fix potential leak in coro_functor move assignment

### DIFF
--- a/include/tmc/detail/coro_functor.hpp
+++ b/include/tmc/detail/coro_functor.hpp
@@ -167,17 +167,7 @@ public:
     Other.obj = nullptr;
   }
 
-  inline coro_functor& operator=(coro_functor&& Other) noexcept {
-    func = Other.func;
-    obj = Other.obj;
-#ifndef NDEBUG
-    Other.func = nullptr;
-#endif
-    Other.obj = nullptr;
-    return *this;
-  }
-
-  inline ~coro_functor() {
+  void clear() {
     uintptr_t mode = reinterpret_cast<uintptr_t>(obj);
     if (mode <= IS_FREE_FUNC) {
       return;
@@ -189,5 +179,18 @@ public:
     // cast_call_or_nothing will ignore the parameter
     memberFunc(obj, false);
   }
+
+  inline coro_functor& operator=(coro_functor&& Other) noexcept {
+    clear();
+    func = Other.func;
+    obj = Other.obj;
+#ifndef NDEBUG
+    Other.func = nullptr;
+#endif
+    Other.obj = nullptr;
+    return *this;
+  }
+
+  inline ~coro_functor() { clear(); }
 };
 } // namespace tmc


### PR DESCRIPTION
A memory leak could occur if:
- the user defines TMC_WORK_ITEM=FUNCORO
- submits a functor (not coroutine) to ex_manual_st

Although the root cause is the move assignment operator of coro_functor, other executors create a new object in scope each time so they are not prone to this. This fix is only for v1.3 which is the first release to include ex_manual_st.

A followup PR will implement the long-term fix (make this type trivially copyable and destroy itself after execution, like std::coroutine_handle)