### PR TITLE
remove unused coroutine_traits from task_unsafe

### DIFF
--- a/include/tmc/detail/task_unsafe.hpp
+++ b/include/tmc/detail/task_unsafe.hpp
@@ -58,8 +58,3 @@ struct awaitable_traits<tmc::detail::task_unsafe<Result>> {
 };
 } // namespace detail
 } // namespace tmc
-
-template <typename Result, typename... Args>
-struct std::coroutine_traits<tmc::detail::task_unsafe<Result>, Args...> {
-  using promise_type = tmc::detail::task_promise<Result>;
-};


### PR DESCRIPTION
task_unsafe isn't ever awaited or exposed in the public API - it's only used internally as a lightweight temporary task handle. So the coroutine_traits specialization was unused. Since task_unsafe is an alias to std::coroutine_handle, and it's not allowed to specialize standard library traits for standard library types, this trait was also illegal.