### PR TITLE
Add check for Count == 0 in post_bulk() / post_bulk_waitable()

### DIFF
--- a/include/tmc/sync.hpp
+++ b/include/tmc/sync.hpp
@@ -478,6 +478,9 @@ void post_bulk(
     tmc::detail::is_func_void<TaskOrFunc>
   )
 {
+  if (Count == 0) {
+    return;
+  }
   if constexpr (std::is_convertible_v<TaskOrFunc, work_item>) {
     tmc::detail::get_executor_traits<E>::post_bulk(
       Executor, static_cast<Iter&&>(Begin), Count, Priority, ThreadHint


### PR DESCRIPTION
Previously if the user passed Count == 0 or an empty iterator pair here there would be an assert failure. Instead it's better to just succeed:
- post_bulk will do nothing
- post_bulk_waitable will return a completed future