### PR TITLE
add cpu_kind operator|

### DIFF
--- a/include/tmc/detail/topology.ipp
+++ b/include/tmc/detail/topology.ipp
@@ -157,7 +157,7 @@ std::vector<size_t> resolve_filter_to_cores(
 }
 } // namespace
 
-topology_filter topology_filter::operator|(topology_filter const& rhs) {
+topology_filter topology_filter::operator|(topology_filter const& rhs) const {
   cpu_topology topo = query();
 
   std::vector<size_t> lhsCores = resolve_filter_to_cores(*this, topo);
@@ -173,7 +173,7 @@ topology_filter topology_filter::operator|(topology_filter const& rhs) {
   return result;
 }
 
-void pin_thread([[maybe_unused]] topology_filter Allowed) {
+void pin_thread([[maybe_unused]] topology_filter const& Allowed) {
   hwloc_topology_t hwlocTopo;
   auto privateTopo = tmc::topology::detail::query_internal(hwlocTopo);
   tmc::topology::cpu_kind::value cpuKind;


### PR DESCRIPTION
- Add operator| for cpu_kind::value so that users can OR these together.
- Make pin_thread take a const& to reduce copying.
- Doc comments improvements.