### PR TITLE
`tmc::fork_group` can be awaited multiple times

### DIFF
--- a/include/tmc/fork_group.hpp
+++ b/include/tmc/fork_group.hpp
@@ -25,6 +25,11 @@ namespace tmc {
 /// A container for imperatively forking awaitables, initiating each
 /// awaitable immediately, and joining them all at a later time.
 ///
+/// Unlike most TMC awaitables, it is OK to await this multiple times. Awaiting
+/// it returns an lvalue reference to the results data, which will remain valid
+/// until you call `reset()` or the destructor. However, awaiting is not
+/// thread-safe; there must only be 1 awaiter at any given time.
+///
 /// `Result` is the result type of the awaitables that will be forked.
 /// Different types of awaitables may be forked with a single fork_group, as
 /// long as they all return the same Result type.
@@ -272,9 +277,6 @@ public:
   /// complete.
   std::coroutine_handle<>
   await_suspend(std::coroutine_handle<> Outer) noexcept {
-#ifndef NDEBUG
-    assert(done_count.load() >= 0 && "You may only co_await this once.");
-#endif
     continuation = Outer;
     std::coroutine_handle<> next;
     // This logic is necessary because we submitted all child tasks before
@@ -302,12 +304,12 @@ public:
     return next;
   }
 
-  /// Returns the result array.
-  TMC_AWAIT_RESUME std::add_rvalue_reference_t<ResultArray>
+  /// Returns an lvalue reference to the result array.
+  TMC_AWAIT_RESUME std::add_lvalue_reference_t<ResultArray>
   await_resume() noexcept
     requires(!std::is_void_v<Result>)
   {
-    return std::move(result_arr);
+    return result_arr;
   }
 
   /// Does nothing.


### PR DESCRIPTION
Previously `tmc::fork_group` was an rvalue-only awaitable, like most other TMC awaitables. This restriction makes sense for awaitables that initiate work and retrieve results in the same operation (since initiating work is not idempotent). However, `fork_group` separates the steps of initiating work and awaiting it. So we can make it an lvalue awaitable which can be awaited multiple times to retrieve the same result again. Or the user can still cast to rvalue to move-from the result. If the user wants to dispatch another group of work later, they can call `reset()` before doing so.

This allows it to replace `tmc::manual_reset_event` in some places, with a caveat: awaiting `manual_reset_event` is thread-safe as it has a mechanism to register multiple awaiters, but `fork_group` does not. So only a single thread should await `fork_group` at any given time.

Supported usages:
`co_await fg; // returns ResultArray&`
`co_await std::move(fg); // returns ResultArray&&`
`std::move(co_await fg); // returns ResultArray&&`