### PR TITLE
Add support for C++ modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+build/
+
 # Prerequisites
 *.d
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,96 @@
+cmake_minimum_required(VERSION 3.28)
+project(TooManyCooks 
+    VERSION 1.0.0
+    LANGUAGES CXX
+    DESCRIPTION "TooManyCooks - A runtime and concurrency library for C++20 coroutines"
+)
+
+# Require C++20 for coroutines and modules
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Options
+option(TMC_BUILD_MODULE "Build the C++20 module" ON)
+option(TMC_USE_HWLOC "Enable hwloc support for topology detection" OFF)
+option(TMC_DEBUG_TASK_ALLOC_COUNT "Enable task allocation counting for debugging" OFF)
+
+# Create the main module library
+add_library(tmc)
+
+# Add the module source
+target_sources(tmc
+    PUBLIC
+        FILE_SET CXX_MODULES FILES
+            modules/tmc.cppm
+)
+
+# Include directories for headers used by the module
+target_include_directories(tmc
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+)
+
+# Compile definitions
+# Module build requires external linkage for helper functions
+target_compile_definitions(tmc PRIVATE TMC_MODULE_BUILD)
+
+if(TMC_USE_HWLOC)
+    target_compile_definitions(tmc PUBLIC TMC_USE_HWLOC)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(HWLOC REQUIRED hwloc)
+    target_include_directories(tmc PUBLIC ${HWLOC_INCLUDE_DIRS})
+    target_link_libraries(tmc PUBLIC ${HWLOC_LIBRARIES})
+endif()
+
+if(TMC_DEBUG_TASK_ALLOC_COUNT)
+    target_compile_definitions(tmc PUBLIC TMC_DEBUG_TASK_ALLOC_COUNT)
+endif()
+
+# Platform-specific settings
+if(UNIX AND NOT APPLE)
+    target_link_libraries(tmc PUBLIC pthread)
+endif()
+
+# Installation rules
+include(GNUInstallDirs)
+
+install(TARGETS tmc
+    EXPORT TooManyCooksTargets
+    FILE_SET CXX_MODULES DESTINATION ${CMAKE_INSTALL_LIBDIR}/modules
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+install(DIRECTORY include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+install(EXPORT TooManyCooksTargets
+    FILE TooManyCooksTargets.cmake
+    NAMESPACE TooManyCooks::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/TooManyCooks
+)
+
+# Create config file
+include(CMakePackageConfigHelpers)
+
+configure_package_config_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/TooManyCooksConfig.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/TooManyCooksConfig.cmake"
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/TooManyCooks
+)
+
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/TooManyCooksConfigVersion.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY AnyNewerVersion
+)
+
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/TooManyCooksConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/TooManyCooksConfigVersion.cmake"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/TooManyCooks
+)

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ It also offers the option to create a [standalone compilation file](https://gith
 
 For a minimal project template, see [tmc-hello-world](https://github.com/tzcnt/tmc-hello-world).
 
+Using CMake, the library can be built as a C++20 module (which requires CMake 3.28 and any module-supporting build system, like Ninja).
+
 ### Configuration
 TooManyCooks will work out of the box as a header-only library without any configuration.
 However, some configuration options are available. See the documentation section [Build-Time Options](https://fleetcode.com/oss/tmc/docs/latest/build_flags.html) for more info.

--- a/cmake/TooManyCooksConfig.cmake.in
+++ b/cmake/TooManyCooksConfig.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/TooManyCooksTargets.cmake")
+
+check_required_components(TooManyCooks)

--- a/include/tmc/detail/awaitable_customizer.hpp
+++ b/include/tmc/detail/awaitable_customizer.hpp
@@ -17,19 +17,19 @@ namespace tmc {
 namespace detail {
 namespace task_flags {
 // Flags bitfield section
-static inline constexpr size_t NONE = 0;
-static inline constexpr size_t EACH = TMC_ONE_BIT << (TMC_PLATFORM_BITS - 1);
+TMC_STATIC_LINKAGE constexpr size_t NONE = 0;
+TMC_STATIC_LINKAGE constexpr size_t EACH = TMC_ONE_BIT << (TMC_PLATFORM_BITS - 1);
 
 // Numeric bitfield sections
-static inline constexpr size_t TASKNUM_HIGH_OFF = 10;
-static inline constexpr size_t TASKNUM_LOW_OFF = 4;
-static inline constexpr size_t TASKNUM_MASK =
+TMC_STATIC_LINKAGE constexpr size_t TASKNUM_HIGH_OFF = 10;
+TMC_STATIC_LINKAGE constexpr size_t TASKNUM_LOW_OFF = 4;
+TMC_STATIC_LINKAGE constexpr size_t TASKNUM_MASK =
   (TMC_ONE_BIT << TASKNUM_HIGH_OFF) - (TMC_ONE_BIT << TASKNUM_LOW_OFF);
 
 // This is the continuation priority, not the current task's priority
-static inline constexpr size_t PRIORITY_HIGH_OFF = 4;
-static inline constexpr size_t PRIORITY_LOW_OFF = 0;
-static inline constexpr size_t PRIORITY_MASK =
+TMC_STATIC_LINKAGE constexpr size_t PRIORITY_HIGH_OFF = 4;
+TMC_STATIC_LINKAGE constexpr size_t PRIORITY_LOW_OFF = 0;
+TMC_STATIC_LINKAGE constexpr size_t PRIORITY_MASK =
   (TMC_ONE_BIT << PRIORITY_HIGH_OFF) - (TMC_ONE_BIT << PRIORITY_LOW_OFF);
 
 } // namespace task_flags

--- a/include/tmc/detail/compat.hpp
+++ b/include/tmc/detail/compat.hpp
@@ -8,6 +8,12 @@
 #include <atomic>
 #include <cstddef>
 
+#ifdef TMC_MODULE_BUILD
+#define TMC_STATIC_LINKAGE inline
+#else
+#define TMC_STATIC_LINKAGE static inline
+#endif
+
 #if defined(_MSC_VER)
 
 #ifdef __has_cpp_attribute
@@ -70,7 +76,7 @@
 #endif
 #define TMC_CPU_X86
 #define TMC_CPU_PAUSE _mm_pause
-static inline size_t TMC_CPU_TIMESTAMP() noexcept {
+TMC_STATIC_LINKAGE size_t TMC_CPU_TIMESTAMP() noexcept {
   return static_cast<size_t>(__rdtsc());
 }
 // Assume a 3.5GHz CPU if we can't get the value (on x86).
@@ -81,29 +87,29 @@ static inline size_t TMC_CPU_TIMESTAMP() noexcept {
 // be running faster, and vice versa. For the current usage of this (the
 // clustering threshold in tmc::channel) this seems like reasonable behavior
 // anyway.
-static inline const size_t TMC_CPU_FREQ = 3500000000;
+TMC_STATIC_LINKAGE const size_t TMC_CPU_FREQ = 3500000000;
 #elif defined(__arm__) || defined(_M_ARM) || defined(_M_ARM64) ||              \
   defined(__aarch64__) || defined(__ARM_ACLE)
 #define TMC_CPU_ARM
-static inline void TMC_CPU_PAUSE() noexcept {
+TMC_STATIC_LINKAGE void TMC_CPU_PAUSE() noexcept {
   // Clang defines __yield intrinsic, but GCC doesn't, so we use asm
   asm volatile("yield");
 }
 // Read the ARM "Virtual Counter" register.
 // This ticks at a frequency independent of the processor frequency.
 // https://developer.arm.com/documentation/ddi0406/cb/System-Level-Architecture/The-Generic-Timer/About-the-Generic-Timer/The-virtual-counter?lang=en
-static inline size_t TMC_CPU_TIMESTAMP() noexcept {
+TMC_STATIC_LINKAGE size_t TMC_CPU_TIMESTAMP() noexcept {
   size_t count;
   asm volatile("mrs %0, cntvct_el0; " : "=r"(count)::"memory");
   return count;
 }
 // Read the ARM "Virtual Counter" frequency.
-static inline size_t TMC_ARM_CPU_FREQ() noexcept {
+TMC_STATIC_LINKAGE size_t TMC_ARM_CPU_FREQ() noexcept {
   size_t freq;
   asm volatile("mrs %0, cntfrq_el0; isb; " : "=r"(freq)::"memory");
   return freq;
 }
-static inline const size_t TMC_CPU_FREQ = TMC_ARM_CPU_FREQ();
+TMC_STATIC_LINKAGE const size_t TMC_CPU_FREQ = TMC_ARM_CPU_FREQ();
 #endif
 
 // clang-format tries to collapse the pragmas into one line...

--- a/include/tmc/detail/concepts_work_item.hpp
+++ b/include/tmc/detail/concepts_work_item.hpp
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "tmc/detail/compat.hpp"
 #include "tmc/detail/concepts_awaitable.hpp"
 #include "tmc/task.hpp"
 
@@ -95,7 +96,7 @@ template <is_callable T> struct executable_kind_v_impl<T> {
   static inline constexpr executable_kind value = executable_kind::CALLABLE;
 };
 template <typename T>
-static inline constexpr executable_kind executable_kind_v =
+TMC_STATIC_LINKAGE constexpr executable_kind executable_kind_v =
   executable_kind_v_impl<T>::value;
 /// end executable_kind<T>
 

--- a/include/tmc/detail/container_cpu_quota.ipp
+++ b/include/tmc/detail/container_cpu_quota.ipp
@@ -22,7 +22,6 @@ namespace tmc {
 namespace detail {
 
 #ifdef __linux__
-namespace {
 
 struct mount_point {
   std::string mount_point_path;
@@ -37,7 +36,7 @@ struct cgroup_subsys {
   std::string path;
 };
 
-std::vector<std::string> split_string(const std::string& s, char delim) {
+inline std::vector<std::string> split_string(const std::string& s, char delim) {
   std::vector<std::string> result;
   std::stringstream ss(s);
   std::string item;
@@ -47,7 +46,7 @@ std::vector<std::string> split_string(const std::string& s, char delim) {
   return result;
 }
 
-std::vector<cgroup_subsys> parse_proc_cgroup(const std::string& path) {
+inline std::vector<cgroup_subsys> parse_proc_cgroup(const std::string& path) {
   std::vector<cgroup_subsys> result;
   std::ifstream file(path);
   if (!file.is_open()) {
@@ -69,7 +68,7 @@ std::vector<cgroup_subsys> parse_proc_cgroup(const std::string& path) {
   return result;
 }
 
-std::vector<mount_point> parse_mountinfo(const std::string& path) {
+inline std::vector<mount_point> parse_mountinfo(const std::string& path) {
   std::vector<mount_point> result;
   std::ifstream file(path);
   if (!file.is_open()) {
@@ -104,7 +103,7 @@ std::vector<mount_point> parse_mountinfo(const std::string& path) {
   return result;
 }
 
-bool is_cgroups_v2() {
+inline bool is_cgroups_v2() {
   auto mounts = parse_mountinfo("/proc/self/mountinfo");
   for (const auto& mp : mounts) {
     if (mp.fs_type == "cgroup2" && mp.mount_point_path == "/sys/fs/cgroup") {
@@ -114,7 +113,7 @@ bool is_cgroups_v2() {
   return false;
 }
 
-std::string find_cgroup_v2_path() {
+inline std::string find_cgroup_v2_path() {
   auto subsystems = parse_proc_cgroup("/proc/self/cgroup");
   for (const auto& subsys : subsystems) {
     if (subsys.id == 0) {
@@ -124,7 +123,7 @@ std::string find_cgroup_v2_path() {
   return "";
 }
 
-std::string find_cgroup_v1_path() {
+inline std::string find_cgroup_v1_path() {
   auto subsystems = parse_proc_cgroup("/proc/self/cgroup");
   auto mounts = parse_mountinfo("/proc/self/mountinfo");
 
@@ -157,7 +156,7 @@ std::string find_cgroup_v1_path() {
   return "";
 }
 
-int64_t read_int_from_file(const std::string& path) {
+inline int64_t read_int_from_file(const std::string& path) {
   std::ifstream file(path);
   if (!file.is_open()) {
     return -1;
@@ -169,7 +168,7 @@ int64_t read_int_from_file(const std::string& path) {
   return value;
 }
 
-container_cpu_quota query_cgroups_v2() {
+inline container_cpu_quota query_cgroups_v2() {
   container_cpu_quota result;
   result.cpu_count = 0.0;
   result.status = container_cpu_status::UNLIMITED;
@@ -225,7 +224,7 @@ container_cpu_quota query_cgroups_v2() {
   return result;
 }
 
-container_cpu_quota query_cgroups_v1() {
+inline container_cpu_quota query_cgroups_v1() {
   container_cpu_quota result;
   result.cpu_count = 0.0;
   result.status = container_cpu_status::UNLIMITED;
@@ -253,7 +252,6 @@ container_cpu_quota query_cgroups_v1() {
   return result;
 }
 
-} // namespace
 #endif
 
 container_cpu_quota query_container_cpu_quota() {

--- a/include/tmc/detail/impl.hpp
+++ b/include/tmc/detail/impl.hpp
@@ -35,5 +35,10 @@
 #define TMC_DECL
 #endif
 #else // !TMC_STANDALONE_COMPILATION
+
+#ifdef TMC_MODULE_BUILD
+#define TMC_DECL
+#else
 #define TMC_DECL inline
+#endif
 #endif

--- a/include/tmc/detail/qu_lockfree.hpp
+++ b/include/tmc/detail/qu_lockfree.hpp
@@ -93,9 +93,9 @@ template <typename thread_id_t> struct thread_id_converter {
 namespace tmc::queue {
 namespace details {
 typedef std::uint32_t thread_id_t;
-static const thread_id_t invalid_thread_id = 0xFFFFFFFFU;
-static const thread_id_t invalid_thread_id2 = 0xFFFFFFFEU;
-static inline thread_id_t thread_id() { return rl::thread_index(); }
+inline constexpr thread_id_t invalid_thread_id = 0xFFFFFFFFU;
+inline constexpr thread_id_t invalid_thread_id2 = 0xFFFFFFFEU;
+inline thread_id_t thread_id() { return rl::thread_index(); }
 } // namespace details
 } // namespace tmc::queue
 #elif defined(_WIN32) || defined(__WINDOWS__) || defined(__WIN32__)
@@ -110,13 +110,13 @@ static_assert(
   "Expected size of unsigned long to be 32 bits on Windows"
 );
 typedef std::uint32_t thread_id_t;
-static const thread_id_t invalid_thread_id =
+inline constexpr thread_id_t invalid_thread_id =
   0; // See http://blogs.msdn.com/b/oldnewthing/archive/2004/02/23/78395.aspx
-static const thread_id_t invalid_thread_id2 =
+inline constexpr thread_id_t invalid_thread_id2 =
   0xFFFFFFFFU; // Not technically guaranteed to be invalid, but is never used
                // in practice. Note that all Win32 thread IDs are presently
                // multiples of 4.
-static inline thread_id_t thread_id() {
+inline thread_id_t thread_id() {
   return static_cast<thread_id_t>(::GetCurrentThreadId());
 }
 } // namespace details
@@ -131,12 +131,12 @@ static_assert(
 );
 
 typedef std::thread::id thread_id_t;
-static const thread_id_t invalid_thread_id; // Default ctor creates invalid ID
+inline const thread_id_t invalid_thread_id; // Default ctor creates invalid ID
 
 // Note we don't define a invalid_thread_id2 since std::thread::id doesn't have
 // one; it's only used if TMC_MOODYCAMEL_CPP11_THREAD_LOCAL_SUPPORTED is defined
 // anyway, which it won't be.
-static inline thread_id_t thread_id() { return std::this_thread::get_id(); }
+inline thread_id_t thread_id() { return std::this_thread::get_id(); }
 
 template <std::size_t> struct thread_id_size {};
 template <> struct thread_id_size<4> {
@@ -172,8 +172,8 @@ template <> struct thread_id_converter<thread_id_t> {
 namespace tmc::queue {
 namespace details {
 typedef std::uintptr_t thread_id_t;
-static const thread_id_t invalid_thread_id = 0; // Address can't be nullptr
-static const thread_id_t invalid_thread_id2 =
+inline constexpr thread_id_t invalid_thread_id = 0; // Address can't be nullptr
+inline constexpr thread_id_t invalid_thread_id2 =
   1; // Member accesses off a null pointer are also generally invalid. Plus
      // it's not aligned.
 inline thread_id_t thread_id() {
@@ -391,7 +391,7 @@ template <> struct _hash_32_or_64<1> {
 template <std::size_t size>
 struct hash_32_or_64 : public _hash_32_or_64<(size > 4)> {};
 
-static inline size_t hash_thread_id(thread_id_t id) {
+inline size_t hash_thread_id(thread_id_t id) {
   static_assert(
     sizeof(thread_id_t) <= 8,
     "Expected a platform where thread IDs are at most 64-bit values"
@@ -403,7 +403,7 @@ static inline size_t hash_thread_id(thread_id_t id) {
 }
 
 // T must be an unsigned integer type
-template <typename T> static inline bool circular_less_than(T a, T b) {
+template <typename T> inline bool circular_less_than(T a, T b) {
   return static_cast<T>(a - b) >
          static_cast<T>(
            static_cast<T>(1) << (static_cast<T>(sizeof(T) * CHAR_BIT - 1))
@@ -414,7 +414,7 @@ template <typename T> static inline bool circular_less_than(T a, T b) {
   // calling code and has no effect when done here.
 }
 
-template <typename U> static inline std::byte* align_for(std::byte* ptr) {
+template <typename U> inline std::byte* align_for(std::byte* ptr) {
   const std::size_t alignment = std::alignment_of<U>::value;
   return ptr +
          (alignment - (reinterpret_cast<std::uintptr_t>(ptr) % alignment)) %
@@ -422,7 +422,7 @@ template <typename U> static inline std::byte* align_for(std::byte* ptr) {
 }
 
 // T must be an unsigned integer type
-template <typename T> static inline T ceil_to_pow_2(T x) {
+template <typename T> inline T ceil_to_pow_2(T x) {
   // Adapted from
   // http://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
   --x;
@@ -436,10 +436,10 @@ template <typename T> static inline T ceil_to_pow_2(T x) {
   return x;
 }
 
-template <typename T> static inline T const& nomove(T const& x) { return x; }
+template <typename T> inline T const& nomove(T const& x) { return x; }
 
 template <typename It>
-static inline auto deref_noexcept(It& it) TMC_MOODYCAMEL_NOEXCEPT
+inline auto deref_noexcept(It& it) TMC_MOODYCAMEL_NOEXCEPT
   -> decltype(*it) {
   return *it;
 }

--- a/include/tmc/detail/topology.ipp
+++ b/include/tmc/detail/topology.ipp
@@ -121,7 +121,7 @@ std::vector<size_t> const& topology_filter::numa_indexes() const {
 
 size_t topology_filter::cpu_kinds() const { return cpu_kinds_; }
 
-namespace {
+namespace detail {
 std::vector<size_t> resolve_filter_to_cores(
   topology_filter const& filter, cpu_topology const& topo
 ) {
@@ -157,13 +157,13 @@ std::vector<size_t> resolve_filter_to_cores(
   // Output will be in sorted order since input is in sorted order
   return allowedCores;
 }
-} // namespace
+} // namespace detail
 
 topology_filter topology_filter::operator|(topology_filter const& rhs) const {
   cpu_topology topo = query();
 
-  std::vector<size_t> lhsCores = resolve_filter_to_cores(*this, topo);
-  std::vector<size_t> rhsCores = resolve_filter_to_cores(rhs, topo);
+  std::vector<size_t> lhsCores = detail::resolve_filter_to_cores(*this, topo);
+  std::vector<size_t> rhsCores = detail::resolve_filter_to_cores(rhs, topo);
 
   // Create a new filter that only includes the effective cores union
   topology_filter result;

--- a/include/tmc/detail/waiter_list.hpp
+++ b/include/tmc/detail/waiter_list.hpp
@@ -4,6 +4,7 @@
 // file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #pragma once
+#include "tmc/detail/compat.hpp"
 #include "tmc/detail/impl.hpp" // IWYU pragma: keep
 
 // Common implementation bits of mutex, semaphore, auto_reset_event,
@@ -83,21 +84,21 @@ public:
 // Utilities used by various awaitables that hold a waiter_list
 // such as mutex, semaphore, and auto_reset_event.
 
-static inline constexpr size_t WAITERS_OFFSET = TMC_PLATFORM_BITS / 2;
-static inline constexpr size_t HALF_MASK =
+TMC_STATIC_LINKAGE constexpr size_t WAITERS_OFFSET = TMC_PLATFORM_BITS / 2;
+TMC_STATIC_LINKAGE constexpr size_t HALF_MASK =
   (TMC_ONE_BIT << (TMC_PLATFORM_BITS / 2)) - 1;
 
 using half_word =
   std::conditional_t<TMC_PLATFORM_BITS == 64, uint32_t, uint16_t>;
 
-static inline void unpack_value(
+TMC_STATIC_LINKAGE void unpack_value(
   size_t Value, half_word& Count_out, size_t& WaiterCount_out
 ) noexcept {
   Count_out = static_cast<half_word>(Value & HALF_MASK);
   WaiterCount_out = (Value >> WAITERS_OFFSET) & HALF_MASK;
 }
 
-static inline size_t pack_value(half_word Count, size_t WaiterCount) noexcept {
+TMC_STATIC_LINKAGE size_t pack_value(half_word Count, size_t WaiterCount) noexcept {
   return (WaiterCount << WAITERS_OFFSET) | static_cast<size_t>(Count);
 }
 

--- a/include/tmc/topology.hpp
+++ b/include/tmc/topology.hpp
@@ -12,8 +12,7 @@
 #include <cstddef>
 #include <vector>
 
-namespace tmc {
-namespace topology {
+namespace tmc::topology {
 /// CPU kind types for hybrid architectures (P-cores vs E-cores).
 /// cpu_kind is a flags bitmap; you can OR together multiple flags to combine
 /// them in a filter.
@@ -239,8 +238,7 @@ TMC_DECL void pin_thread(topology_filter const& Allowed);
 
 #endif
 
-} // namespace topology
-} // namespace tmc
+} // namespace tmc::topology
 
 #if !defined(TMC_STANDALONE_COMPILATION) || defined(TMC_IMPL)
 #include "tmc/detail/topology.ipp"

--- a/include/tmc/traits.hpp
+++ b/include/tmc/traits.hpp
@@ -5,11 +5,11 @@
 
 #pragma once
 
+#include "tmc/detail/compat.hpp"
 #include "tmc/detail/concepts_awaitable.hpp"
 #include "tmc/detail/concepts_work_item.hpp"
 
-namespace tmc {
-namespace traits {
+namespace tmc::traits {
 /// If this type is returned from a type trait, it indicates that the type trait
 /// doesn't apply to whatever you're inspecting. For example, `unknown_t` will
 /// be returned from `awaitable_result_t` if the provided type is not an
@@ -66,7 +66,7 @@ using executable_kind = tmc::detail::executable_kind;
 /// - Else if T is a callable type, returns `executable_kind::CALLABLE`.
 /// - Else returns `executable_kind::UNKNOWN`.
 template <typename T>
-static inline constexpr executable_kind executable_kind_v =
+TMC_STATIC_LINKAGE constexpr executable_kind executable_kind_v =
   tmc::detail::executable_kind_v<T>;
 
 /// - If T is an awaitable type, returns `awaitable_result_t<T>`.
@@ -129,5 +129,4 @@ concept is_func_nonvoid = tmc::detail::is_func_nonvoid<T>;
 template <typename T, typename Result>
 concept is_func_result = tmc::detail::is_func_result<T, Result>;
 
-} // namespace traits
-} // namespace tmc
+} // namespace tmc::traits

--- a/modules/tmc.cppm
+++ b/modules/tmc.cppm
@@ -1,0 +1,147 @@
+// Copyright (c) 2023-2026 Logan McDougall
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+module;
+
+#include <tmc/all_headers.hpp>
+
+export module tmc;
+
+export namespace tmc {
+    using tmc::async_main;
+    using tmc::atomic_condvar;
+    using tmc::auto_reset_event;
+    using tmc::aw_acquire;
+    using tmc::aw_atomic_condvar;
+    using tmc::aw_atomic_condvar_co_notify;
+    using tmc::aw_auto_reset_event_co_set;
+    using tmc::aw_barrier;
+    using tmc::aw_ex_scope_enter;
+    using tmc::aw_ex_scope_exit;
+    using tmc::aw_fork_clang;
+    using tmc::aw_fork_group;
+    using tmc::aw_fork_tuple_clang;
+    using tmc::aw_manual_reset_event;
+    using tmc::aw_manual_reset_event_co_set;
+    using tmc::aw_mutex_co_unlock;
+    using tmc::aw_mutex_lock_scope;
+    using tmc::aw_reschedule;
+    using tmc::aw_resume_on;
+    using tmc::aw_semaphore_acquire_scope;
+    using tmc::aw_semaphore_co_release;
+    using tmc::aw_spawn;
+    using tmc::aw_spawn_fork;
+    using tmc::aw_spawn_fork_impl;
+    using tmc::aw_spawn_func;
+    using tmc::aw_spawn_func_fork;
+    using tmc::aw_spawn_func_fork_impl;
+    using tmc::aw_spawn_func_impl;
+    using tmc::aw_spawn_group;
+    using tmc::aw_spawn_impl;
+    using tmc::aw_spawn_many;
+    using tmc::aw_spawn_many_each;
+    using tmc::aw_spawn_many_fork;
+    using tmc::aw_spawn_many_impl;
+    using tmc::aw_spawn_tuple;
+    using tmc::aw_spawn_tuple_each;
+    using tmc::aw_spawn_tuple_fork;
+    using tmc::aw_spawn_tuple_impl;
+    using tmc::aw_task;
+    using tmc::aw_yield;
+    using tmc::aw_yield_counter;
+    using tmc::aw_yield_counter_dynamic;
+    using tmc::aw_yield_if_requested;
+    using tmc::barrier;
+    using tmc::chan_default_config;
+    using tmc::chan_err;
+    using tmc::chan_tok;
+    using tmc::chan_zc_scope;
+    using tmc::chan_zc_scope;
+    using tmc::change_priority;
+    using tmc::channel;
+    using tmc::check_yield_counter;
+    using tmc::check_yield_counter_dynamic;
+    using tmc::cpu_executor;
+    using tmc::current_executor;
+    using tmc::current_priority;
+    using tmc::current_thread_index;
+    using tmc::enter;
+    using tmc::ex_any;
+    using tmc::ex_braid;
+    using tmc::ex_cpu;
+    using tmc::ex_cpu_st;
+    using tmc::ex_manual_st;
+    using tmc::fork_clang;
+    using tmc::fork_group;
+    using tmc::fork_tuple_clang;
+    using tmc::iter_adapter;
+    using tmc::latch;
+    using tmc::make_channel;
+    using tmc::manual_reset_event;
+    using tmc::mutex;
+    using tmc::mutex_scope;
+    using tmc::post;
+    using tmc::post_bulk;
+    using tmc::post_bulk_waitable;
+    using tmc::post_waitable;
+    using tmc::reschedule;
+    using tmc::resume_on;
+    using tmc::semaphore;
+    using tmc::semaphore_scope;
+    using tmc::set_default_executor;
+    using tmc::spawn;
+    using tmc::spawn_clang;
+    using tmc::spawn_func;
+    using tmc::spawn_func_many;
+    using tmc::spawn_group;
+    using tmc::spawn_many;
+    using tmc::spawn_tuple;
+    using tmc::task;
+    using tmc::work_item;
+    using tmc::yield;
+    using tmc::yield_if_requested;
+    using tmc::yield_requested;
+
+    namespace topology {
+        using tmc::topology::core_group;
+        using tmc::topology::cpu_kind;
+        using tmc::topology::thread_info;
+        using tmc::topology::thread_packing_strategy;
+        using tmc::topology::thread_pinning_level;
+
+        #ifdef TMC_USE_HWLOC
+        using tmc::topology::cpu_topology;
+        using tmc::topology::topology_filter;
+        using tmc::topology::pin_thread;
+        #endif
+    }
+
+    namespace traits {
+        using tmc::traits::awaitable_result_t;
+        using tmc::traits::callable_result_t;
+        using tmc::traits::executable_kind;
+        using tmc::traits::executable_kind_v;
+        using tmc::traits::executable_result_t;
+        using tmc::traits::executable_traits;
+        using tmc::traits::is_awaitable;
+        using tmc::traits::is_callable;
+        using tmc::traits::is_func;
+        using tmc::traits::is_func_nonvoid;
+        using tmc::traits::is_func_result;
+        using tmc::traits::is_func_void;
+        using tmc::traits::is_task;
+        using tmc::traits::is_task_nonvoid;
+        using tmc::traits::is_task_result;
+        using tmc::traits::is_task_void;
+        using tmc::traits::unknown_t;
+    }
+
+    namespace debug {
+        #ifdef TMC_DEBUG_TASK_ALLOC_COUNT
+        using tmc::debug::get_task_alloc_count;
+        using tmc::debug::set_task_alloc_count;
+        #endif
+    }
+}


### PR DESCRIPTION
This PR adds support for C++ modules, which currently must be manually compiled (no `CMakeLists.txt` exists).