### PR TITLE
Added a requirement on task::return_value

### DIFF
--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -284,7 +284,10 @@ template <typename Result> struct task_promise {
 
   template <typename RV>
   void
-  return_value(RV&& Value) noexcept(std::is_nothrow_move_constructible_v<RV>) {
+  return_value(RV&& Value) noexcept(std::is_nothrow_move_constructible_v<RV>)
+    requires(requires() {
+      { *customizer.result_ptr = static_cast<RV &&>(Value) };
+    }) {
     *customizer.result_ptr = static_cast<RV&&>(Value);
   }
 


### PR DESCRIPTION
This changes error message and squiggle to appear on every incorrect `co_return` statement rather than inside task.hpp if you attempt to `co_return` the incorrect type from a coroutine.