### PR TITLE
capture *_group continuation_executor at the await point

### DIFF
--- a/include/tmc/fork_group.hpp
+++ b/include/tmc/fork_group.hpp
@@ -79,17 +79,13 @@ public:
   /// Constructs an empty fork group. It is recommended to use
   /// `tmc::fork_group()` instead of this constructor.
   aw_fork_group()
-      : task_count{0},
-        continuation_executor{tmc::detail::this_thread::executor()},
-        done_count{0} {}
+      : task_count{0}, continuation_executor{nullptr}, done_count{0} {}
 
   /// Constructs an empty fork group with runtime size.
   /// It is recommended to use `tmc::fork_group(RuntimeMaxCount)` instead of
   /// this constructor.
   aw_fork_group(size_t RuntimeMaxCount)
-      : task_count{0},
-        continuation_executor{tmc::detail::this_thread::executor()},
-        done_count{0} {
+      : task_count{0}, continuation_executor{nullptr}, done_count{0} {
     if constexpr (MaxCount == 0 && !std::is_void_v<Result>) {
       assert(
         RuntimeMaxCount > 0 && "If Result is non-void, either MaxCount or "
@@ -104,9 +100,7 @@ public:
   /// constructor.
   template <typename Awaitable>
   aw_fork_group(Awaitable&& Aw)
-      : task_count{0},
-        continuation_executor{tmc::detail::this_thread::executor()},
-        done_count{0} {
+      : task_count{0}, continuation_executor{nullptr}, done_count{0} {
     fork(static_cast<Awaitable&&>(Aw));
   }
 
@@ -115,9 +109,7 @@ public:
   /// instead of this constructor.
   template <typename Awaitable>
   aw_fork_group(size_t RuntimeMaxCount, Awaitable&& Aw)
-      : task_count{0},
-        continuation_executor{tmc::detail::this_thread::executor()},
-        done_count{0} {
+      : task_count{0}, continuation_executor{nullptr}, done_count{0} {
     if constexpr (MaxCount == 0 && !std::is_void_v<Result>) {
       assert(
         RuntimeMaxCount > 0 &&
@@ -275,6 +267,12 @@ public:
     assert(done_count.load() >= 0 && "You may only co_await this once.");
 #endif
     continuation = Outer;
+    // fork_group can be awaited in a different context than where it was
+    // created. Therefore, capture the continuation_executor at the await point,
+    // unless it was overridden by resume_on().
+    if (continuation_executor == nullptr) {
+      continuation_executor = tmc::detail::this_thread::executor();
+    }
     std::coroutine_handle<> next;
     // This logic is necessary because we submitted all child tasks before
     // the parent suspended. Allowing parent to be resumed before it
@@ -286,8 +284,7 @@ public:
     if (remaining > 0) {
       next = std::noop_coroutine();
     } else { // Resume if remaining <= 0 (tasks already finished)
-      if (continuation_executor == nullptr ||
-          tmc::detail::this_thread::exec_is(continuation_executor)) {
+      if (tmc::detail::this_thread::exec_is(continuation_executor)) {
         next = Outer;
       } else {
         // Need to resume on a different executor

--- a/include/tmc/spawn_group.hpp
+++ b/include/tmc/spawn_group.hpp
@@ -65,7 +65,7 @@ public:
   aw_spawn_group()
       : task_count{0}, prio{tmc::detail::this_thread::this_task().prio},
         executor{tmc::detail::this_thread::executor()},
-        continuation_executor{tmc::detail::this_thread::executor()} {}
+        continuation_executor{nullptr} {}
 
   /// Constructs an empty spawn group. It is recommended to use
   /// `tmc::spawn_group(Awaitable&& Aw)` instead of this constructor.
@@ -73,7 +73,7 @@ public:
   aw_spawn_group(Awaitable&& Aw)
       : task_count{1}, prio{tmc::detail::this_thread::this_task().prio},
         executor{tmc::detail::this_thread::executor()},
-        continuation_executor{tmc::detail::this_thread::executor()} {
+        continuation_executor{nullptr} {
     if constexpr (MaxCount == 0) {
       tasks.push_back(std::move(Aw));
     } else {
@@ -172,6 +172,12 @@ public:
   /// Initiates all of the wrapped awaitables and waits for them to complete.
   aw_spawn_many_impl<Result, MaxCount, false, false>
   operator co_await() && noexcept {
+    // spawn_group can be awaited in a different context than where it was
+    // created. Therefore, capture the continuation_executor at the await point,
+    // unless it was overridden by resume_on().
+    if (continuation_executor == nullptr) {
+      continuation_executor = tmc::detail::this_thread::executor();
+    }
     if constexpr (MaxCount == 0) {
       return tmc::spawn_many(tasks.begin(), tasks.size())
         .with_priority(prio)
@@ -196,6 +202,12 @@ public:
     "You must co_await the fork() awaitable before it goes out of scope."
   )]]
   aw_spawn_many_fork<Result, MaxCount, false> fork() && noexcept {
+    // spawn_group can be awaited in a different context than where it was
+    // created. Therefore, capture the continuation_executor at the await point,
+    // unless it was overridden by resume_on().
+    if (continuation_executor == nullptr) {
+      continuation_executor = tmc::detail::this_thread::executor();
+    }
     if constexpr (MaxCount == 0) {
       return tmc::spawn_many(tasks.begin(), tasks.size())
         .with_priority(prio)


### PR DESCRIPTION
Previously the continuation_executor of `spawn_group` / `fork_group` was captured at the time that the group was created. This is consistent with the capturing behavior of all the other `spawn_*()` functions. However, the `spawn_*()` functions are typically used to fork-join within a single coroutine, but `spawn_group` / `fork_group` have different use cases:
- `spawn_group` can be used to construct a packaged group and return it so it may be dispatched + awaited later
- `fork_group` can be passed in to functions to dispatch work to an executor in a different context than where it was created

This causes issues when `tmc::current_executor()` returns different values at construction time vs. await time.

Both of these types may also be constructed as static / global and have tasks dispatched to them, then awaited later during resource cleanup. This should be a clean way to ensure all tasks are complete before application shutdown (as opposed to raw `tmc::post()` / `.detach()` which don't allow shutdown synchronization). However, when these are static / global, their constructor runs before any executor is created, capturing nullptr as the continuation_executor. This breaks when they are eventually awaited, even if they are being awaited from a task with a valid executor.

---

The solution which maintains the general invariant "awaiting tasks resume back on their original executor" for these types is to capture the continuation_executor at await time, rather than constructor time. This does not affect the behavior when the `.resume_on()` customizer is called - it always overrides the default continuation_executor.

I'm also considering whether this behavior should be generalized to all of the `spawn_*()` functions, as I think it's possible to trigger the erroneous behavior with them as well - but you would have to really try to do so. For now this fix is targeted only at the most likely sources of  this error, where using them as intended could trigger this problem.