### PR TITLE
Add CMake config/install setup, add conanfile.py and vcpkg ports/ folder

### DIFF
--- a/.github/workflows/arm64-macos-clang.yml
+++ b/.github/workflows/arm64-macos-clang.yml
@@ -34,7 +34,7 @@ jobs:
       # continue-on-error: true # this should never fail if triggered from TMC workflow
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DCMD_COMPILE_FLAGS='-Werror;-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}}' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(sysctl -n hw.logicalcpu) --target all
     - name: run tests

--- a/.github/workflows/arm64-macos-clang.yml
+++ b/.github/workflows/arm64-macos-clang.yml
@@ -18,6 +18,8 @@ jobs:
         PRESET: [clang-macos-debug, clang-macos-release]
         WORK_ITEM: [CORO, FUNCORO]
     steps:
+    - name: install-hwloc
+      run: brew install hwloc
     - uses: actions/checkout@v4
       with:
         repository: tzcnt/tmc-examples

--- a/.github/workflows/coverage-bitmaps.yml
+++ b/.github/workflows/coverage-bitmaps.yml
@@ -40,7 +40,7 @@ jobs:
       # continue-on-error: true # this should never fail if triggered from TMC workflow
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_USE_HWLOC=${{matrix.HWLOC}} -DCMD_COMPILE_FLAGS='-Werror;-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}}${{matrix.THREADS == 'ON' && ';-DTMC_MORE_THREADS' || ''}}${{matrix.WORK_ITEM == 'FUNC' && ';-DTMC_TRIVIAL_TASK' || ''}};-fprofile-instr-generate;-fcoverage-mapping' -DCMD_LINK_FLAGS='-Wl,--build-id;-fprofile-instr-generate;-fcoverage-mapping' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_USE_HWLOC=${{matrix.HWLOC}} -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} ${{matrix.THREADS == 'ON' && '-DTMC_MORE_THREADS=ON' || ''}} ${{matrix.WORK_ITEM == 'FUNC' && '-DTMC_TRIVIAL_TASK=ON' || ''}} -DCMD_COMPILE_FLAGS='-Werror;-fprofile-instr-generate;-fcoverage-mapping' -DCMD_LINK_FLAGS='-Wl,--build-id;-fprofile-instr-generate;-fcoverage-mapping' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests

--- a/.github/workflows/coverage-docker.yml
+++ b/.github/workflows/coverage-docker.yml
@@ -41,7 +41,7 @@ jobs:
         RUN apt-get update && apt-get install -y cmake ninja-build git libhwloc-dev hwloc
         WORKDIR /src
         COPY . .
-        RUN cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_USE_HWLOC=${{matrix.HWLOC}} -DCMD_COMPILE_FLAGS='-Werror;-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}}${{matrix.WORK_ITEM == 'FUNC' && ';-DTMC_TRIVIAL_TASK' || ''}};-fprofile-instr-generate;-fcoverage-mapping' -DCMD_LINK_FLAGS='-Wl,--build-id;-fprofile-instr-generate;-fcoverage-mapping' --preset ${{matrix.PRESET}} .
+        RUN cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_USE_HWLOC=${{matrix.HWLOC}} -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} ${{matrix.WORK_ITEM == 'FUNC' && '-DTMC_TRIVIAL_TASK=ON' || ''}} -DCMD_COMPILE_FLAGS='-Werror;-fprofile-instr-generate;-fcoverage-mapping' -DCMD_LINK_FLAGS='-Wl,--build-id;-fprofile-instr-generate;-fcoverage-mapping' --preset ${{matrix.PRESET}} .
         RUN cmake --build ./build/${{matrix.PRESET}} --parallel 16 --target test_container
         WORKDIR /src/build/${{matrix.PRESET}}/tests
         EOF

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -39,7 +39,7 @@ jobs:
       # continue-on-error: true # this should never fail if triggered from TMC workflow
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_USE_HWLOC=${{matrix.HWLOC}} -DCMD_COMPILE_FLAGS='-Werror;-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}}${{matrix.WORK_ITEM == 'FUNC' && ';-DTMC_TRIVIAL_TASK' || ''}};-fprofile-instr-generate;-fcoverage-mapping' -DCMD_LINK_FLAGS='-Wl,--build-id;-fprofile-instr-generate;-fcoverage-mapping' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_USE_HWLOC=${{matrix.HWLOC}} -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} ${{matrix.WORK_ITEM == 'FUNC' && '-DTMC_TRIVIAL_TASK=ON' || ''}} -DCMD_COMPILE_FLAGS='-Werror;-fprofile-instr-generate;-fcoverage-mapping' -DCMD_LINK_FLAGS='-Wl,--build-id;-fprofile-instr-generate;-fcoverage-mapping' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests

--- a/.github/workflows/topology.yml
+++ b/.github/workflows/topology.yml
@@ -38,7 +38,7 @@ jobs:
       # continue-on-error: true # this should never fail if triggered from TMC workflow
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DCMD_COMPILE_FLAGS='-Werror;-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}}' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target hwloc_topo
     - name: run tests

--- a/.github/workflows/x64-linux-clang-asan.yml
+++ b/.github/workflows/x64-linux-clang-asan.yml
@@ -34,7 +34,7 @@ jobs:
       # continue-on-error: true # this should never fail if triggered from TMC workflow
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DCMD_COMPILE_FLAGS='-Werror;-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}};-fsanitize=address' -DCMD_LINK_FLAGS='-fsanitize=address' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror;-fsanitize=address' -DCMD_LINK_FLAGS='-fsanitize=address' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests

--- a/.github/workflows/x64-linux-clang-asan.yml
+++ b/.github/workflows/x64-linux-clang-asan.yml
@@ -18,6 +18,8 @@ jobs:
         PRESET: [clang-linux-debug,clang-linux-release]
         WORK_ITEM: [CORO,FUNCORO]
     steps:
+    - name: install-hwloc
+      run: sudo apt-get update && sudo apt-get install -y hwloc libhwloc-dev
     - uses: actions/checkout@v4
       with:
         repository: tzcnt/tmc-examples

--- a/.github/workflows/x64-linux-clang-tsan.yml
+++ b/.github/workflows/x64-linux-clang-tsan.yml
@@ -34,7 +34,7 @@ jobs:
       # continue-on-error: true # this should never fail if triggered from TMC workflow
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DCMD_COMPILE_FLAGS='-Werror;-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}};-fsanitize=thread' -DCMD_LINK_FLAGS='-fsanitize=thread' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror;-fsanitize=thread' -DCMD_LINK_FLAGS='-fsanitize=thread' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests

--- a/.github/workflows/x64-linux-clang-tsan.yml
+++ b/.github/workflows/x64-linux-clang-tsan.yml
@@ -18,6 +18,8 @@ jobs:
         PRESET: [clang-linux-debug,clang-linux-release]
         WORK_ITEM: [CORO,FUNCORO]
     steps:
+    - name: install-hwloc
+      run: sudo apt-get update && sudo apt-get install -y hwloc libhwloc-dev
     - uses: actions/checkout@v4
       with:
         repository: tzcnt/tmc-examples

--- a/.github/workflows/x64-linux-clang-ubsan.yml
+++ b/.github/workflows/x64-linux-clang-ubsan.yml
@@ -34,7 +34,7 @@ jobs:
       # continue-on-error: true # this should never fail if triggered from TMC workflow
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DCMD_COMPILE_FLAGS='-Werror;-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}};-fsanitize=undefined;-fno-sanitize-recover' -DCMD_LINK_FLAGS='-fsanitize=undefined' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror;-fsanitize=undefined;-fno-sanitize-recover' -DCMD_LINK_FLAGS='-fsanitize=undefined' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests

--- a/.github/workflows/x64-linux-clang-ubsan.yml
+++ b/.github/workflows/x64-linux-clang-ubsan.yml
@@ -18,6 +18,8 @@ jobs:
         PRESET: [clang-linux-debug,clang-linux-release]
         WORK_ITEM: [CORO,FUNCORO]
     steps:
+    - name: install-hwloc
+      run: sudo apt-get update && sudo apt-get install -y hwloc libhwloc-dev
     - uses: actions/checkout@v4
       with:
         repository: tzcnt/tmc-examples

--- a/.github/workflows/x64-linux-clang.yml
+++ b/.github/workflows/x64-linux-clang.yml
@@ -34,7 +34,7 @@ jobs:
       # continue-on-error: true # this should never fail if triggered from TMC workflow
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DCMD_COMPILE_FLAGS='-Werror;-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}}' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests

--- a/.github/workflows/x64-linux-clang.yml
+++ b/.github/workflows/x64-linux-clang.yml
@@ -18,6 +18,8 @@ jobs:
         PRESET: [clang-linux-debug, clang-linux-release]
         WORK_ITEM: [CORO, FUNCORO]
     steps:
+    - name: install-hwloc
+      run: sudo apt-get update && sudo apt-get install -y hwloc libhwloc-dev
     - uses: actions/checkout@v4
       with:
         repository: tzcnt/tmc-examples

--- a/.github/workflows/x64-linux-gcc.yml
+++ b/.github/workflows/x64-linux-gcc.yml
@@ -34,7 +34,7 @@ jobs:
       # continue-on-error: true # this should never fail if triggered from TMC workflow
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DCMD_COMPILE_FLAGS='-Werror;-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}}' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests

--- a/.github/workflows/x64-linux-gcc.yml
+++ b/.github/workflows/x64-linux-gcc.yml
@@ -18,6 +18,8 @@ jobs:
         PRESET: [gcc-linux-debug, gcc-linux-release]
         WORK_ITEM: [CORO, FUNCORO]
     steps:
+    - name: install-hwloc
+      run: sudo apt-get update && sudo apt-get install -y hwloc libhwloc-dev
     - uses: actions/checkout@v4
       with:
         repository: tzcnt/tmc-examples

--- a/.github/workflows/x64-windows-clang-cl.yml
+++ b/.github/workflows/x64-windows-clang-cl.yml
@@ -35,7 +35,7 @@ jobs:
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - uses: ilammy/msvc-dev-cmd@v1
     - name: configure
-      run: cmake -G "Ninja" -DTMC_AS_SUBMODULE=ON -DCMD_COMPILE_FLAGS='-Werror;-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}}' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Ninja" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --target all
     - name: run tests

--- a/.github/workflows/x86-linux-clang.yml
+++ b/.github/workflows/x86-linux-clang.yml
@@ -36,7 +36,7 @@ jobs:
       # continue-on-error: true # this should never fail if triggered from TMC workflow
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DCMD_COMPILE_FLAGS='-Werror;-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}};-m32' -DCMD_LINK_FLAGS='-m32' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror;-m32' -DCMD_LINK_FLAGS='-m32' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests

--- a/.github/workflows/x86-linux-clang.yml
+++ b/.github/workflows/x86-linux-clang.yml
@@ -36,7 +36,7 @@ jobs:
       # continue-on-error: true # this should never fail if triggered from TMC workflow
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror;-m32' -DCMD_LINK_FLAGS='-m32' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_USE_HWLOC=OFF -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror;-m32' -DCMD_LINK_FLAGS='-m32' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests

--- a/.github/workflows/x86-linux-gcc.yml
+++ b/.github/workflows/x86-linux-gcc.yml
@@ -36,7 +36,7 @@ jobs:
       # continue-on-error: true # this should never fail if triggered from TMC workflow
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14 -DTMC_AS_SUBMODULE=ON -DCMD_COMPILE_FLAGS='-Werror;-DTMC_WORK_ITEM=${{matrix.WORK_ITEM}};-m32' -DCMD_LINK_FLAGS='-m32' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14 -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror;-m32' -DCMD_LINK_FLAGS='-m32' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests

--- a/.github/workflows/x86-linux-gcc.yml
+++ b/.github/workflows/x86-linux-gcc.yml
@@ -36,7 +36,7 @@ jobs:
       # continue-on-error: true # this should never fail if triggered from TMC workflow
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14 -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror;-m32' -DCMD_LINK_FLAGS='-m32' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14 -DTMC_AS_SUBMODULE=ON -DTMC_USE_HWLOC=OFF -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror;-m32' -DCMD_LINK_FLAGS='-m32' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,112 @@
+cmake_minimum_required(VERSION 3.16)
+project(TooManyCooks LANGUAGES CXX)
+
+# ---- Dependency Options ----
+option(TMC_USE_HWLOC "Enable hwloc topology-aware thread placement" ON)
+option(TMC_USE_BOOST_ASIO "Use boost::asio instead of standalone asio" OFF)
+
+# ---- Configuration Options ----
+set(TMC_WORK_ITEM "CORO" CACHE STRING "Work item type: CORO or FUNCORO")
+set_property(CACHE TMC_WORK_ITEM PROPERTY STRINGS "CORO" "FUNCORO")
+
+option(TMC_TRIVIAL_TASK "Enable trivial task optimization" OFF)
+option(TMC_NODISCARD_AWAIT "Enable [[nodiscard]] on co_await" OFF)
+
+set(TMC_PRIORITY_COUNT "" CACHE STRING "Number of priority levels (1-16, empty for default)")
+
+option(TMC_MORE_THREADS "Allow more than 64 threads" OFF)
+option(TMC_DEBUG_TASK_ALLOC_COUNT "Track task allocation count for HALO analysis" OFF)
+option(TMC_DEBUG_THREAD_CREATION "Print thread creation and work stealing info" OFF)
+
+# ---- Build Mode Options ----
+option(TMC_STANDALONE_COMPILATION "Enable standalone compilation mode" OFF)
+if(WIN32)
+    option(TMC_WINDOWS_DLL "Enable Windows DLL mode" OFF)
+endif()
+
+# ---- INTERFACE library target ----
+add_library(tmc INTERFACE)
+add_library(tmc::tmc ALIAS tmc)
+
+target_include_directories(tmc INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+
+target_compile_features(tmc INTERFACE cxx_std_20)
+
+# ---- Propagate preprocessor defines ----
+if(TMC_USE_HWLOC)
+    target_compile_definitions(tmc INTERFACE TMC_USE_HWLOC)
+endif()
+
+if(TMC_USE_BOOST_ASIO)
+    target_compile_definitions(tmc INTERFACE TMC_USE_BOOST_ASIO)
+endif()
+
+if(TMC_WORK_ITEM STREQUAL "FUNCORO")
+    target_compile_definitions(tmc INTERFACE "TMC_WORK_ITEM=FUNCORO")
+endif()
+
+if(TMC_TRIVIAL_TASK)
+    target_compile_definitions(tmc INTERFACE TMC_TRIVIAL_TASK)
+endif()
+
+if(TMC_NODISCARD_AWAIT)
+    target_compile_definitions(tmc INTERFACE TMC_NODISCARD_AWAIT)
+endif()
+
+if(NOT "${TMC_PRIORITY_COUNT}" STREQUAL "")
+    target_compile_definitions(tmc INTERFACE "TMC_PRIORITY_COUNT=${TMC_PRIORITY_COUNT}")
+endif()
+
+if(TMC_MORE_THREADS)
+    target_compile_definitions(tmc INTERFACE TMC_MORE_THREADS)
+endif()
+
+if(TMC_DEBUG_TASK_ALLOC_COUNT)
+    target_compile_definitions(tmc INTERFACE TMC_DEBUG_TASK_ALLOC_COUNT)
+endif()
+
+if(TMC_DEBUG_THREAD_CREATION)
+    target_compile_definitions(tmc INTERFACE TMC_DEBUG_THREAD_CREATION)
+endif()
+
+if(TMC_STANDALONE_COMPILATION)
+    target_compile_definitions(tmc INTERFACE TMC_STANDALONE_COMPILATION)
+endif()
+
+if(WIN32 AND TMC_WINDOWS_DLL)
+    target_compile_definitions(tmc INTERFACE TMC_WINDOWS_DLL)
+endif()
+
+# ---- Dependencies ----
+
+# hwloc
+if(TMC_USE_HWLOC)
+    if(NOT TARGET hwloc::hwloc)
+        find_library(HWLOC_LIBRARY NAMES hwloc)
+        find_path(HWLOC_INCLUDE_DIR NAMES hwloc.h)
+        if(HWLOC_LIBRARY AND HWLOC_INCLUDE_DIR)
+            message(STATUS "TooManyCooks: Found hwloc: ${HWLOC_LIBRARY}")
+            add_library(hwloc::hwloc UNKNOWN IMPORTED)
+            set_target_properties(hwloc::hwloc PROPERTIES
+                IMPORTED_LOCATION "${HWLOC_LIBRARY}"
+                INTERFACE_INCLUDE_DIRECTORIES "${HWLOC_INCLUDE_DIR}"
+            )
+        else()
+            message(FATAL_ERROR
+                "TMC_USE_HWLOC is ON but hwloc was not found. "
+                "Install libhwloc-dev (Debian/Ubuntu) or set -DTMC_USE_HWLOC=OFF. "
+                "On Windows, create an hwloc::hwloc imported target before add_subdirectory()."
+            )
+        endif()
+    endif()
+    target_link_libraries(tmc INTERFACE hwloc::hwloc)
+endif()
+
+# pthreads
+if(CMAKE_SYSTEM_NAME MATCHES "Linux|FreeBSD")
+    find_package(Threads REQUIRED)
+    target_link_libraries(tmc INTERFACE Threads::Threads)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 3.16)
-project(TooManyCooks LANGUAGES CXX)
+project(TooManyCooks VERSION 1.5.0 LANGUAGES CXX)
 
 # ---- Dependency Options ----
+# all options are documented in detail at https://www.fleetcode.com/oss/tmc/docs/dev/build_flags.html
 option(TMC_USE_HWLOC "Enable hwloc topology-aware thread placement" ON)
 option(TMC_USE_BOOST_ASIO "Use boost::asio instead of standalone asio" OFF)
 
@@ -12,101 +13,63 @@ set_property(CACHE TMC_WORK_ITEM PROPERTY STRINGS "CORO" "FUNCORO")
 option(TMC_TRIVIAL_TASK "Enable trivial task optimization" OFF)
 option(TMC_NODISCARD_AWAIT "Enable [[nodiscard]] on co_await" OFF)
 
-set(TMC_PRIORITY_COUNT "" CACHE STRING "Number of priority levels (1-16, empty for default)")
+set(TMC_PRIORITY_COUNT "" CACHE STRING "Number of priority levels (1-16, empty for runtime-configurable)")
 
 option(TMC_MORE_THREADS "Allow more than 64 threads" OFF)
 option(TMC_DEBUG_TASK_ALLOC_COUNT "Track task allocation count for HALO analysis" OFF)
 option(TMC_DEBUG_THREAD_CREATION "Print thread creation and work stealing info" OFF)
 
 # ---- Build Mode Options ----
-option(TMC_STANDALONE_COMPILATION "Enable standalone compilation mode" OFF)
+option(TMC_HEADER_ONLY "Enable header-only mode" ON)
+
 if(WIN32)
     option(TMC_WINDOWS_DLL "Enable Windows DLL mode" OFF)
 endif()
 
-# ---- INTERFACE library target ----
-add_library(tmc INTERFACE)
-add_library(tmc::tmc ALIAS tmc)
+if(TMC_WINDOWS_DLL AND TMC_HEADER_ONLY)
+    message(FATAL_ERROR "TMC_WINDOWS_DLL requires TMC_HEADER_ONLY=OFF")
+endif()
 
-target_include_directories(tmc INTERFACE
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+# ---- INTERFACE library target ----
+add_library(TooManyCooks INTERFACE)
+add_library(TooManyCooks::TooManyCooks ALIAS TooManyCooks)
+
+target_include_directories(TooManyCooks INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )
 
-target_compile_features(tmc INTERFACE cxx_std_20)
+target_compile_features(TooManyCooks INTERFACE cxx_std_20)
 
-# ---- Propagate preprocessor defines ----
-if(TMC_USE_HWLOC)
-    target_compile_definitions(tmc INTERFACE TMC_USE_HWLOC)
-endif()
-
-if(TMC_USE_BOOST_ASIO)
-    target_compile_definitions(tmc INTERFACE TMC_USE_BOOST_ASIO)
-endif()
-
-if(TMC_WORK_ITEM STREQUAL "FUNCORO")
-    target_compile_definitions(tmc INTERFACE "TMC_WORK_ITEM=FUNCORO")
-endif()
-
-if(TMC_TRIVIAL_TASK)
-    target_compile_definitions(tmc INTERFACE TMC_TRIVIAL_TASK)
-endif()
-
-if(TMC_NODISCARD_AWAIT)
-    target_compile_definitions(tmc INTERFACE TMC_NODISCARD_AWAIT)
-endif()
-
-if(NOT "${TMC_PRIORITY_COUNT}" STREQUAL "")
-    target_compile_definitions(tmc INTERFACE "TMC_PRIORITY_COUNT=${TMC_PRIORITY_COUNT}")
-endif()
-
-if(TMC_MORE_THREADS)
-    target_compile_definitions(tmc INTERFACE TMC_MORE_THREADS)
-endif()
-
-if(TMC_DEBUG_TASK_ALLOC_COUNT)
-    target_compile_definitions(tmc INTERFACE TMC_DEBUG_TASK_ALLOC_COUNT)
-endif()
-
-if(TMC_DEBUG_THREAD_CREATION)
-    target_compile_definitions(tmc INTERFACE TMC_DEBUG_THREAD_CREATION)
-endif()
-
-if(TMC_STANDALONE_COMPILATION)
-    target_compile_definitions(tmc INTERFACE TMC_STANDALONE_COMPILATION)
-endif()
-
-if(WIN32 AND TMC_WINDOWS_DLL)
-    target_compile_definitions(tmc INTERFACE TMC_WINDOWS_DLL)
-endif()
+# Map CMake options onto INTERFACE-scoped preprocessor definitions
+include(${CMAKE_CURRENT_LIST_DIR}/cmake/tmc-options.cmake)
+tmc_apply_options(TooManyCooks)
 
 # ---- Dependencies ----
 
 # hwloc
 if(TMC_USE_HWLOC)
-    if(NOT TARGET hwloc::hwloc)
-        find_library(HWLOC_LIBRARY NAMES hwloc)
-        find_path(HWLOC_INCLUDE_DIR NAMES hwloc.h)
-        if(HWLOC_LIBRARY AND HWLOC_INCLUDE_DIR)
-            message(STATUS "TooManyCooks: Found hwloc: ${HWLOC_LIBRARY}")
-            add_library(hwloc::hwloc UNKNOWN IMPORTED)
-            set_target_properties(hwloc::hwloc PROPERTIES
-                IMPORTED_LOCATION "${HWLOC_LIBRARY}"
-                INTERFACE_INCLUDE_DIRECTORIES "${HWLOC_INCLUDE_DIR}"
-            )
-        else()
-            message(FATAL_ERROR
-                "TMC_USE_HWLOC is ON but hwloc was not found. "
-                "Install libhwloc-dev (Debian/Ubuntu) or set -DTMC_USE_HWLOC=OFF. "
-                "On Windows, create an hwloc::hwloc imported target before add_subdirectory()."
-            )
-        endif()
+    include(${CMAKE_CURRENT_LIST_DIR}/cmake/tmc-find-hwloc.cmake)
+    tmc_find_hwloc()
+
+    if(NOT TMC_HWLOC_FOUND)
+        message(FATAL_ERROR
+            "TMC_USE_HWLOC is ON but hwloc was not found. "
+            "Install libhwloc-dev (Debian/Ubuntu) or set -DTMC_USE_HWLOC=OFF. "
+            "On Windows, create an hwloc::hwloc imported target before add_subdirectory()."
+        )
     endif()
-    target_link_libraries(tmc INTERFACE hwloc::hwloc)
+
+    target_link_libraries(TooManyCooks INTERFACE hwloc::hwloc)
 endif()
 
 # pthreads
 if(CMAKE_SYSTEM_NAME MATCHES "Linux|FreeBSD")
     find_package(Threads REQUIRED)
-    target_link_libraries(tmc INTERFACE Threads::Threads)
+    target_link_libraries(TooManyCooks INTERFACE Threads::Threads)
+endif()
+
+# hide install target when used as a subproject
+if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+    include(${CMAKE_CURRENT_LIST_DIR}/cmake/tmc-install.cmake)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,14 +20,14 @@ option(TMC_DEBUG_TASK_ALLOC_COUNT "Track task allocation count for HALO analysis
 option(TMC_DEBUG_THREAD_CREATION "Print thread creation and work stealing info" OFF)
 
 # ---- Build Mode Options ----
-option(TMC_HEADER_ONLY "Enable header-only mode" ON)
+option(TMC_STANDALONE_COMPILATION "Disable header-only mode. Library will be built into the file that defines TMC_IMPL" OFF)
 
 if(WIN32)
     option(TMC_WINDOWS_DLL "Enable Windows DLL mode" OFF)
 endif()
 
-if(TMC_WINDOWS_DLL AND TMC_HEADER_ONLY)
-    message(FATAL_ERROR "TMC_WINDOWS_DLL requires TMC_HEADER_ONLY=OFF")
+if(TMC_WINDOWS_DLL AND NOT TMC_STANDALONE_COMPILATION)
+    message(FATAL_ERROR "TMC_WINDOWS_DLL requires TMC_STANDALONE_COMPILATION=ON")
 endif()
 
 # ---- INTERFACE library target ----

--- a/README.md
+++ b/README.md
@@ -62,6 +62,18 @@ It also offers the option to create a [standalone compilation file](https://gith
 
 For a minimal project template, see [tmc-hello-world](https://github.com/tzcnt/tmc-hello-world).
 
+TooManyCooks can also be installed with vcpkg from this repository's overlay port:
+```sh
+vcpkg install toomanycooks --overlay-ports=ports
+```
+Then consume it from CMake:
+```cmake
+find_package(TooManyCooks CONFIG REQUIRED)
+target_link_libraries(your_target PRIVATE TooManyCooks::TooManyCooks)
+```
+
+The vcpkg port enables `hwloc` by default. In classic mode, install `toomanycooks[core]` to install without hwloc. Optional features include `standalone-asio`, `boost-asio`, `funcoro`, `trivial-task`, `nodiscard-await`, `more-threads`, `standalone-compilation`, and `windows-dll`.
+
 Versions prior to v1.5 (the current dev version) require the creation of a standalone compilation file. For the latest stable release (v1.4) see the [older version of the README](https://github.com/tzcnt/TooManyCooks/tree/v1.4.0?tab=readme-ov-file#building) for build instructions.
 
 ### Configuration

--- a/cmake/TooManyCooksConfig.cmake.in
+++ b/cmake/TooManyCooksConfig.cmake.in
@@ -1,0 +1,19 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+if(@TMC_USE_HWLOC@)
+    include("${CMAKE_CURRENT_LIST_DIR}/TmcFindHwloc.cmake")
+    tmc_find_hwloc()
+    if(NOT TMC_HWLOC_FOUND)
+        set(${CMAKE_FIND_PACKAGE_NAME}_NOT_FOUND_MESSAGE "TMC_USE_HWLOC is ON but hwloc was not found")
+        set(${CMAKE_FIND_PACKAGE_NAME}_FOUND FALSE)
+        return()
+    endif()
+endif()
+
+if(CMAKE_SYSTEM_NAME MATCHES "Linux|FreeBSD")
+    find_dependency(Threads)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/TooManyCooksTargets.cmake")

--- a/cmake/TooManyCooksConfig.cmake.in
+++ b/cmake/TooManyCooksConfig.cmake.in
@@ -3,7 +3,7 @@
 include(CMakeFindDependencyMacro)
 
 if(@TMC_USE_HWLOC@)
-    include("${CMAKE_CURRENT_LIST_DIR}/TmcFindHwloc.cmake")
+    include("${CMAKE_CURRENT_LIST_DIR}/tmc-find-hwloc.cmake")
     tmc_find_hwloc()
     if(NOT TMC_HWLOC_FOUND)
         set(${CMAKE_FIND_PACKAGE_NAME}_NOT_FOUND_MESSAGE "TMC_USE_HWLOC is ON but hwloc was not found")

--- a/cmake/TooManyCooksConfig.cmake.in
+++ b/cmake/TooManyCooksConfig.cmake.in
@@ -17,3 +17,35 @@ if(CMAKE_SYSTEM_NAME MATCHES "Linux|FreeBSD")
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/TooManyCooksTargets.cmake")
+
+# vcpkg doesn't support setting TMC_PRIORITY_COUNT as a feature. This means it can't be configured before being installed.
+# The below script allows the user to set TMC_PRIORITY_COUNT before calling find_package in their CMake project.
+if(DEFINED TMC_PRIORITY_COUNT AND NOT "${TMC_PRIORITY_COUNT}" STREQUAL "")
+    if(NOT "${TMC_PRIORITY_COUNT}" MATCHES "^([1-9]|1[0-6])$")
+        message(FATAL_ERROR "TMC_PRIORITY_COUNT must be an integer from 1 to 16")
+    endif()
+
+    get_target_property(_TooManyCooks_COMPILE_DEFINITIONS TooManyCooks::TooManyCooks INTERFACE_COMPILE_DEFINITIONS)
+    if(NOT _TooManyCooks_COMPILE_DEFINITIONS)
+        set(_TooManyCooks_COMPILE_DEFINITIONS)
+    endif()
+
+    set(_TooManyCooks_EXISTING_PRIORITY_COUNT)
+    foreach(_TooManyCooks_DEFINITION IN LISTS _TooManyCooks_COMPILE_DEFINITIONS)
+        if("${_TooManyCooks_DEFINITION}" MATCHES "^TMC_PRIORITY_COUNT=([0-9]+)$")
+            set(_TooManyCooks_EXISTING_PRIORITY_COUNT "${CMAKE_MATCH_1}")
+        endif()
+    endforeach()
+
+    if(NOT "${_TooManyCooks_EXISTING_PRIORITY_COUNT}" STREQUAL "" AND NOT "${_TooManyCooks_EXISTING_PRIORITY_COUNT}" STREQUAL "${TMC_PRIORITY_COUNT}")
+        message(FATAL_ERROR "TooManyCooks was already configured with TMC_PRIORITY_COUNT=${_TooManyCooks_EXISTING_PRIORITY_COUNT}; cannot also use TMC_PRIORITY_COUNT=${TMC_PRIORITY_COUNT}")
+    endif()
+
+    if("${_TooManyCooks_EXISTING_PRIORITY_COUNT}" STREQUAL "")
+        target_compile_definitions(TooManyCooks::TooManyCooks INTERFACE "TMC_PRIORITY_COUNT=${TMC_PRIORITY_COUNT}")
+    endif()
+
+    unset(_TooManyCooks_EXISTING_PRIORITY_COUNT)
+    unset(_TooManyCooks_DEFINITION)
+    unset(_TooManyCooks_COMPILE_DEFINITIONS)
+endif()

--- a/cmake/tmc-find-hwloc.cmake
+++ b/cmake/tmc-find-hwloc.cmake
@@ -1,0 +1,25 @@
+function(tmc_find_hwloc)
+    if(NOT TARGET hwloc::hwloc)
+        find_package(hwloc CONFIG QUIET)
+    endif()
+
+    if(NOT TARGET hwloc::hwloc)
+        find_library(HWLOC_LIBRARY NAMES hwloc)
+        find_path(HWLOC_INCLUDE_DIR NAMES hwloc.h)
+
+        if(HWLOC_LIBRARY AND HWLOC_INCLUDE_DIR)
+            message(STATUS "TooManyCooks: Found hwloc: ${HWLOC_LIBRARY}")
+            add_library(hwloc::hwloc UNKNOWN IMPORTED)
+            set_target_properties(hwloc::hwloc PROPERTIES
+                IMPORTED_LOCATION "${HWLOC_LIBRARY}"
+                INTERFACE_INCLUDE_DIRECTORIES "${HWLOC_INCLUDE_DIR}"
+            )
+        endif()
+    endif()
+
+    if(TARGET hwloc::hwloc)
+        set(TMC_HWLOC_FOUND TRUE PARENT_SCOPE)
+    else()
+        set(TMC_HWLOC_FOUND FALSE PARENT_SCOPE)
+    endif()
+endfunction()

--- a/cmake/tmc-install.cmake
+++ b/cmake/tmc-install.cmake
@@ -23,7 +23,7 @@ install(FILES LICENSE
   COMPONENT TooManyCooks_Development
 )
 
-install(FILES cmake/TmcFindHwloc.cmake
+install(FILES cmake/tmc-find-hwloc.cmake
   DESTINATION ${TooManyCooks_INSTALL_CMAKEDIR}
   COMPONENT TooManyCooks_Development
 )

--- a/cmake/tmc-install.cmake
+++ b/cmake/tmc-install.cmake
@@ -1,0 +1,58 @@
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
+set(TooManyCooks_INSTALL_CMAKEDIR
+  "${CMAKE_INSTALL_LIBDIR}/cmake/TooManyCooks"
+  CACHE STRING "CMake package config location relative to the install prefix"
+)
+
+mark_as_advanced(TooManyCooks_INSTALL_CMAKEDIR)
+
+install(TARGETS TooManyCooks
+  EXPORT TooManyCooksTargets
+  COMPONENT TooManyCooks_Development
+)
+
+install(DIRECTORY include/
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  COMPONENT TooManyCooks_Development
+)
+
+install(FILES LICENSE
+  DESTINATION licenses
+  COMPONENT TooManyCooks_Development
+)
+
+install(FILES cmake/TmcFindHwloc.cmake
+  DESTINATION ${TooManyCooks_INSTALL_CMAKEDIR}
+  COMPONENT TooManyCooks_Development
+)
+
+install(EXPORT TooManyCooksTargets
+  DESTINATION ${TooManyCooks_INSTALL_CMAKEDIR}
+  NAMESPACE TooManyCooks::
+  FILE TooManyCooksTargets.cmake
+  COMPONENT TooManyCooks_Development
+)
+
+configure_package_config_file(
+  ${CMAKE_CURRENT_LIST_DIR}/TooManyCooksConfig.cmake.in
+  ${CMAKE_CURRENT_BINARY_DIR}/TooManyCooksConfig.cmake
+  INSTALL_DESTINATION ${TooManyCooks_INSTALL_CMAKEDIR}
+)
+
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/TooManyCooksConfigVersion.cmake
+  COMPATIBILITY SameMajorVersion
+  ARCH_INDEPENDENT
+)
+
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/TooManyCooksConfig.cmake
+  ${CMAKE_CURRENT_BINARY_DIR}/TooManyCooksConfigVersion.cmake
+  DESTINATION ${TooManyCooks_INSTALL_CMAKEDIR}
+  COMPONENT TooManyCooks_Development
+)
+
+# eventually, if we want to build installer packages
+# include(CPack)

--- a/cmake/tmc-options.cmake
+++ b/cmake/tmc-options.cmake
@@ -41,7 +41,7 @@ function(tmc_apply_options target)
         target_compile_definitions(${target} INTERFACE TMC_STANDALONE_COMPILATION)
     endif()
 
-    if(WIN32 AND TMC_WINDOWS_DLL)
+    if(TMC_WINDOWS_DLL)
         target_compile_definitions(${target} INTERFACE TMC_WINDOWS_DLL)
     endif()
 endfunction()

--- a/cmake/tmc-options.cmake
+++ b/cmake/tmc-options.cmake
@@ -35,7 +35,7 @@ function(tmc_apply_options target)
         target_compile_definitions(${target} INTERFACE TMC_DEBUG_THREAD_CREATION)
     endif()
 
-    if(NOT TMC_HEADER_ONLY)
+    if(TMC_STANDALONE_COMPILATION)
         target_compile_definitions(${target} INTERFACE TMC_STANDALONE_COMPILATION)
     endif()
 

--- a/cmake/tmc-options.cmake
+++ b/cmake/tmc-options.cmake
@@ -1,0 +1,45 @@
+function(tmc_apply_options target)
+    if(TMC_USE_HWLOC)
+        target_compile_definitions(${target} INTERFACE TMC_USE_HWLOC)
+    endif()
+
+    if(TMC_USE_BOOST_ASIO)
+        target_compile_definitions(${target} INTERFACE TMC_USE_BOOST_ASIO)
+    endif()
+
+    if(TMC_WORK_ITEM STREQUAL "FUNCORO")
+        target_compile_definitions(${target} INTERFACE "TMC_WORK_ITEM=FUNCORO")
+    endif()
+
+    if(TMC_TRIVIAL_TASK)
+        target_compile_definitions(${target} INTERFACE TMC_TRIVIAL_TASK)
+    endif()
+
+    if(TMC_NODISCARD_AWAIT)
+        target_compile_definitions(${target} INTERFACE TMC_NODISCARD_AWAIT)
+    endif()
+
+    if(NOT "${TMC_PRIORITY_COUNT}" STREQUAL "")
+        target_compile_definitions(${target} INTERFACE "TMC_PRIORITY_COUNT=${TMC_PRIORITY_COUNT}")
+    endif()
+
+    if(TMC_MORE_THREADS)
+        target_compile_definitions(${target} INTERFACE TMC_MORE_THREADS)
+    endif()
+
+    if(TMC_DEBUG_TASK_ALLOC_COUNT)
+        target_compile_definitions(${target} INTERFACE TMC_DEBUG_TASK_ALLOC_COUNT)
+    endif()
+
+    if(TMC_DEBUG_THREAD_CREATION)
+        target_compile_definitions(${target} INTERFACE TMC_DEBUG_THREAD_CREATION)
+    endif()
+
+    if(NOT TMC_HEADER_ONLY)
+        target_compile_definitions(${target} INTERFACE TMC_STANDALONE_COMPILATION)
+    endif()
+
+    if(WIN32 AND TMC_WINDOWS_DLL)
+        target_compile_definitions(${target} INTERFACE TMC_WINDOWS_DLL)
+    endif()
+endfunction()

--- a/cmake/tmc-options.cmake
+++ b/cmake/tmc-options.cmake
@@ -35,7 +35,9 @@ function(tmc_apply_options target)
         target_compile_definitions(${target} INTERFACE TMC_DEBUG_THREAD_CREATION)
     endif()
 
-    if(TMC_STANDALONE_COMPILATION)
+    if(TMC_STANDALONE_COMPILATION AND NOT TMC_WINDOWS_DLL)
+        # TMC_WINDOWS_DLL requires TMC_STANDALONE_COMPILATION at the CMake level for clarity,
+        # but as defines, they are redundant - TMC_WINDOWS_DLL implies TMC_STANDALONE_COMPILATION
         target_compile_definitions(${target} INTERFACE TMC_STANDALONE_COMPILATION)
     endif()
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,163 @@
+from conan import ConanFile
+from conan.errors import ConanInvalidConfiguration
+from conan.tools.layout import basic_layout
+from conan.tools.build import check_min_cppstd
+from conan.tools.files import copy
+from conan.tools.scm import Version
+import os
+
+required_conan_version = ">=2.10"
+
+class ToomanycooksConan(ConanFile):
+    name = "toomanycooks"
+    version = "1.5.0"
+    description = "The C++20 coroutine framework with no compromises. Excellent performance, simple syntax, and powerful features."
+    license = "BSL-1.0"
+    url = "https://github.com/tzcnt/TooManyCooks"
+    homepage = "https://github.com/tzcnt/TooManyCooks"
+    topics = ("tasking",
+              "coroutine",
+              "thread-pool",
+              "i/o",
+              "work-stealing",
+              "lockfree",
+              "header-only")
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    no_copy_source = True
+    options = {
+        # Dependency Options
+        "with_hwloc": [True, False],
+        "with_asio": [None, "standalone", "boost"],
+
+        # Configs
+        "work_item": ["CORO", "FUNCORO"],
+        "trivial_task": [True, False],
+        "nodiscard_await": [True, False],
+        "priority_count": [None,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16],
+        "more_threads": [True, False],
+        "debug_task_alloc_count": [True, False],
+        "debug_thread_creation": [True, False],
+
+        # Build Options (default is header-only if both are disabled)
+        "standalone_compilation": [True, False],
+        "windows_dll": [True, False],
+    }
+    default_options = {
+        "with_hwloc": True,
+        "with_asio": None,
+        "work_item": "CORO",
+        "trivial_task": False,
+        "nodiscard_await": False,
+        "priority_count": None,
+        "more_threads": False,
+        "debug_task_alloc_count": False,
+        "debug_thread_creation": False,
+        "standalone_compilation": False,
+        "windows_dll": False,
+    }
+    options_description = {
+        "with_hwloc": "https://www.fleetcode.com/oss/tmc/docs/dev/build_flags.html#tmc-use-hwloc",
+        "with_asio": "allows you to add standalone asio or boost::asio as an optional dependency",
+        "work_item": "https://www.fleetcode.com/oss/tmc/docs/dev/build_flags.html#tmc-work-item",
+        "trivial_task": "https://www.fleetcode.com/oss/tmc/docs/dev/build_flags.html#tmc-trivial-task",
+        "nodiscard_await": "https://www.fleetcode.com/oss/tmc/docs/dev/build_flags.html#tmc-nodiscard-await",
+        "priority_count": "https://www.fleetcode.com/oss/tmc/docs/dev/build_flags.html#tmc-priority-count",
+        "more_threads": "https://www.fleetcode.com/oss/tmc/docs/dev/build_flags.html#tmc-more-threads",
+        "debug_task_alloc_count": "https://www.fleetcode.com/oss/tmc/docs/dev/build_flags.html#tmc-debug-task-alloc-count",
+        "debug_thread_creation": "https://www.fleetcode.com/oss/tmc/docs/dev/build_flags.html#tmc-debug-thread-creation",
+        "standalone_compilation": "https://www.fleetcode.com/oss/tmc/docs/dev/build_flags.html#build-modes",
+        "windows_dll": "https://www.fleetcode.com/oss/tmc/docs/dev/build_flags.html#build-modes",
+    }
+
+    def config_options(self):
+        if self.settings.os != "Windows":
+            del self.options.windows_dll
+
+    @property
+    def _min_cppstd(self):
+        return 20
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "apple-clang": "17",
+            "clang": "17",
+            "gcc": "14",
+            "msvc": "195",
+            "Visual Studio": "18",
+        }
+
+    def requirements(self):
+        if self.options.with_hwloc:
+            self.requires("hwloc/[>=2.4]", transitive_headers=True, transitive_libs=True)
+        if self.options.with_asio == "standalone":
+            self.requires("asio/[>=1.28 <2]", transitive_headers=True)
+        if self.options.with_asio == "boost":
+            self.requires(f"boost/[>=1.84]", transitive_headers=True)
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            check_min_cppstd(self, self._min_cppstd)
+        minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+            raise ConanInvalidConfiguration(f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support.")
+        
+    def export_sources(self):
+        copy(self, "LICENSE", src=self.recipe_folder, dst=self.export_sources_folder)
+        copy(self, "*.hpp", src=os.path.join(self.recipe_folder, "include"), dst=os.path.join(self.export_sources_folder, "include"))
+        copy(self, "*.ipp", src=os.path.join(self.recipe_folder, "include"), dst=os.path.join(self.export_sources_folder, "include"))
+
+    def layout(self):
+        basic_layout(self)
+
+    def package_id(self):
+        self.info.settings.clear()
+
+    def package(self):
+        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+
+        include_dir = os.path.join(self.source_folder, "include")
+        copy(self, "*.hpp", src=include_dir, dst=os.path.join(self.package_folder, "include"))
+        copy(self, "*.ipp", src=include_dir, dst=os.path.join(self.package_folder, "include"))
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
+
+        if self.options.with_hwloc:
+            self.cpp_info.defines.append("TMC_USE_HWLOC")
+
+        if self.options.with_asio == "boost":
+            self.cpp_info.defines.append("TMC_USE_BOOST_ASIO")
+
+        if self.options.standalone_compilation:
+            self.cpp_info.defines.append("TMC_STANDALONE_COMPILATION")
+
+        if self.options.get_safe("windows_dll"):
+            self.cpp_info.defines.append("TMC_WINDOWS_DLL")
+
+        pc = self.options.priority_count
+        if pc != None:
+            self.cpp_info.defines.append(f"TMC_PRIORITY_COUNT={pc}")
+
+        if self.options.work_item == "FUNCORO":
+            self.cpp_info.defines.append("TMC_WORK_ITEM=FUNCORO")
+
+        if self.options.trivial_task:
+            self.cpp_info.defines.append("TMC_TRIVIAL_TASK")
+
+        if self.options.more_threads:
+            self.cpp_info.defines.append("TMC_MORE_THREADS")
+
+        if self.options.nodiscard_await:
+            self.cpp_info.defines.append("TMC_NODISCARD_AWAIT")
+
+        if self.options.debug_task_alloc_count:
+            self.cpp_info.defines.append("TMC_DEBUG_TASK_ALLOC_COUNT")
+
+        if self.options.debug_thread_creation:
+            self.cpp_info.defines.append("TMC_DEBUG_THREAD_CREATION")
+
+        if self.settings.os in ["Linux", "FreeBSD"]:
+            self.cpp_info.system_libs = ["pthread"]

--- a/conanfile.py
+++ b/conanfile.py
@@ -40,8 +40,8 @@ class ToomanycooksConan(ConanFile):
         "debug_task_alloc_count": [True, False],
         "debug_thread_creation": [True, False],
 
-        # Build Options
-        "header_only": [True, False],
+        # Build Options - by default (both disabled), the library is header-only
+        "standalone_compilation": [True, False],
         "windows_dll": [True, False],
     }
     default_options = {
@@ -54,7 +54,7 @@ class ToomanycooksConan(ConanFile):
         "more_threads": False,
         "debug_task_alloc_count": False,
         "debug_thread_creation": False,
-        "header_only": True,
+        "standalone_compilation": False,
         "windows_dll": False,
     }
     options_description = {
@@ -67,7 +67,7 @@ class ToomanycooksConan(ConanFile):
         "more_threads": "https://www.fleetcode.com/oss/tmc/docs/dev/build_flags.html#tmc-more-threads",
         "debug_task_alloc_count": "https://www.fleetcode.com/oss/tmc/docs/dev/build_flags.html#tmc-debug-task-alloc-count",
         "debug_thread_creation": "https://www.fleetcode.com/oss/tmc/docs/dev/build_flags.html#tmc-debug-thread-creation",
-        "header_only": "https://www.fleetcode.com/oss/tmc/docs/dev/build_flags.html#build-modes",
+        "standalone_compilation": "https://www.fleetcode.com/oss/tmc/docs/dev/build_flags.html#build-modes",
         "windows_dll": "https://www.fleetcode.com/oss/tmc/docs/dev/build_flags.html#build-modes",
     }
 
@@ -98,8 +98,8 @@ class ToomanycooksConan(ConanFile):
             self.requires(f"boost/[>=1.84]", transitive_headers=True)
 
     def validate(self):
-        if self.options.get_safe("windows_dll", False) and self.options.header_only:
-            raise ConanInvalidConfiguration("windows_dll requires header_only=False")
+        if self.options.get_safe("windows_dll", False) and not self.options.standalone_compilation:
+            raise ConanInvalidConfiguration("windows_dll requires standalone_compilation=True")
         if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, self._min_cppstd)
         minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
@@ -132,7 +132,7 @@ class ToomanycooksConan(ConanFile):
             "TMC_MORE_THREADS": self.options.more_threads,
             "TMC_DEBUG_TASK_ALLOC_COUNT": self.options.debug_task_alloc_count,
             "TMC_DEBUG_THREAD_CREATION": self.options.debug_thread_creation,
-            "TMC_HEADER_ONLY": self.options.header_only,
+            "TMC_STANDALONE_COMPILATION": self.options.standalone_compilation,
             "TMC_WINDOWS_DLL": self.options.get_safe("windows_dll", False),
         })
         cmake.build()

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,8 +1,8 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.layout import basic_layout
 from conan.tools.build import check_min_cppstd
-from conan.tools.files import copy, save
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.files import copy
 from conan.tools.scm import Version
 import os
 
@@ -25,6 +25,7 @@ class ToomanycooksConan(ConanFile):
     package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
+    generators = "CMakeDeps", "CMakeToolchain"
     options = {
         # Dependency Options
         "with_hwloc": [True, False],
@@ -39,8 +40,8 @@ class ToomanycooksConan(ConanFile):
         "debug_task_alloc_count": [True, False],
         "debug_thread_creation": [True, False],
 
-        # Build Options (default is header-only if both are disabled)
-        "standalone_compilation": [True, False],
+        # Build Options
+        "header_only": [True, False],
         "windows_dll": [True, False],
     }
     default_options = {
@@ -53,7 +54,7 @@ class ToomanycooksConan(ConanFile):
         "more_threads": False,
         "debug_task_alloc_count": False,
         "debug_thread_creation": False,
-        "standalone_compilation": False,
+        "header_only": True,
         "windows_dll": False,
     }
     options_description = {
@@ -66,7 +67,7 @@ class ToomanycooksConan(ConanFile):
         "more_threads": "https://www.fleetcode.com/oss/tmc/docs/dev/build_flags.html#tmc-more-threads",
         "debug_task_alloc_count": "https://www.fleetcode.com/oss/tmc/docs/dev/build_flags.html#tmc-debug-task-alloc-count",
         "debug_thread_creation": "https://www.fleetcode.com/oss/tmc/docs/dev/build_flags.html#tmc-debug-thread-creation",
-        "standalone_compilation": "https://www.fleetcode.com/oss/tmc/docs/dev/build_flags.html#build-modes",
+        "header_only": "https://www.fleetcode.com/oss/tmc/docs/dev/build_flags.html#build-modes",
         "windows_dll": "https://www.fleetcode.com/oss/tmc/docs/dev/build_flags.html#build-modes",
     }
 
@@ -97,6 +98,8 @@ class ToomanycooksConan(ConanFile):
             self.requires(f"boost/[>=1.84]", transitive_headers=True)
 
     def validate(self):
+        if self.options.get_safe("windows_dll", False) and self.options.header_only:
+            raise ConanInvalidConfiguration("windows_dll requires header_only=False")
         if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, self._min_cppstd)
         minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
@@ -106,103 +109,44 @@ class ToomanycooksConan(ConanFile):
     def export_sources(self):
         copy(self, "LICENSE", src=self.recipe_folder, dst=self.export_sources_folder)
         copy(self, "CMakeLists.txt", src=self.recipe_folder, dst=self.export_sources_folder)
+        copy(self, "*.cmake", src=os.path.join(self.recipe_folder, "cmake"), dst=os.path.join(self.export_sources_folder, "cmake"))
+        copy(self, "*.cmake.in", src=os.path.join(self.recipe_folder, "cmake"), dst=os.path.join(self.export_sources_folder, "cmake"))
         copy(self, "*.hpp", src=os.path.join(self.recipe_folder, "include"), dst=os.path.join(self.export_sources_folder, "include"))
         copy(self, "*.ipp", src=os.path.join(self.recipe_folder, "include"), dst=os.path.join(self.export_sources_folder, "include"))
 
     def layout(self):
-        basic_layout(self)
+        cmake_layout(self)
 
     def package_id(self):
         self.info.settings.clear()
 
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure({
+            "TMC_USE_HWLOC": self.options.with_hwloc,
+            "TMC_USE_BOOST_ASIO": self.options.with_asio == "boost",
+            "TMC_WORK_ITEM": self.options.work_item,
+            "TMC_TRIVIAL_TASK": self.options.trivial_task,
+            "TMC_NODISCARD_AWAIT": self.options.nodiscard_await,
+            "TMC_PRIORITY_COUNT": "" if self.options.priority_count == None else self.options.priority_count,
+            "TMC_MORE_THREADS": self.options.more_threads,
+            "TMC_DEBUG_TASK_ALLOC_COUNT": self.options.debug_task_alloc_count,
+            "TMC_DEBUG_THREAD_CREATION": self.options.debug_thread_creation,
+            "TMC_HEADER_ONLY": self.options.header_only,
+            "TMC_WINDOWS_DLL": self.options.get_safe("windows_dll", False),
+        })
+        cmake.build()
+
     def package(self):
-        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
-        copy(self, "CMakeLists.txt", src=self.source_folder, dst=self.package_folder)
-
-        include_dir = os.path.join(self.source_folder, "include")
-        copy(self, "*.hpp", src=include_dir, dst=os.path.join(self.package_folder, "include"))
-        copy(self, "*.ipp", src=include_dir, dst=os.path.join(self.package_folder, "include"))
-
-        save(self, os.path.join(self.package_folder, "cmake", "tmc-conan-options.cmake"),
-             self._generate_cmake_options())
-
-    def _cmake_bool(self, val):
-        return "ON" if val else "OFF"
-
-    def _generate_cmake_options(self):
-        lines = [
-            f'set(TMC_USE_HWLOC {self._cmake_bool(self.options.with_hwloc)} CACHE BOOL "" FORCE)',
-            f'set(TMC_USE_BOOST_ASIO {self._cmake_bool(self.options.with_asio == "boost")} CACHE BOOL "" FORCE)',
-            f'set(TMC_WORK_ITEM "{self.options.work_item}" CACHE STRING "" FORCE)',
-            f'set(TMC_TRIVIAL_TASK {self._cmake_bool(self.options.trivial_task)} CACHE BOOL "" FORCE)',
-            f'set(TMC_NODISCARD_AWAIT {self._cmake_bool(self.options.nodiscard_await)} CACHE BOOL "" FORCE)',
-        ]
-
-        pc = self.options.priority_count
-        if pc != None:
-            lines.append(f'set(TMC_PRIORITY_COUNT "{pc}" CACHE STRING "" FORCE)')
-        else:
-            lines.append('set(TMC_PRIORITY_COUNT "" CACHE STRING "" FORCE)')
-
-        lines.extend([
-            f'set(TMC_MORE_THREADS {self._cmake_bool(self.options.more_threads)} CACHE BOOL "" FORCE)',
-            f'set(TMC_DEBUG_TASK_ALLOC_COUNT {self._cmake_bool(self.options.debug_task_alloc_count)} CACHE BOOL "" FORCE)',
-            f'set(TMC_DEBUG_THREAD_CREATION {self._cmake_bool(self.options.debug_thread_creation)} CACHE BOOL "" FORCE)',
-            f'set(TMC_STANDALONE_COMPILATION {self._cmake_bool(self.options.standalone_compilation)} CACHE BOOL "" FORCE)',
-        ])
-
-        wd = self.options.get_safe("windows_dll")
-        if wd is not None:
-            lines.append(f'set(TMC_WINDOWS_DLL {self._cmake_bool(wd)} CACHE BOOL "" FORCE)')
-
-        # Apply defines to the Conan-generated target based on cache variables.
-        # This mirrors the logic in CMakeLists.txt for add_subdirectory consumers.
-        lines.append('')
-        lines.append('if(TARGET tmc::tmc)')
-        lines.append('    if(TMC_USE_HWLOC)')
-        lines.append('        target_compile_definitions(tmc::tmc INTERFACE TMC_USE_HWLOC)')
-        lines.append('    endif()')
-        lines.append('    if(TMC_USE_BOOST_ASIO)')
-        lines.append('        target_compile_definitions(tmc::tmc INTERFACE TMC_USE_BOOST_ASIO)')
-        lines.append('    endif()')
-        lines.append('    if(TMC_WORK_ITEM STREQUAL "FUNCORO")')
-        lines.append('        target_compile_definitions(tmc::tmc INTERFACE "TMC_WORK_ITEM=FUNCORO")')
-        lines.append('    endif()')
-        lines.append('    if(TMC_TRIVIAL_TASK)')
-        lines.append('        target_compile_definitions(tmc::tmc INTERFACE TMC_TRIVIAL_TASK)')
-        lines.append('    endif()')
-        lines.append('    if(TMC_NODISCARD_AWAIT)')
-        lines.append('        target_compile_definitions(tmc::tmc INTERFACE TMC_NODISCARD_AWAIT)')
-        lines.append('    endif()')
-        lines.append('    if(NOT "${TMC_PRIORITY_COUNT}" STREQUAL "")')
-        lines.append('        target_compile_definitions(tmc::tmc INTERFACE "TMC_PRIORITY_COUNT=${TMC_PRIORITY_COUNT}")')
-        lines.append('    endif()')
-        lines.append('    if(TMC_MORE_THREADS)')
-        lines.append('        target_compile_definitions(tmc::tmc INTERFACE TMC_MORE_THREADS)')
-        lines.append('    endif()')
-        lines.append('    if(TMC_DEBUG_TASK_ALLOC_COUNT)')
-        lines.append('        target_compile_definitions(tmc::tmc INTERFACE TMC_DEBUG_TASK_ALLOC_COUNT)')
-        lines.append('    endif()')
-        lines.append('    if(TMC_DEBUG_THREAD_CREATION)')
-        lines.append('        target_compile_definitions(tmc::tmc INTERFACE TMC_DEBUG_THREAD_CREATION)')
-        lines.append('    endif()')
-        lines.append('    if(TMC_STANDALONE_COMPILATION)')
-        lines.append('        target_compile_definitions(tmc::tmc INTERFACE TMC_STANDALONE_COMPILATION)')
-        lines.append('    endif()')
-        lines.append('    if(WIN32 AND TMC_WINDOWS_DLL)')
-        lines.append('        target_compile_definitions(tmc::tmc INTERFACE TMC_WINDOWS_DLL)')
-        lines.append('    endif()')
-        lines.append('endif()')
-
-        return '\n'.join(lines) + '\n'
+        cmake = CMake(self)
+        cmake.install(component="TooManyCooks_Development")
 
     def package_info(self):
         self.cpp_info.bindirs = []
         self.cpp_info.libdirs = []
 
-        self.cpp_info.set_property("cmake_file_name", "tmc")
-        self.cpp_info.set_property("cmake_target_name", "tmc::tmc")
-        self.cpp_info.set_property("cmake_build_modules", [os.path.join("cmake", "tmc-conan-options.cmake")])
+        self.cpp_info.set_property("cmake_file_name", "TooManyCooks")
+        self.cpp_info.set_property("cmake_target_name", "TooManyCooks::TooManyCooks")
 
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs = ["pthread"]

--- a/conanfile.py
+++ b/conanfile.py
@@ -40,7 +40,7 @@ class ToomanycooksConan(ConanFile):
         "debug_task_alloc_count": [True, False],
         "debug_thread_creation": [True, False],
 
-        # Build Options - by default (both disabled), the library is header-only
+        # Build Modes - by default (both False), the library is header-only
         "standalone_compilation": [True, False],
         "windows_dll": [True, False],
     }
@@ -85,7 +85,6 @@ class ToomanycooksConan(ConanFile):
             "apple-clang": "17",
             "clang": "17",
             "gcc": "14",
-            "msvc": "195",
             "Visual Studio": "18",
         }
 
@@ -100,6 +99,11 @@ class ToomanycooksConan(ConanFile):
     def validate(self):
         if self.options.get_safe("windows_dll", False) and not self.options.standalone_compilation:
             raise ConanInvalidConfiguration("windows_dll requires standalone_compilation=True")
+        if self.settings.compiler == "msvc":
+            raise ConanInvalidConfiguration(
+                "TooManyCooks is currently unsupported with MSVC due to a compiler bug: "
+                "https://developercommunity.visualstudio.com/t/MSVC-incorrectly-caches-thread_local-var/11041371"
+            )
         if self.settings.compiler.get_safe("cppstd"):
             check_min_cppstd(self, self._min_cppstd)
         minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
@@ -122,7 +126,7 @@ class ToomanycooksConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
-        cmake.configure({
+        cmake.configure(variables={
             "TMC_USE_HWLOC": self.options.with_hwloc,
             "TMC_USE_BOOST_ASIO": self.options.with_asio == "boost",
             "TMC_WORK_ITEM": self.options.work_item,

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,7 +1,7 @@
 from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
+from conan.tools.layout import basic_layout
 from conan.tools.build import check_min_cppstd
-from conan.tools.cmake import CMake, cmake_layout
 from conan.tools.files import copy
 from conan.tools.scm import Version
 import os
@@ -25,7 +25,6 @@ class ToomanycooksConan(ConanFile):
     package_type = "header-library"
     settings = "os", "arch", "compiler", "build_type"
     no_copy_source = True
-    generators = "CMakeDeps", "CMakeToolchain"
     options = {
         # Dependency Options
         "with_hwloc": [True, False],
@@ -112,38 +111,19 @@ class ToomanycooksConan(ConanFile):
         
     def export_sources(self):
         copy(self, "LICENSE", src=self.recipe_folder, dst=self.export_sources_folder)
-        copy(self, "CMakeLists.txt", src=self.recipe_folder, dst=self.export_sources_folder)
-        copy(self, "*.cmake", src=os.path.join(self.recipe_folder, "cmake"), dst=os.path.join(self.export_sources_folder, "cmake"))
-        copy(self, "*.cmake.in", src=os.path.join(self.recipe_folder, "cmake"), dst=os.path.join(self.export_sources_folder, "cmake"))
-        copy(self, "*.hpp", src=os.path.join(self.recipe_folder, "include"), dst=os.path.join(self.export_sources_folder, "include"))
-        copy(self, "*.ipp", src=os.path.join(self.recipe_folder, "include"), dst=os.path.join(self.export_sources_folder, "include"))
+        copy(self, "*.hpp", src=self.recipe_folder, dst=self.export_sources_folder)
+        copy(self, "*.ipp", src=self.recipe_folder, dst=self.export_sources_folder)
 
     def layout(self):
-        cmake_layout(self)
+        basic_layout(self)
 
     def package_id(self):
         self.info.settings.clear()
 
-    def build(self):
-        cmake = CMake(self)
-        cmake.configure(variables={
-            "TMC_USE_HWLOC": self.options.with_hwloc,
-            "TMC_USE_BOOST_ASIO": self.options.with_asio == "boost",
-            "TMC_WORK_ITEM": self.options.work_item,
-            "TMC_TRIVIAL_TASK": self.options.trivial_task,
-            "TMC_NODISCARD_AWAIT": self.options.nodiscard_await,
-            "TMC_PRIORITY_COUNT": "" if self.options.priority_count == None else self.options.priority_count,
-            "TMC_MORE_THREADS": self.options.more_threads,
-            "TMC_DEBUG_TASK_ALLOC_COUNT": self.options.debug_task_alloc_count,
-            "TMC_DEBUG_THREAD_CREATION": self.options.debug_thread_creation,
-            "TMC_STANDALONE_COMPILATION": self.options.standalone_compilation,
-            "TMC_WINDOWS_DLL": self.options.get_safe("windows_dll", False),
-        })
-        cmake.build()
-
     def package(self):
-        cmake = CMake(self)
-        cmake.install(component="TooManyCooks_Development")
+        copy(self, "LICENSE", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        copy(self, "*.hpp", src=self.source_folder, dst=self.package_folder)
+        copy(self, "*.ipp", src=self.source_folder, dst=self.package_folder)
 
     def package_info(self):
         self.cpp_info.bindirs = []
@@ -151,6 +131,29 @@ class ToomanycooksConan(ConanFile):
 
         self.cpp_info.set_property("cmake_file_name", "TooManyCooks")
         self.cpp_info.set_property("cmake_target_name", "TooManyCooks::TooManyCooks")
+
+        if self.options.with_hwloc:
+            self.cpp_info.defines.append("TMC_USE_HWLOC")
+        if self.options.with_asio == "boost":
+            self.cpp_info.defines.append("TMC_USE_BOOST_ASIO")
+        if self.options.work_item == "FUNCORO":
+            self.cpp_info.defines.append("TMC_WORK_ITEM=FUNCORO")
+        if self.options.trivial_task:
+            self.cpp_info.defines.append("TMC_TRIVIAL_TASK")
+        if self.options.nodiscard_await:
+            self.cpp_info.defines.append("TMC_NODISCARD_AWAIT")
+        if self.options.priority_count != None:
+            self.cpp_info.defines.append(f"TMC_PRIORITY_COUNT={self.options.priority_count}")
+        if self.options.more_threads:
+            self.cpp_info.defines.append("TMC_MORE_THREADS")
+        if self.options.debug_task_alloc_count:
+            self.cpp_info.defines.append("TMC_DEBUG_TASK_ALLOC_COUNT")
+        if self.options.debug_thread_creation:
+            self.cpp_info.defines.append("TMC_DEBUG_THREAD_CREATION")
+        if self.options.standalone_compilation and not self.options.get_safe("windows_dll", False):
+            self.cpp_info.defines.append("TMC_STANDALONE_COMPILATION")
+        if self.options.get_safe("windows_dll", False):
+            self.cpp_info.defines.append("TMC_WINDOWS_DLL")
 
         if self.settings.os in ["Linux", "FreeBSD"]:
             self.cpp_info.system_libs = ["pthread"]

--- a/ports/toomanycooks/portfile.cmake
+++ b/ports/toomanycooks/portfile.cmake
@@ -1,0 +1,52 @@
+set(SOURCE_PATH "${CURRENT_PORT_DIR}/../..")
+set(VCPKG_BUILD_TYPE release) # header-only port
+
+if("standalone-asio" IN_LIST FEATURES AND "boost-asio" IN_LIST FEATURES)
+    message(FATAL_ERROR "toomanycooks features 'standalone-asio' and 'boost-asio' are mutually exclusive")
+endif()
+
+if("windows-dll" IN_LIST FEATURES AND NOT VCPKG_TARGET_IS_WINDOWS)
+    message(FATAL_ERROR "toomanycooks feature 'windows-dll' is only supported for Windows targets")
+endif()
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        hwloc                    TMC_USE_HWLOC
+        boost-asio               TMC_USE_BOOST_ASIO
+        trivial-task             TMC_TRIVIAL_TASK
+        nodiscard-await          TMC_NODISCARD_AWAIT
+        more-threads             TMC_MORE_THREADS
+        debug-task-alloc-count   TMC_DEBUG_TASK_ALLOC_COUNT
+        debug-thread-creation    TMC_DEBUG_THREAD_CREATION
+        standalone-compilation   TMC_STANDALONE_COMPILATION
+        windows-dll              TMC_WINDOWS_DLL
+)
+
+set(TMC_WORK_ITEM CORO)
+if("funcoro" IN_LIST FEATURES)
+    set(TMC_WORK_ITEM FUNCORO)
+endif()
+
+if("windows-dll" IN_LIST FEATURES)
+    list(APPEND FEATURE_OPTIONS -DTMC_STANDALONE_COMPILATION=ON)
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DTMC_WORK_ITEM=${TMC_WORK_ITEM}
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(PACKAGE_NAME TooManyCooks CONFIG_PATH lib/cmake/TooManyCooks)
+
+file(REMOVE_RECURSE
+    "${CURRENT_PACKAGES_DIR}/debug"
+    "${CURRENT_PACKAGES_DIR}/lib"
+    "${CURRENT_PACKAGES_DIR}/licenses"
+)
+
+file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/toomanycooks/portfile.cmake
+++ b/ports/toomanycooks/portfile.cmake
@@ -22,6 +22,9 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         windows-dll              TMC_WINDOWS_DLL
 )
 
+# TMC_PRIORITY_COUNT feature can't be exposed as a vcpkg feature, since vcpkg doesn't support integer configurations.
+# Instead, users must specify it manually before find_package(TooManyCooks).
+
 set(TMC_WORK_ITEM CORO)
 if("funcoro" IN_LIST FEATURES)
     set(TMC_WORK_ITEM FUNCORO)

--- a/ports/toomanycooks/usage
+++ b/ports/toomanycooks/usage
@@ -3,6 +3,12 @@ toomanycooks provides CMake targets:
     find_package(TooManyCooks CONFIG REQUIRED)
     target_link_libraries(main PRIVATE TooManyCooks::TooManyCooks)
 
-The default vcpkg feature enables hwloc. Disable it with:
+The default vcpkg feature enables hwloc. To disable hwloc, use:
 
     vcpkg install "toomanycooks[core]" --overlay-ports=ports
+
+In addition to the features exposed to vcpkg, TooManyCooks also supports an optional package-wide configuration TMC_PRIORITY_COUNT.
+Since vcpkg doesn't support integer configurations, to use this, set it manually before find_package() in your CMake file:
+
+    set(TMC_PRIORITY_COUNT 8) # integer from 1 to 16
+    find_package(TooManyCooks CONFIG REQUIRED)

--- a/ports/toomanycooks/usage
+++ b/ports/toomanycooks/usage
@@ -1,0 +1,8 @@
+toomanycooks provides CMake targets:
+
+    find_package(TooManyCooks CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE TooManyCooks::TooManyCooks)
+
+The default vcpkg feature enables hwloc. Disable it with:
+
+    vcpkg install "toomanycooks[core]" --overlay-ports=ports

--- a/ports/toomanycooks/vcpkg.json
+++ b/ports/toomanycooks/vcpkg.json
@@ -1,0 +1,66 @@
+{
+  "name": "toomanycooks",
+  "version": "1.5.0",
+  "description": "The C++20 coroutine framework with no compromises. Excellent performance, simple syntax, and powerful features.",
+  "homepage": "https://github.com/tzcnt/TooManyCooks",
+  "documentation": "https://fleetcode.com/oss/tmc/docs",
+  "license": "BSL-1.0",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "hwloc"
+  ],
+  "features": {
+    "hwloc": {
+      "description": "Enable hwloc topology-aware thread placement.",
+      "dependencies": [
+        "hwloc"
+      ]
+    },
+    "standalone-asio": {
+      "description": "Install standalone Asio for use with the tmc/asio headers.",
+      "dependencies": [
+        "asio"
+      ]
+    },
+    "boost-asio": {
+      "description": "Use Boost.Asio instead of standalone Asio for the tmc/asio headers.",
+      "dependencies": [
+        "boost-asio"
+      ]
+    },
+    "funcoro": {
+      "description": "Set TMC_WORK_ITEM=FUNCORO."
+    },
+    "trivial-task": {
+      "description": "Enable TMC_TRIVIAL_TASK."
+    },
+    "nodiscard-await": {
+      "description": "Enable TMC_NODISCARD_AWAIT."
+    },
+    "more-threads": {
+      "description": "Enable TMC_MORE_THREADS."
+    },
+    "debug-task-alloc-count": {
+      "description": "Enable TMC_DEBUG_TASK_ALLOC_COUNT."
+    },
+    "debug-thread-creation": {
+      "description": "Enable TMC_DEBUG_THREAD_CREATION."
+    },
+    "standalone-compilation": {
+      "description": "Enable TMC_STANDALONE_COMPILATION."
+    },
+    "windows-dll": {
+      "description": "Enable TMC_WINDOWS_DLL and TMC_STANDALONE_COMPILATION. Only valid for Windows targets."
+    }
+  }
+}

--- a/ports/toomanycooks/vcpkg.json
+++ b/ports/toomanycooks/vcpkg.json
@@ -60,7 +60,8 @@
       "description": "Enable TMC_STANDALONE_COMPILATION."
     },
     "windows-dll": {
-      "description": "Enable TMC_WINDOWS_DLL and TMC_STANDALONE_COMPILATION. Only valid for Windows targets."
+      "description": "Enable TMC_WINDOWS_DLL and TMC_STANDALONE_COMPILATION.",
+      "supports": "windows"
     }
   }
 }


### PR DESCRIPTION
TooManyCooks now exposes a `CMakeLists.txt` with:
- a CMake INTERFACE target `TooManyCooks::TooManyCooks`
- CMake options equivalent to the preprocessor-macro configs. e.g. setting the CMake option TMC_USE_HWLOC=ON will define TMC_USE_HWLOC for the library. These options are configured in the `cmake/tmc-options.cmake` file.
- since it's an INTERFACE target, all consumers (typically done by calling `target_link_libraries(${target} PRIVATE TooManyCooks::TooManyCooks)` will also automatically get these options / definitions propagated to them
- TMC_USE_HWLOC=ON is now the default for TooManyCooks
- a CMake install target defined by `cmake/tmc-install.cmake` which configures the library with the provided options and then installs the configured version from the template `cmake/TooManyCooksConfig.cmake.in`

This is backward compatible with existing projects that don't link to the new target, since setting the compile definitions manually / linking hwloc manually still works.

Migrating to the new CMake target from a legacy manual-setup project is simple:
```
# Configure any TMC CMake options before including the library
option(TMC_NODISCARD_AWAIT "Enable [[nodiscard]] on co_await" ON)

add_subdirectory(${tmc_repo_dir})
target_link_libraries(${target_name} PRIVATE TooManyCooks::TooManyCooks)
```

Note - the default config is header-only. If you set TMC_STANDALONE_COMPILATION and/or TMC_WINDOWS_DLL, you must provide an implementation file with `#define TMC_IMPL` and `#include "tmc/all_headers.hpp`, as before. The new CMake project does not provide this. This allows you to place the library implementation into the most appropriate place in your project.

---

Added vcpkg port in `ports/toomanycooks/` which:
- exposes vcpkg features that map to most of the CMake options
  - the exception is TMC_PRIORITY_COUNT, which must still be configured separately by the consuming CMake project because vcpkg doesn't support integer feature options
- finds hwloc, asio and/or boost-asio dependencies via vcpkg
- uses the CMake install target to install the configured version of TMC

---

Added `conanfile.py` which:
- does not use the CMakeLists.txt since conan is build system-agnostic
- exposes conan options that map to all of the CMake options. Sets these using `self.cpp_info.defines` so they are propagated to all consumers
- finds hwloc, asio and/or boost-asio dependencies via conan
- copies the necessary files to the include directory

This means that if you are using a CMake project and you include TooManyCooks via conan, the CMakeDeps generator will create a CMake target that is equivalent to the one that's packaged with the library. If you use a different build system, you'll get the equivalent for that build system.