### PR TITLE
ex_cpu_st uses a more tightly integrated / efficient ingest queue

### DIFF
--- a/include/tmc/detail/ex_cpu_st.ipp
+++ b/include/tmc/detail/ex_cpu_st.ipp
@@ -18,6 +18,13 @@
 
 #include <coroutine>
 
+#ifdef __linux__
+#include <cstdint>
+#include <linux/futex.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+#endif
+
 #ifdef TMC_USE_HWLOC
 #include "tmc/detail/thread_layout.hpp"
 
@@ -32,48 +39,26 @@ static_assert(sizeof(void*) == sizeof(hwloc_bitmap_t));
 
 namespace tmc {
 
-void ex_cpu_st::set_state(WorkerState NewState) {
-  thread_state.store(NewState, std::memory_order_release);
+namespace {
+
+#ifdef __linux__
+tmc::detail::atomic_wait_t*
+wait_address(std::atomic<tmc::detail::atomic_wait_t>& Wait) noexcept {
+  static_assert(sizeof(tmc::detail::atomic_wait_t) == sizeof(uint32_t));
+  return reinterpret_cast<tmc::detail::atomic_wait_t*>(&Wait);
 }
 
-ex_cpu_st::WorkerState ex_cpu_st::get_state() {
-  return thread_state.load(std::memory_order_acquire);
+void notify_wait(std::atomic<tmc::detail::atomic_wait_t>& Wait) noexcept {
+  syscall(
+    SYS_futex, wait_address(Wait), FUTEX_WAKE_PRIVATE, 1, nullptr, nullptr, 0
+  );
 }
+#endif
+
+} // namespace
 
 bool ex_cpu_st::is_initialized() {
   return initialized.load(std::memory_order_relaxed);
-}
-
-void ex_cpu_st::notify_n(size_t Priority, bool FromExecThread) {
-  // In combination with the inverse barrier/double-check in the main worker
-  // loop, prevents lost wakeups.
-  if (!FromExecThread) {
-    tmc::detail::memory_barrier();
-  }
-  WorkerState currentState = get_state();
-
-  // For single-threaded executor: only wake if thread is sleeping
-  if (currentState == WorkerState::SLEEPING) {
-    thread_state_data.sleep_wait.fetch_add(1, std::memory_order_acq_rel);
-    thread_state_data.sleep_wait.notify_one();
-  } else if (currentState == WorkerState::WORKING) {
-    // Possibly interrupt a working thread, if new task priority is higher
-    if TMC_PRIORITY_CONSTEXPR (PRIORITY_COUNT > 1) {
-      auto currentPrio =
-        thread_state_data.yield_priority.load(std::memory_order_relaxed);
-      // 2 threads may request a task to yield at the same time. The
-      // thread with the higher priority (lower priority index) should
-      // prevail.
-      while (currentPrio > Priority) {
-        if (thread_state_data.yield_priority.compare_exchange_strong(
-              currentPrio, Priority, std::memory_order_acq_rel
-            )) {
-          return;
-        }
-      }
-    }
-  }
-  // If thread is already spinning or working, no need to wake it
 }
 
 void ex_cpu_st::init_thread_locals(size_t Slot) {
@@ -90,13 +75,8 @@ void ex_cpu_st::clear_thread_locals() {
 }
 
 void ex_cpu_st::run_one(
-  tmc::work_item& Item, const size_t Prio, size_t& PrevPriority,
-  bool& WasSpinning
+  tmc::work_item& Item, const size_t Prio, size_t& PrevPriority
 ) {
-  if (WasSpinning) {
-    WasSpinning = false;
-    set_state(WorkerState::WORKING);
-  }
   if TMC_PRIORITY_CONSTEXPR (PRIORITY_COUNT > 1) {
     thread_state_data.yield_priority.store(Prio, std::memory_order_release);
     if (Prio != PrevPriority) {
@@ -116,10 +96,8 @@ void ex_cpu_st::run_one(
 // returns true if no tasks were found (caller should wait on cv)
 // returns false if thread stop requested (caller should exit)
 bool ex_cpu_st::try_run_some(
-  std::stop_token& ThreadStopToken, size_t& PrevPriority
+  std::stop_token& ThreadStopToken, size_t& PrevPriority, bool* DidWait
 ) {
-  // Precondition: this thread is spinning / not working
-  bool wasSpinning = true;
   while (true) {
   TOP:
     if (ThreadStopToken.stop_requested()) [[unlikely]] {
@@ -130,11 +108,15 @@ bool ex_cpu_st::try_run_some(
       if (!private_work[prio].empty()) {
         item = std::move(private_work[prio].back());
         private_work[prio].pop_back();
-        run_one(item, prio, PrevPriority, wasSpinning);
+        run_one(item, prio, PrevPriority);
         goto TOP;
       }
       if (work_queues[prio].try_pull(item)) {
-        run_one(item, prio, PrevPriority, wasSpinning);
+        if (DidWait[prio]) {
+          DidWait[prio] = false;
+          wait_count.fetch_add(1, std::memory_order_release);
+        }
+        run_one(item, prio, PrevPriority);
         goto TOP;
       }
     }
@@ -162,12 +144,8 @@ void ex_cpu_st::post(work_item&& Item, size_t Priority, size_t ThreadHint) {
   // we should use the external queue to force FIFO ordering.
   if (fromExecThread && ThreadHint != 0) [[likely]] {
     private_work[Priority].push_back(static_cast<work_item&&>(Item));
-    notify_n(Priority, fromExecThread);
   } else {
-    ++ref_count;
     work_queues[Priority].post(static_cast<work_item&&>(Item));
-    notify_n(Priority, fromExecThread);
-    --ref_count;
   }
 }
 
@@ -175,13 +153,17 @@ tmc::ex_any* ex_cpu_st::type_erased() { return &type_erased_this; }
 
 // Default constructor does not call init() - you need to do it afterward
 ex_cpu_st::ex_cpu_st()
-    : init_params{nullptr}, type_erased_this(this), spins{4}, ref_count{0}
+    : init_params{nullptr}, type_erased_this(this), spins{4}
 #ifndef TMC_PRIORITY_COUNT
       ,
       PRIORITY_COUNT{1}
 #endif
 {
   initialized.store(false, std::memory_order_seq_cst);
+  wait_count.store(0, std::memory_order_relaxed);
+#ifndef __linux__
+  wake_wait.store(0, std::memory_order_relaxed);
+#endif
 }
 
 auto ex_cpu_st::make_worker(
@@ -234,49 +216,95 @@ auto ex_cpu_st::make_worker(
     tmc::topology::thread_info threadInfo{};
     threadInfo.index = Slot;
     size_t previousPrio = NO_TASK_RUNNING;
+
+    // If consumer signaled that it was going to wait on a particular priority,
+    // it should set this to true.
+    bool didWait[TMC_MAX_PRIORITY_COUNT]{};
+
+#ifdef __linux__
+    struct futex_waitv waiters[TMC_MAX_PRIORITY_COUNT + 1];
+    for (size_t i = 0; i < PRIORITY_COUNT; ++i) {
+      waiters[i].val = task_queue_t::WAIT_VALUE;
+      waiters[i].flags = FUTEX_32 | FUTEX_PRIVATE_FLAG;
+      waiters[i].__reserved = 0;
+      // Setup all queue waiters, except for the wait address
+    }
+    // The last waiter is statically reserved for the teardown signal
+    waiters[PRIORITY_COUNT] = {
+      .val = 0,
+      .uaddr = reinterpret_cast<uintptr_t>(wait_address(this->stop_wait)),
+      .flags = FUTEX_32 | FUTEX_PRIVATE_FLAG,
+      .__reserved = 0,
+    };
+#endif
+
   TOP:
-    while (try_run_some(ThreadStopToken, previousPrio)) {
+    while (try_run_some(ThreadStopToken, previousPrio, didWait)) {
       if (ThreadPostRunHook != nullptr && ThreadPostRunHook(threadInfo)) {
         goto TOP;
       }
 
-      // Transition from working to spinning
-      set_state(WorkerState::SPINNING);
-      for (size_t i = 0; i < spins; ++i) {
+      for (size_t i = 1; i < spins; ++i) {
         TMC_CPU_PAUSE();
         for (size_t prio = 0; prio < PRIORITY_COUNT; ++prio) {
           if (!work_queues[prio].empty()) {
             goto TOP;
           }
         }
+        if (ThreadStopToken.stop_requested()) [[unlikely]] {
+          break;
+        }
       }
 
       previousPrio = NO_TASK_RUNNING;
 
-      // Transition from spinning to sleeping.
-      auto waitValue =
-        thread_state_data.sleep_wait.load(std::memory_order_relaxed);
-      set_state(WorkerState::SLEEPING);
-      tmc::detail::memory_barrier(); // pairs with barrier in notify_n
+#ifndef __linux__
+      auto waitValue = wake_wait.load(std::memory_order_seq_cst);
+#endif
 
-      // Double check that the queue is empty after the memory
-      // barrier. In combination with the inverse double-check in
-      // notify_n, this prevents any lost wakeups.
+      work_item item;
       for (size_t prio = 0; prio < PRIORITY_COUNT; ++prio) {
-        if (!work_queues[prio].empty()) {
-          set_state(WorkerState::SPINNING);
+        auto queueWait = work_queues[prio].pull(item);
+        if (queueWait == nullptr) {
+          if (didWait[prio]) {
+            didWait[prio] = false;
+            wait_count.fetch_add(1, std::memory_order_release);
+          }
+          run_one(item, prio, previousPrio);
           goto TOP;
         }
+        didWait[prio] = true;
+#ifdef __linux__
+        waiters[prio].uaddr = reinterpret_cast<uintptr_t>(queueWait);
+#endif
       }
 
       // No work found. Go to sleep.
       if (ThreadStopToken.stop_requested()) [[unlikely]] {
         break;
       }
-      thread_state_data.sleep_wait.wait(waitValue);
-
-      // Upon waking, transition from sleeping to spinning
-      set_state(WorkerState::SPINNING);
+#ifdef __linux__
+      long waitResult =
+        syscall(SYS_futex_waitv, waiters, PRIORITY_COUNT + 1, 0, nullptr, 0);
+      if (waitResult >= 0 && static_cast<size_t>(waitResult) < PRIORITY_COUNT) {
+        didWait[waitResult] = false;
+        // Don't increment failed_wait_count since this was a successful wait.
+      }
+#else
+      // Non-Linux platforms don't provide a futex_waitv equivalent. Use a
+      // shared wake word for all queues. Producers conservatively count every
+      // wake attempt that observed WAITING, so keep didWait set here and
+      // account it when the item is consumed.
+      if (ThreadStopToken.stop_requested()) [[unlikely]] {
+        break;
+      }
+      for (size_t prio = 0; prio < PRIORITY_COUNT; ++prio) {
+        if (!work_queues[prio].empty()) {
+          goto TOP;
+        }
+      }
+      wake_wait.wait(waitValue);
+#endif
     }
     if (ThreadTeardownHook != nullptr) {
       tmc::topology::thread_info info{};
@@ -338,8 +366,14 @@ void ex_cpu_st::init() {
 
   // Initialize single thread state
   thread_state_data.yield_priority = NO_TASK_RUNNING;
-  thread_state_data.sleep_wait = 0;
-  thread_state.store(WorkerState::SPINNING);
+  stop_wait.store(0, std::memory_order_relaxed);
+  wait_count.store(0, std::memory_order_relaxed);
+#ifndef __linux__
+  wake_wait.store(0, std::memory_order_relaxed);
+  for (size_t i = 0; i < PRIORITY_COUNT; ++i) {
+    work_queues[i].set_wake_wait(wake_wait);
+  }
+#endif
 
   // Start worker thread
   std::atomic<tmc::detail::atomic_wait_t> initThreadsBarrier(1);
@@ -418,14 +452,31 @@ void ex_cpu_st::teardown() {
 
   // Stop and join the single worker thread
   thread_stopper.request_stop();
-  thread_state_data.sleep_wait.fetch_add(1, std::memory_order_seq_cst);
-  thread_state_data.sleep_wait.notify_one();
+  stop_wait.store(1, std::memory_order_release);
+#ifdef __linux__
+  notify_wait(stop_wait);
+#else
+  wake_wait.fetch_add(1, std::memory_order_release);
+  wake_wait.notify_one();
+#endif
 
   if (worker_thread.joinable()) {
     worker_thread.join();
   }
 
-  while (ref_count.load() > 0) {
+  // For each failed wait, there must also be a failed wake - where the producer
+  // released the data to the queue, but didn't wake us, since we already took
+  // the data. In those scenarios, it's possible for the queue destruction to
+  // race with the futex wake of the producer. Wait for all of the failed wakes
+  // to finish before destroying.
+  while (true) {
+    size_t wakeCount = 0;
+    for (size_t i = 0; i < PRIORITY_COUNT; ++i) {
+      wakeCount += work_queues[i].wake_count.load(std::memory_order_acquire);
+    }
+    if (wakeCount == wait_count.load(std::memory_order_acquire)) {
+      break;
+    }
     TMC_CPU_PAUSE();
   }
 

--- a/include/tmc/detail/ex_cpu_st.ipp
+++ b/include/tmc/detail/ex_cpu_st.ipp
@@ -38,25 +38,6 @@ static_assert(sizeof(void*) == sizeof(hwloc_bitmap_t));
 #endif
 
 namespace tmc {
-
-namespace {
-
-#ifdef __linux__
-tmc::detail::atomic_wait_t*
-wait_address(std::atomic<tmc::detail::atomic_wait_t>& Wait) noexcept {
-  static_assert(sizeof(tmc::detail::atomic_wait_t) == sizeof(uint32_t));
-  return reinterpret_cast<tmc::detail::atomic_wait_t*>(&Wait);
-}
-
-void notify_wait(std::atomic<tmc::detail::atomic_wait_t>& Wait) noexcept {
-  syscall(
-    SYS_futex, wait_address(Wait), FUTEX_WAKE_PRIVATE, 1, nullptr, nullptr, 0
-  );
-}
-#endif
-
-} // namespace
-
 bool ex_cpu_st::is_initialized() {
   return initialized.load(std::memory_order_relaxed);
 }
@@ -252,7 +233,7 @@ auto ex_cpu_st::make_worker(
     // The last waiter is statically reserved for the teardown signal
     waiters[PRIORITY_COUNT] = {
       .val = 0,
-      .uaddr = reinterpret_cast<uintptr_t>(wait_address(this->stop_wait)),
+      .uaddr = reinterpret_cast<uintptr_t>(&this->stop_wait),
       .flags = FUTEX_32 | FUTEX_PRIVATE_FLAG,
       .__reserved = 0,
     };
@@ -474,7 +455,10 @@ void ex_cpu_st::teardown() {
   thread_stopper.request_stop();
   stop_wait.store(1, std::memory_order_release);
 #ifdef __linux__
-  notify_wait(stop_wait);
+  syscall(
+    SYS_futex, reinterpret_cast<tmc::detail::atomic_waker_t*>(&stop_wait),
+    FUTEX_WAKE_PRIVATE, 1, nullptr, nullptr, 0
+  );
 #else
   wake_wait.fetch_add(1, std::memory_order_release);
   wake_wait.notify_one();

--- a/include/tmc/detail/ex_cpu_st.ipp
+++ b/include/tmc/detail/ex_cpu_st.ipp
@@ -136,6 +136,22 @@ void ex_cpu_st::clamp_priority(size_t& Priority) {
   }
 }
 
+void ex_cpu_st::request_yield(size_t Priority) {
+  if TMC_PRIORITY_CONSTEXPR (PRIORITY_COUNT > 1) {
+    auto currentPrio =
+      thread_state_data.yield_priority.load(std::memory_order_relaxed);
+    // 2 threads may request a task to yield at the same time. The thread with
+    // the higher priority (lower priority index) should prevail.
+    while (currentPrio > Priority) {
+      if (thread_state_data.yield_priority.compare_exchange_strong(
+            currentPrio, Priority, std::memory_order_acq_rel
+          )) {
+        return;
+      }
+    }
+  }
+}
+
 void ex_cpu_st::post(work_item&& Item, size_t Priority, size_t ThreadHint) {
   clamp_priority(Priority);
   bool fromExecThread =
@@ -144,8 +160,12 @@ void ex_cpu_st::post(work_item&& Item, size_t Priority, size_t ThreadHint) {
   // we should use the external queue to force FIFO ordering.
   if (fromExecThread && ThreadHint != 0) [[likely]] {
     private_work[Priority].push_back(static_cast<work_item&&>(Item));
+    request_yield(Priority);
   } else {
-    work_queues[Priority].post(static_cast<work_item&&>(Item));
+    bool didWake = work_queues[Priority].post(static_cast<work_item&&>(Item));
+    if (!didWake) {
+      request_yield(Priority);
+    }
   }
 }
 
@@ -469,10 +489,13 @@ void ex_cpu_st::teardown() {
   // the data. In those scenarios, it's possible for the queue destruction to
   // race with the futex wake of the producer. Wait for all of the failed wakes
   // to finish before destroying.
+  // On non-Linux, we can't distinguish failed from successful wakes, so we just
+  // wait for all wakes.
   while (true) {
     size_t wakeCount = 0;
     for (size_t i = 0; i < PRIORITY_COUNT; ++i) {
-      wakeCount += work_queues[i].wake_count.load(std::memory_order_acquire);
+      wakeCount +=
+        work_queues[i].wake_ref_count.load(std::memory_order_acquire);
     }
     if (wakeCount == wait_count.load(std::memory_order_acquire)) {
       break;

--- a/include/tmc/detail/qu_mpsc_blocking.hpp
+++ b/include/tmc/detail/qu_mpsc_blocking.hpp
@@ -1,0 +1,662 @@
+// Copyright (c) 2023-2026 Logan McDougall
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+// Unbounded MPSC queue using linked list of blocks. Uses a similar fetch-add
+// slot acquisition scheme to tmc::channel, but with various changes:
+// - consumers are single-threaded, so read offset does not need to be atomic
+// - queue cannot be closed
+// - single consumer's offset is non-atomic
+
+// Instead of hazard pointers, uses a quiescent-state based reclamation scheme:
+// 1. Producers reserve tickets with write_offset, then load write_block.
+// 2. The consumer enters a new block and publishes it as the new write_block.
+// 3. The consumer snapshots write_offset as the reclaim cutoff.
+// 4. Once read_offset reaches that cutoff, producers that may have observed the
+//    old write_block are done, so old blocks can be recycled.
+// This scheme works only with single-consumer queues since we can be sure that
+// after the consumer reached the cutoff, there are guaranteed to be no other
+// users of the old blocks.
+
+// This version is modified to allow callers to block. It is co-designed with
+// ex_cpu_st for an efficient blocking / reference counting scheme.
+
+#include "tmc/detail/compat.hpp"
+
+#include <array>
+#include <atomic>
+#include <cassert>
+#include <type_traits>
+#include <utility>
+
+#ifdef __linux__
+#include <linux/futex.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+#endif
+
+namespace tmc {
+namespace detail {
+// Allocates elements without constructing them, to be constructed later using
+// placement new. T need not be default, copy, or move constructible.
+// The caller must track whether the element exists, and manually invoke the
+// destructor if necessary.
+template <typename T> struct qu_mpsc_blocking_storage {
+  union alignas(alignof(T)) {
+    T value;
+  };
+#ifndef NDEBUG
+  bool exists = false;
+#endif
+
+  qu_mpsc_blocking_storage() noexcept {}
+
+  template <typename... ConstructArgs>
+  void emplace(ConstructArgs&&... Args) noexcept {
+#ifndef NDEBUG
+    assert(!exists);
+    exists = true;
+#endif
+    ::new (static_cast<void*>(&value)) T(static_cast<ConstructArgs&&>(Args)...);
+  }
+
+  void destroy() noexcept {
+#ifndef NDEBUG
+    assert(exists);
+    exists = false;
+#endif
+    value.~T();
+  }
+
+  // Precondition: Other.value must exist
+  qu_mpsc_blocking_storage(qu_mpsc_blocking_storage&& Other) noexcept {
+    emplace(static_cast<T&&>(Other.value));
+    Other.destroy();
+  }
+  qu_mpsc_blocking_storage&
+  operator=(qu_mpsc_blocking_storage&& Other) noexcept {
+    emplace(static_cast<T&&>(Other.value));
+    Other.destroy();
+    return *this;
+  }
+
+  // If data was present, the caller is responsible for destroying it.
+#ifndef NDEBUG
+  ~qu_mpsc_blocking_storage() { assert(!exists); }
+#else
+  ~qu_mpsc_blocking_storage()
+    requires(std::is_trivially_destructible_v<T>)
+  = default;
+  ~qu_mpsc_blocking_storage()
+    requires(!std::is_trivially_destructible_v<T>)
+  {}
+#endif
+
+  qu_mpsc_blocking_storage(const qu_mpsc_blocking_storage&) = delete;
+  qu_mpsc_blocking_storage& operator=(const qu_mpsc_blocking_storage&) = delete;
+};
+
+struct qu_mpsc_blocking_default_config {
+  /// The number of elements that can be stored in each block in the
+  /// qu_mpsc_blocking linked list.
+  static inline constexpr size_t BlockSize = 4096;
+
+  /// At level 0, queue elements will be padded up to the next increment of 64
+  /// bytes. This reduces false sharing between neighboring elements.
+  /// At level 1, no padding will be applied.
+  static inline constexpr size_t PackingLevel = 0;
+
+  /// If true, the first storage block will be a member of the qu_mpsc_blocking
+  /// object (instead of dynamically allocated). Subsequent storage blocks are
+  /// always dynamically allocated.
+  static inline constexpr bool EmbedFirstBlock = false;
+};
+
+template <
+  typename T, typename Config = tmc::detail::qu_mpsc_blocking_default_config>
+class qu_mpsc_blocking {
+  static inline constexpr size_t BlockSize = Config::BlockSize;
+  static inline constexpr size_t BlockSizeMask = BlockSize - 1;
+  static_assert(
+    BlockSize && ((BlockSize & (BlockSize - 1)) == 0),
+    "BlockSize must be a power of 2"
+  );
+
+  // Ensure that the subtraction of unsigned offsets always results in a value
+  // that can be represented as a signed integer.
+  static_assert(
+    BlockSize <= (TMC_ONE_BIT << (TMC_PLATFORM_BITS - 1)),
+    "BlockSize must not be larger than half the max value that can be "
+    "represented by a platform word"
+  );
+
+  // Implementing handling for throwing construction is not possible with the
+  // current design.
+  static_assert(std::is_nothrow_move_constructible_v<T>);
+
+private:
+  class element_t {
+    static inline constexpr tmc::detail::atomic_wait_t EMPTY = 0;
+    static inline constexpr tmc::detail::atomic_wait_t WAITING = 1;
+    static inline constexpr tmc::detail::atomic_wait_t DATA = 2;
+    std::atomic<tmc::detail::atomic_wait_t> flags;
+
+  public:
+    tmc::detail::qu_mpsc_blocking_storage<T> data;
+
+    static constexpr size_t UNPADLEN =
+      sizeof(std::atomic<tmc::detail::atomic_wait_t>) +
+      sizeof(tmc::detail::qu_mpsc_blocking_storage<T>);
+    static constexpr size_t WANTLEN = (UNPADLEN + TMC_CACHE_LINE_SIZE - 1) &
+                                      static_cast<size_t>(
+                                        0 - TMC_CACHE_LINE_SIZE
+                                      ); // round up to TMC_CACHE_LINE_SIZE
+    static constexpr size_t PADLEN =
+      UNPADLEN < WANTLEN ? (WANTLEN - UNPADLEN) : 999;
+
+    struct empty {};
+    using Padding = std::conditional_t<
+      Config::PackingLevel == 0 && PADLEN != 999, char[PADLEN], empty>;
+    TMC_NO_UNIQUE_ADDRESS Padding pad;
+
+    static constexpr tmc::detail::atomic_wait_t WAIT_VALUE = WAITING;
+
+    tmc::detail::atomic_wait_t* wait_address() noexcept {
+      return reinterpret_cast<tmc::detail::atomic_wait_t*>(&flags);
+    }
+
+    tmc::detail::atomic_wait_t* set_waiting_or_get_wait_address() noexcept {
+      tmc::detail::atomic_wait_t prev =
+        flags.exchange(WAITING, std::memory_order_seq_cst);
+      if (prev != DATA) {
+        return wait_address();
+      }
+      return nullptr;
+    }
+
+    // On Linux, returns true if we tried to wake a waiter but failed.
+    // On other OSes, returns true if waiter should be woken.
+    bool set_data_ready_and_notify_waiter() noexcept {
+      // On non-Linux, producer does store data -> load waiters on non-Linux. A
+      // StoreLoad barrier is required in between to prevent lost wakeups, hence
+      // the seq_cst ordering.
+      // On Linux, the futex provides the necessary barrier, but in practice
+      // seq_cst and acq_rel exchanges are identical on modern x86/ARM, so we
+      // use a single ordering for consistency.
+      tmc::detail::atomic_wait_t prev =
+        flags.exchange(DATA, std::memory_order_seq_cst);
+      if (prev != WAITING) {
+        return false;
+      }
+#ifdef __linux__
+      long woken = syscall(
+        SYS_futex, reinterpret_cast<tmc::detail::atomic_wait_t*>(&flags),
+        FUTEX_WAKE_PRIVATE, 1, nullptr, nullptr, 0
+      );
+      return woken == 0;
+#else
+      return true;
+#endif
+    }
+
+    bool is_data_waiting() noexcept {
+      return DATA == flags.load(std::memory_order_acquire);
+    }
+
+    void reset() noexcept { flags.store(EMPTY, std::memory_order_relaxed); }
+  };
+
+  using element = element_t;
+  static_assert(Config::PackingLevel < 2);
+
+  struct data_block {
+    std::atomic<size_t> offset;
+    std::atomic<data_block*> next;
+    std::array<element, BlockSize> values;
+
+    void reset_values() noexcept {
+      for (size_t i = 0; i < BlockSize; ++i) {
+        values[i].reset();
+      }
+    }
+
+    data_block(size_t Offset) noexcept {
+      offset.store(Offset, std::memory_order_relaxed);
+      next.store(nullptr, std::memory_order_relaxed);
+      reset_values();
+    }
+
+    data_block() noexcept : data_block(0) {}
+  };
+
+  static_assert(std::atomic<size_t>::is_always_lock_free);
+  static_assert(std::atomic<data_block*>::is_always_lock_free);
+  static_assert(std::atomic<tmc::detail::atomic_wait_t>::is_always_lock_free);
+
+  char pad0[TMC_CACHE_LINE_SIZE - sizeof(size_t)];
+  std::atomic<size_t> write_offset;
+  char pad1[TMC_CACHE_LINE_SIZE - sizeof(size_t)];
+  size_t read_offset;
+  data_block* read_block;
+  char pad2[TMC_CACHE_LINE_SIZE - sizeof(size_t) - sizeof(data_block*)];
+
+  std::atomic<data_block*> write_block;
+  data_block* head_block;
+  data_block* tail_block;
+
+  data_block* pending_reclaim_old_head;
+  data_block* pending_reclaim_new_head;
+  size_t pending_reclaim_cutoff;
+
+#ifndef __linux__
+  std::atomic<tmc::detail::atomic_wait_t>* wake_wait;
+#endif
+
+  struct empty {};
+  using EmbeddedBlock =
+    std::conditional_t<Config::EmbedFirstBlock, data_block, empty>;
+  TMC_NO_UNIQUE_ADDRESS EmbeddedBlock embedded_block;
+
+public:
+  class aw_pull;
+
+  // On Linux, counts only "failed wakes" - producer wake operations that
+  // observed a waiting consumer but woke no kernel waiter. The single consumer
+  // accounts for these before running the corresponding item; owners may wait
+  // for both sides to match before destroying the queue storage.
+  // On other OSes, counts all wakes, since the OS APIs don't provide the
+  // necessary information, AND the OS APIs don't support user-space multi-wait,
+  // instead requiring the use of kernel objects. So we just use C++20 standard
+  // std::atomic::wait on a single value shared across multiple queues.
+  std::atomic<size_t> wake_count;
+
+  qu_mpsc_blocking() noexcept {
+    data_block* block;
+    if constexpr (Config::EmbedFirstBlock) {
+      block = &embedded_block;
+    } else {
+      block = new data_block(0);
+    }
+    head_block = block;
+    write_block.store(block, std::memory_order_relaxed);
+    tail_block = block;
+    write_offset.store(0, std::memory_order_relaxed);
+    read_offset = 0;
+    read_block = block;
+    pending_reclaim_old_head = nullptr;
+    pending_reclaim_new_head = nullptr;
+    pending_reclaim_cutoff = 0;
+#ifndef __linux__
+    wake_wait = nullptr;
+#endif
+    wake_count.store(0, std::memory_order_relaxed);
+    tmc::detail::memory_barrier();
+  }
+
+private:
+  static inline bool circular_less_than(size_t a, size_t b) noexcept {
+    return a - b > (TMC_ONE_BIT << (TMC_PLATFORM_BITS - 1));
+  }
+
+  void reclaim_blocks(data_block* OldHead, data_block* NewHead) noexcept {
+    // Reset blocks and move them to the tail of the list in groups of 4.
+    while (true) {
+      std::array<data_block*, 4> unlinked;
+      size_t unlinkedCount = 0;
+      for (; unlinkedCount < unlinked.size(); ++unlinkedCount) {
+        if (OldHead == NewHead) {
+          break;
+        }
+        unlinked[unlinkedCount] = OldHead;
+        OldHead = OldHead->next.load(std::memory_order_acquire);
+      }
+      if (unlinkedCount == 0) {
+        break;
+      }
+
+      for (size_t i = 0; i < unlinkedCount; ++i) {
+        unlinked[i]->reset_values();
+      }
+
+      data_block* tailBlock = tail_block;
+      data_block* next = tailBlock->next.load(std::memory_order_acquire);
+
+      // Iterate forward in case tailBlock is part of unlinked.
+      while (next != nullptr) {
+        tailBlock = next;
+        next = tailBlock->next.load(std::memory_order_acquire);
+      }
+      // Actually unlink the blocks from the head of the queue.
+      // They stay linked to each other.
+      unlinked[unlinkedCount - 1]->next.store(
+        nullptr, std::memory_order_release
+      );
+
+      while (true) {
+        // Update their offsets to the end of the queue.
+        size_t boff =
+          tailBlock->offset.load(std::memory_order_relaxed) + BlockSize;
+        for (size_t i = 0; i < unlinkedCount; ++i) {
+          unlinked[i]->offset.store(boff, std::memory_order_relaxed);
+          boff += BlockSize;
+        }
+
+        // Re-link the tail of the queue to the head of the unlinked blocks.
+        if (tailBlock->next.compare_exchange_strong(
+              next, unlinked[0], std::memory_order_acq_rel,
+              std::memory_order_acquire
+            )) {
+          break;
+        }
+
+        // Tail was out of date, find the new tail.
+        while (next != nullptr) {
+          tailBlock = next;
+          next = tailBlock->next.load(std::memory_order_acquire);
+        }
+      }
+
+      tail_block = unlinked[unlinkedCount - 1];
+    }
+  }
+
+  // Given idx and a starting block, advance it until the block containing idx
+  // is found.
+  static inline data_block* find_block(data_block* Block, size_t Idx) noexcept {
+    size_t offset = Block->offset.load(std::memory_order_relaxed);
+    size_t targetOffset = Idx & ~BlockSizeMask;
+    // Find or allocate the associated block
+    while (offset != targetOffset) {
+      data_block* next = Block->next.load(std::memory_order_acquire);
+      if (next == nullptr) {
+        data_block* newBlock = new data_block(offset + BlockSize);
+        if (Block->next.compare_exchange_strong(
+              next, newBlock, std::memory_order_acq_rel,
+              std::memory_order_acquire
+            )) {
+          next = newBlock;
+        } else {
+          delete newBlock;
+        }
+      }
+      Block = next;
+      offset += BlockSize;
+      assert(Block->offset.load(std::memory_order_relaxed) == offset);
+    }
+
+    assert(
+      Idx >= Block->offset.load(std::memory_order_relaxed) &&
+      Idx <= Block->offset.load(std::memory_order_relaxed) + BlockSize - 1
+    );
+    return Block;
+  }
+
+  bool try_finish_pending_reclaim() noexcept {
+    if (pending_reclaim_old_head == nullptr) {
+      return false;
+    }
+
+    // The pending blocks were removed from the producer-visible write head
+    // before pending_reclaim_cutoff was read from write_offset. Any producer
+    // that can still be walking from the old write head must therefore have a
+    // reservation before this cutoff. Once the single consumer reaches the
+    // cutoff, those producers have published their elements and no longer touch
+    // the old blocks.
+    if (circular_less_than(read_offset, pending_reclaim_cutoff)) {
+      return false;
+    }
+
+    data_block* oldHead = pending_reclaim_old_head;
+    data_block* newHead = pending_reclaim_new_head;
+    head_block = newHead;
+    pending_reclaim_old_head = nullptr;
+    pending_reclaim_new_head = nullptr;
+    reclaim_blocks(oldHead, newHead);
+    return true;
+  }
+
+  void try_start_reclaim(data_block* NewHead) noexcept {
+    if (pending_reclaim_old_head != nullptr) {
+      return;
+    }
+
+    data_block* oldHead = head_block;
+    size_t newHeadOffset = read_offset & ~BlockSizeMask;
+    assert(NewHead->offset.load(std::memory_order_relaxed) == newHeadOffset);
+    size_t oldOff = oldHead->offset.load(std::memory_order_relaxed);
+    if (!circular_less_than(oldOff, newHeadOffset)) {
+      return;
+    }
+
+    // This seq_cst store and the following seq_cst write_offset load form the
+    // cutoff protocol with producers, which do a seq_cst fetch_add before a
+    // seq_cst load of write_block. A producer that observes the old write_block
+    // must have a reservation included in the cutoff.
+    write_block.store(NewHead, std::memory_order_seq_cst);
+    pending_reclaim_cutoff = write_offset.load(std::memory_order_seq_cst);
+    pending_reclaim_old_head = oldHead;
+    pending_reclaim_new_head = NewHead;
+  }
+
+  void try_reclaim_blocks(data_block* NewHead) noexcept {
+    try_finish_pending_reclaim();
+    try_start_reclaim(NewHead);
+    try_finish_pending_reclaim();
+  }
+
+  // Idx will be initialized by this function
+  element* get_write_ticket(size_t& Idx) noexcept {
+    // seq_cst is needed here so the reader can order its write_block update and
+    // subsequent write_offset load against the producer's reservation and
+    // write_block load.
+    Idx = write_offset.fetch_add(1, std::memory_order_seq_cst);
+    data_block* block = write_block.load(std::memory_order_seq_cst);
+
+    assert(
+      circular_less_than(block->offset.load(std::memory_order_relaxed), 1 + Idx)
+    );
+
+    block = find_block(block, Idx);
+    element* elem = &block->values[Idx & BlockSizeMask];
+    return elem;
+  }
+
+  element* get_read_ticket(size_t& Idx, data_block*& Block) noexcept {
+    Idx = read_offset;
+    Block = read_block;
+
+    assert(
+      circular_less_than(Block->offset.load(std::memory_order_relaxed), 1 + Idx)
+    );
+
+    Block = find_block(Block, Idx);
+    return &Block->values[Idx & BlockSizeMask];
+  }
+
+  void finish_read(element* Elem, data_block* Block, size_t Idx) noexcept {
+    Elem->data.destroy();
+    read_offset = Idx + 1;
+    // Only try to advance the producer-visible write head once the consumer
+    // has entered a new block. Pending reclaim may also complete here; if its
+    // cutoff was reached earlier, this delays recycling by at most one block
+    // while keeping the per-element hot path small.
+    if ((Idx & BlockSizeMask) == 0) {
+      read_block = Block;
+      try_reclaim_blocks(Block);
+    }
+  }
+
+  template <typename... Args>
+  void write_element(element* Elem, Args&&... ConstructArgs) noexcept {
+    Elem->data.emplace(std::forward<Args>(ConstructArgs)...);
+
+    if (Elem->set_data_ready_and_notify_waiter()) {
+      // On Linux the futex wait pointer is a member of the element.
+      // On other OSes it is an external pointer referenced by this queue.
+#ifndef __linux__
+      wake_wait->fetch_add(1, std::memory_order_release);
+      wake_wait->notify_one();
+#endif
+      wake_count.fetch_add(1, std::memory_order_release);
+    }
+  }
+
+  // StartIdx and EndIdx will be initialized by this function.
+  // Count must be non-zero (enforced by the caller).
+  data_block* get_write_ticket_bulk(
+    size_t Count, size_t& StartIdx, size_t& EndIdx
+  ) noexcept {
+    // seq_cst is needed here so the reader can order its write_block update and
+    // subsequent write_offset load against the producer's reservation and
+    // write_block load.
+    StartIdx = write_offset.fetch_add(Count, std::memory_order_seq_cst);
+    EndIdx = StartIdx + Count;
+    data_block* block = write_block.load(std::memory_order_seq_cst);
+
+    assert(circular_less_than(
+      block->offset.load(std::memory_order_relaxed), 1 + StartIdx
+    ));
+
+    // Ensure all blocks for the operation are allocated and available.
+    data_block* startBlock = find_block(block, StartIdx);
+    find_block(startBlock, EndIdx - 1);
+    return startBlock;
+  }
+
+public:
+  using wait_ptr = tmc::detail::atomic_wait_t*;
+  static constexpr tmc::detail::atomic_wait_t WAIT_VALUE = element::WAIT_VALUE;
+
+#ifndef __linux__
+  void
+  set_wake_wait(std::atomic<tmc::detail::atomic_wait_t>& WakeWait) noexcept {
+    wake_wait = &WakeWait;
+  }
+#endif
+
+  template <typename U> void post(U&& Val) noexcept {
+    // Get write ticket and associated block.
+    size_t idx;
+    element* elem = get_write_ticket(idx);
+
+    write_element(elem, static_cast<U&&>(Val));
+  }
+
+  template <typename It> void post_bulk(It&& Items, size_t Count) noexcept {
+    if (Count == 0) [[unlikely]] {
+      return;
+    }
+
+    // Get write ticket and associated block.
+    size_t startIdx, endIdx;
+    data_block* block = get_write_ticket_bulk(Count, startIdx, endIdx);
+
+    size_t idx = startIdx;
+    while (idx < endIdx) {
+      element* elem = &block->values[idx & BlockSizeMask];
+
+      TMC_DISABLE_WARNING_PESSIMIZING_MOVE_BEGIN
+      write_element(elem, std::move(*Items));
+      TMC_DISABLE_WARNING_PESSIMIZING_MOVE_END
+
+      ++Items;
+      ++idx;
+      if ((idx & BlockSizeMask) == 0) {
+        block = block->next.load(std::memory_order_acquire);
+        // all blocks should have been preallocated for [startIdx, endIdx)
+        assert(block != nullptr || idx >= endIdx);
+      }
+    }
+  }
+
+  // Only safe to call from the single consumer.
+  bool empty() {
+    size_t Idx = read_offset;
+    data_block* block = find_block(read_block, Idx);
+    element* elem = &block->values[Idx & BlockSizeMask];
+
+    bool isEmpty = !elem->is_data_waiting();
+    return isEmpty;
+  }
+
+  /// Attempts to pull a T into Output.
+  ///
+  /// Returns nullptr if a value was pulled into Output. Otherwise, returns the
+  /// address of the current element's wait word, which the caller may block on
+  /// until it differs from WAIT_VALUE. qu_mpsc_blocking has no close operation,
+  /// so callers that need to terminate a consumer loop should post a sentinel
+  /// value.
+  [[nodiscard]] wait_ptr pull(T& Output) noexcept {
+    static_assert(std::is_nothrow_move_constructible_v<T>);
+
+    size_t Idx;
+    data_block* block;
+    element* elem = get_read_ticket(Idx, block);
+
+    if (!elem->is_data_waiting()) {
+      wait_ptr waitAddress = elem->set_waiting_or_get_wait_address();
+      if (waitAddress != nullptr) {
+        return waitAddress;
+      }
+    }
+
+    Output = std::move(elem->data.value);
+    finish_read(elem, block, Idx);
+    return nullptr;
+  }
+
+  bool try_pull(T& output) {
+    size_t Idx;
+    data_block* block;
+    element* elem = get_read_ticket(Idx, block);
+
+    if (elem->is_data_waiting()) {
+      // Data is already ready here.
+      output = std::move(elem->data.value);
+      finish_read(elem, block, Idx);
+      return true;
+    }
+    return false;
+  }
+
+  ~qu_mpsc_blocking() {
+    {
+      size_t woff = write_offset.load(std::memory_order_relaxed);
+      size_t idx = read_offset;
+      data_block* block = head_block;
+      while (circular_less_than(idx, woff)) {
+        block = find_block(block, idx);
+        element* elem = &block->values[idx & BlockSizeMask];
+        if (elem->is_data_waiting()) {
+          elem->data.destroy();
+        }
+        ++idx;
+      }
+    }
+    {
+      data_block* block = head_block;
+      while (block != nullptr) {
+        data_block* next = block->next.load(std::memory_order_acquire);
+        if constexpr (Config::EmbedFirstBlock) {
+          if (block != &embedded_block) {
+            delete block;
+          }
+        } else {
+          delete block;
+        }
+        block = next;
+      }
+    }
+  }
+
+  qu_mpsc_blocking(const qu_mpsc_blocking&) = delete;
+  qu_mpsc_blocking& operator=(const qu_mpsc_blocking&) = delete;
+  qu_mpsc_blocking(qu_mpsc_blocking&&) = delete;
+  qu_mpsc_blocking& operator=(qu_mpsc_blocking&&) = delete;
+};
+
+} // namespace detail
+} // namespace tmc

--- a/include/tmc/detail/qu_mpsc_blocking.hpp
+++ b/include/tmc/detail/qu_mpsc_blocking.hpp
@@ -138,13 +138,12 @@ class qu_mpsc_blocking {
   static_assert(std::is_nothrow_move_constructible_v<T>);
 
 private:
-  class element_t {
+  struct element_t {
     static inline constexpr tmc::detail::atomic_wait_t EMPTY = 0;
     static inline constexpr tmc::detail::atomic_wait_t WAITING = 1;
     static inline constexpr tmc::detail::atomic_wait_t DATA = 2;
     std::atomic<tmc::detail::atomic_wait_t> flags;
 
-  public:
     tmc::detail::qu_mpsc_blocking_storage<T> data;
 
     static constexpr size_t UNPADLEN =
@@ -175,31 +174,6 @@ private:
         return wait_address();
       }
       return nullptr;
-    }
-
-    // On Linux, returns true if we tried to wake a waiter but failed.
-    // On other OSes, returns true if waiter should be woken.
-    bool set_data_ready_and_notify_waiter() noexcept {
-      // On non-Linux, producer does store data -> load waiters on non-Linux. A
-      // StoreLoad barrier is required in between to prevent lost wakeups, hence
-      // the seq_cst ordering.
-      // On Linux, the futex provides the necessary barrier, but in practice
-      // seq_cst and acq_rel exchanges are identical on modern x86/ARM, so we
-      // use a single ordering for consistency.
-      tmc::detail::atomic_wait_t prev =
-        flags.exchange(DATA, std::memory_order_seq_cst);
-      if (prev != WAITING) {
-        return false;
-      }
-#ifdef __linux__
-      long woken = syscall(
-        SYS_futex, reinterpret_cast<tmc::detail::atomic_wait_t*>(&flags),
-        FUTEX_WAKE_PRIVATE, 1, nullptr, nullptr, 0
-      );
-      return woken == 0;
-#else
-      return true;
-#endif
     }
 
     bool is_data_waiting() noexcept {
@@ -263,15 +237,17 @@ private:
 public:
   class aw_pull;
 
-  // On Linux, counts only "failed wakes" - producer wake operations that
-  // observed a waiting consumer but woke no kernel waiter. The single consumer
-  // accounts for these before running the corresponding item; owners may wait
-  // for both sides to match before destroying the queue storage.
-  // On other OSes, counts all wakes, since the OS APIs don't provide the
-  // necessary information, AND the OS APIs don't support user-space multi-wait,
-  // instead requiring the use of kernel objects. So we just use C++20 standard
-  // std::atomic::wait on a single value shared across multiple queues.
-  std::atomic<size_t> wake_count;
+  // Used as a reference count to prevent racing between producer syscall and
+  // consumer teardown. On Linux, counts only "failed wakes" - producer wake
+  // operations that observed a waiting consumer but woke no kernel waiter. The
+  // single consumer accounts for these before running the corresponding item;
+  // owners may wait for both sides to match before destroying the queue
+  // storage. On other OSes, counts all wakes, since the OS APIs don't provide
+  // the necessary information, AND the OS APIs don't support user-space
+  // multi-wait, instead requiring the use of kernel objects. So we just use
+  // C++20 standard std::atomic::wait on a single value shared across multiple
+  // queues.
+  std::atomic<size_t> wake_ref_count;
 
   qu_mpsc_blocking() noexcept {
     data_block* block;
@@ -292,7 +268,7 @@ public:
 #ifndef __linux__
     wake_wait = nullptr;
 #endif
-    wake_count.store(0, std::memory_order_relaxed);
+    wake_ref_count.store(0, std::memory_order_relaxed);
     tmc::detail::memory_barrier();
   }
 
@@ -489,19 +465,40 @@ private:
     }
   }
 
+  // Returns true if a waiter was found.
   template <typename... Args>
-  void write_element(element* Elem, Args&&... ConstructArgs) noexcept {
+  bool write_element(element* Elem, Args&&... ConstructArgs) noexcept {
     Elem->data.emplace(std::forward<Args>(ConstructArgs)...);
 
-    if (Elem->set_data_ready_and_notify_waiter()) {
-      // On Linux the futex wait pointer is a member of the element.
-      // On other OSes it is an external pointer referenced by this queue.
-#ifndef __linux__
-      wake_wait->fetch_add(1, std::memory_order_release);
-      wake_wait->notify_one();
-#endif
-      wake_count.fetch_add(1, std::memory_order_release);
+    // On non-Linux, producer does store data -> load waiters on non-Linux. A
+    // StoreLoad barrier is required in between to prevent lost wakeups, hence
+    // the seq_cst ordering.
+    // On Linux, the futex provides the necessary barrier, but in practice
+    // seq_cst and acq_rel exchanges are identical on modern x86/ARM, so we
+    // use a single ordering for consistency.
+    tmc::detail::atomic_wait_t prev =
+      Elem->flags.exchange(element_t::DATA, std::memory_order_seq_cst);
+    if (prev != element_t::WAITING) {
+      return false;
     }
+
+#ifdef __linux__
+    long wokenCount = syscall(
+      SYS_futex, reinterpret_cast<tmc::detail::atomic_wait_t*>(&Elem->flags),
+      FUTEX_WAKE_PRIVATE, 1, nullptr, nullptr, 0
+    );
+    assert(wokenCount >= 0);
+    bool didWake = wokenCount != 0;
+    if (!didWake) {
+      wake_ref_count.fetch_add(1, std::memory_order_release);
+    }
+    return didWake;
+#else
+    wake_wait->fetch_add(1, std::memory_order_release);
+    wake_wait->notify_one();
+    wake_ref_count.fetch_add(1, std::memory_order_release);
+    return true;
+#endif
   }
 
   // StartIdx and EndIdx will be initialized by this function.
@@ -537,17 +534,19 @@ public:
   }
 #endif
 
-  template <typename U> void post(U&& Val) noexcept {
+  // Returns true if a waiter was found.
+  template <typename U> bool post(U&& Val) noexcept {
     // Get write ticket and associated block.
     size_t idx;
     element* elem = get_write_ticket(idx);
 
-    write_element(elem, static_cast<U&&>(Val));
+    return write_element(elem, static_cast<U&&>(Val));
   }
 
-  template <typename It> void post_bulk(It&& Items, size_t Count) noexcept {
+  // Returns true if a waiter was found.
+  template <typename It> bool post_bulk(It&& Items, size_t Count) noexcept {
     if (Count == 0) [[unlikely]] {
-      return;
+      return false;
     }
 
     // Get write ticket and associated block.
@@ -555,11 +554,12 @@ public:
     data_block* block = get_write_ticket_bulk(Count, startIdx, endIdx);
 
     size_t idx = startIdx;
+    bool didWake = false;
     while (idx < endIdx) {
       element* elem = &block->values[idx & BlockSizeMask];
 
       TMC_DISABLE_WARNING_PESSIMIZING_MOVE_BEGIN
-      write_element(elem, std::move(*Items));
+      didWake |= write_element(elem, std::move(*Items));
       TMC_DISABLE_WARNING_PESSIMIZING_MOVE_END
 
       ++Items;
@@ -570,6 +570,7 @@ public:
         assert(block != nullptr || idx >= endIdx);
       }
     }
+    return didWake;
   }
 
   // Only safe to call from the single consumer.

--- a/include/tmc/detail/qu_mpsc_blocking.hpp
+++ b/include/tmc/detail/qu_mpsc_blocking.hpp
@@ -163,15 +163,11 @@ private:
 
     static constexpr tmc::detail::atomic_wait_t WAIT_VALUE = WAITING;
 
-    tmc::detail::atomic_wait_t* wait_address() noexcept {
-      return reinterpret_cast<tmc::detail::atomic_wait_t*>(&flags);
-    }
-
     tmc::detail::atomic_wait_t* set_waiting_or_get_wait_address() noexcept {
       tmc::detail::atomic_wait_t prev =
         flags.exchange(WAITING, std::memory_order_seq_cst);
       if (prev != DATA) {
-        return wait_address();
+        return reinterpret_cast<tmc::detail::atomic_wait_t*>(&flags);
       }
       return nullptr;
     }

--- a/include/tmc/ex_cpu_st.hpp
+++ b/include/tmc/ex_cpu_st.hpp
@@ -85,6 +85,7 @@ class ex_cpu_st {
   TMC_DECL bool is_initialized();
 
   TMC_DECL void clamp_priority(size_t& Priority);
+  TMC_DECL void request_yield(size_t Priority);
 
   TMC_DECL void init_thread_locals(size_t Slot);
   TMC_DECL void clear_thread_locals();
@@ -228,8 +229,13 @@ public:
           private_work[Priority].push_back(std::move(*Items));
           ++Items;
         }
+        request_yield(Priority);
       } else {
-        work_queues[Priority].post_bulk(static_cast<It&&>(Items), Count);
+        bool didWake =
+          work_queues[Priority].post_bulk(static_cast<It&&>(Items), Count);
+        if (!didWake) {
+          request_yield(Priority);
+        }
       }
     }
   }

--- a/include/tmc/ex_cpu_st.hpp
+++ b/include/tmc/ex_cpu_st.hpp
@@ -10,7 +10,7 @@
 #include "tmc/detail/compat.hpp"
 #include "tmc/detail/hwloc_unique_bitmap.hpp"
 #include "tmc/detail/init_params.hpp"
-#include "tmc/detail/qu_mpsc.hpp"
+#include "tmc/detail/qu_mpsc_blocking.hpp"
 #include "tmc/detail/thread_locals.hpp"
 #include "tmc/detail/tiny_vec.hpp"
 #include "tmc/ex_any.hpp"
@@ -30,19 +30,18 @@ namespace tmc {
 /// round-trip latency, and better internal execution performance, as it does
 /// not need internal synchronization mechanisms.
 class ex_cpu_st {
-  struct qu_cfg : tmc::detail::qu_mpsc_default_config {
+  struct qu_cfg : tmc::detail::qu_mpsc_blocking_default_config {
     static inline constexpr size_t BlockSize = 16384;
     static inline constexpr size_t PackingLevel = 1;
     // static inline constexpr bool EmbedFirstBlock = false;
   };
-  enum class WorkerState : uint8_t { SLEEPING, WORKING, SPINNING };
 
   tmc::detail::InitParams* init_params; // accessed only during init()
 
   std::jthread worker_thread;
   tmc::ex_any type_erased_this;
 
-  using task_queue_t = tmc::detail::qu_mpsc<work_item, qu_cfg>;
+  using task_queue_t = tmc::detail::qu_mpsc_blocking<work_item, qu_cfg>;
   tmc::detail::tiny_vec<task_queue_t> work_queues; // size() == PRIORITY_COUNT
 
   tmc::detail::tiny_vec<std::vector<work_item>>
@@ -52,20 +51,25 @@ class ex_cpu_st {
   size_t spins;
 
   std::atomic<bool> initialized;
-  std::atomic<WorkerState> thread_state;
+  std::atomic<tmc::detail::atomic_wait_t> stop_wait;
+
+  // On Linux, counts only "failed waits" - queue items consumed after the
+  // worker had published a wait state, but before it was actually woken by a
+  // producer wake operation. This is possible since futex signals whether wake
+  // actually woke anything, and whether wait actually waited.
+  // On other OSes, counts all waits, since the OS APIs don't provide the
+  // necessary information, AND the OS APIs don't support user-space multi-wait,
+  // instead requiring the use of kernel objects. So we just use C++20 standard
+  // std::atomic::wait on a single value shared across all queues.
+  std::atomic<size_t> wait_count;
+#ifndef __linux__
+  std::atomic<tmc::detail::atomic_wait_t> wake_wait;
+#endif
 
   struct ThreadState {
     std::atomic<size_t> yield_priority; // check to yield to a higher prio task
-    std::atomic<tmc::detail::atomic_waker_t>
-      sleep_wait; // futex waker for this thread
   };
   ThreadState thread_state_data;
-  // ref_count prevents a race condition between post() which resumes a task
-  // that completes and destroys the executor before the post() call completes -
-  // after the enqueue, before the notify_n step. This can only happen when
-  // post() is called by non-executor threads; if an executor thread is still
-  // running, the join() call in the destructor will block until it completes.
-  std::atomic<size_t> ref_count;
 
   // capitalized variables are constant while ex_cpu_st is initialized & running
 #ifdef TMC_PRIORITY_COUNT
@@ -82,7 +86,6 @@ class ex_cpu_st {
 
   TMC_DECL void clamp_priority(size_t& Priority);
 
-  TMC_DECL void notify_n(size_t Priority, bool FromExecThread);
   TMC_DECL void init_thread_locals(size_t Slot);
   TMC_DECL void clear_thread_locals();
 
@@ -99,16 +102,12 @@ class ex_cpu_st {
 
   // returns true if no tasks were found (caller should wait on cv)
   // returns false if thread stop requested (caller should exit)
-  TMC_DECL bool
-  try_run_some(std::stop_token& ThreadStopToken, size_t& PrevPriority);
-
-  TMC_DECL void run_one(
-    tmc::work_item& Item, const size_t Prio, size_t& PrevPriority,
-    bool& WasSpinning
+  TMC_DECL bool try_run_some(
+    std::stop_token& ThreadStopToken, size_t& PrevPriority, bool* DidSleep
   );
 
-  TMC_DECL void set_state(WorkerState NewState);
-  TMC_DECL WorkerState get_state();
+  TMC_DECL void
+  run_one(tmc::work_item& Item, const size_t Prio, size_t& PrevPriority);
 
   TMC_DECL std::coroutine_handle<>
   dispatch(std::coroutine_handle<> Outer, size_t Priority);
@@ -151,7 +150,8 @@ public:
   /// after it finishes running a batch of tasks, before entering the
   /// spinning/sleeping phase. If the hook returns true, the worker will
   /// immediately re-enter the run loop to check for more work.
-  TMC_DECL ex_cpu_st& set_thread_post_run_hook(std::function<bool(size_t)> Hook);
+  TMC_DECL ex_cpu_st&
+  set_thread_post_run_hook(std::function<bool(size_t)> Hook);
 
   /// Builder func to set a hook that will be invoked at the startup of the
   /// executor thread, and passed the ordinal index of the thread (which is
@@ -228,12 +228,8 @@ public:
           private_work[Priority].push_back(std::move(*Items));
           ++Items;
         }
-        notify_n(Priority, fromExecThread);
       } else {
-        ++ref_count;
         work_queues[Priority].post_bulk(static_cast<It&&>(Items), Count);
-        notify_n(Priority, fromExecThread);
-        --ref_count;
       }
     }
   }


### PR DESCRIPTION
This is an internal performance enhancement with no API changes.

https://github.com/tzcnt/TooManyCooks/pull/129 documents a race condition between post() + notify() and teardown() that can occur when post() submits the final task that ultimately leads to the end of the executor's lifetime. Previously this was solved with a ref_count that was always inc/dec by the external executor thread, but that's quite expensive, adding two additional locked instructions to the path.

The new implementation signals via the specific queue element slot's flags whether or not the consumer intends to sleep, and producers only need to increment this counter when they wake a consumer. This is paired with a counter on the consumer side that only increments after it tries to sleep. On Linux, this can be optimized further and we only need to increment the counter when waking/waiting fails (the race condition only occurs when the consumer sees the data is ready flag before actually going to sleep, causing the futex wait to return EAGAIN). In teardown() we check that these two counters are equal to each other, instead of checking that the ref_count == 0.

The legacy implementation also required a memory barrier between storing the data and double-checking the consumer sleep state. With the new implementation, this is achieved using a seq-cst exchange + load (which on x86 has no additional overhead compared to the normal queue producer-consumer synchronization).

The legacy implementation could also result in multiple producers issuing syscalls in parallel when waking a consumer. The new implementation ensures that only a single producer can wake a consumer.

This improves performance in a ex_cpu_st <-> ex_cpu_st roundtrip bench when using `.set_spins(80)` on both the producer and the consumer from:
| bench | old | new |
| --- | --- | --- |
| unloaded (1 producer) | 3.3M ops/sec | 5.1M ops/sec |
| loaded (32 producers) | 6.7M ops/sec | 18M ops/sec |

Note the performance in this benchmark actually degrades in the 1-producer case without `set_spins`, from 2.9M ops/sec -> 254K ops/sec, because the new design is much more efficient at finishing the post() operation, so each executor finds its own queue empty and goes to sleep before the other executor returns. This benchmark issue can be rectified by setting `.set_spins(40)` to keep the executors spinning during the ping-pong. This comes out to approx. 1 us of spinning. I considered increasing the number of spins by default, but decided not to, as I believe it would be rare for this particular scenario to occur - most of the time, the producer will be another kind of executor, and will be publishing work infrequently to an ex_cpu_st, and I don't want to artificially consume ~1us of latency every time the user publishes a single work item. I'll add a note in the release notes about this behavior and recommend users increase the number of spins if needed.

---

The original design was borne from treating the individual queues + executor overall sleep wake/mechanism as separate objects and building the functionality from that. This new design instead relies on integrated codesign, making the queue no longer general-purpose. I've already identified an opportunity to take the learnings from this and apply it to the multi-threaded ex_cpu as well.