### PR TITLE
External producers to ex_cpu can safely skip waking

### DIFF
--- a/include/tmc/detail/ex_cpu.ipp
+++ b/include/tmc/detail/ex_cpu.ipp
@@ -266,20 +266,19 @@ INTERRUPT_DONE:
     else {
       // If we get here, no sleeping thread was found, and this thread isn't
       // part of the allowed priority group. This is a last-chance fallback to
-      // prevent the whole priority group from sleeping with queued work. The
-      // priority's sentinel thread publishes intent before its final queue
-      // check; producers that see that intent claim the wake by swapping in
-      // WAKE. If the state is not WAIT, the sentinel is either running/spinning
-      // or a different producer already claimed the fallback wake.
+      // prevent a lost wakeup for the whole priority group. The priority's
+      // sentinel thread publishes intent before its final queue check;
+      // producers that see that intent claim the wake by swapping in WAKE. If
+      // the state is not WAIT, the sentinel is either running/spinning or a
+      // different producer already claimed the fallback wake.
       tmc::detail::memory_barrier();
       if (FALLBACK_WAKE_WAIT !=
-          fallback_wake_states[Priority].state.load(std::memory_order_acquire)) {
+          fallback_wake_states[Priority].load(std::memory_order_acquire)) {
         return;
       }
-      if (FALLBACK_WAKE_WAIT !=
-          fallback_wake_states[Priority].state.exchange(
-            FALLBACK_WAKE_WAKE, std::memory_order_acq_rel
-          )) {
+      if (FALLBACK_WAKE_WAIT != fallback_wake_states[Priority].exchange(
+                                  FALLBACK_WAKE_WAKE, std::memory_order_acq_rel
+                                )) {
         return;
       }
       slot = waker_matrix[Priority].get_row(0)[0];
@@ -562,8 +561,8 @@ auto ex_cpu::make_worker(
     auto clearFallbackWakeStates = [&]() {
       for (size_t prio = PriorityRangeBegin; prio < PriorityRangeEnd; ++prio) {
         if (isFallbackSentinel(prio)) {
-          fallback_wake_states[prio].state.store(
-            FALLBACK_WAKE_NONE, std::memory_order_seq_cst
+          fallback_wake_states[prio].store(
+            FALLBACK_WAKE_NONE, std::memory_order_release
           );
         }
       }
@@ -628,12 +627,12 @@ auto ex_cpu::make_worker(
       bool skipWait = false;
       for (size_t prio = PriorityRangeBegin; prio < PriorityRangeEnd; ++prio) {
         if (isFallbackSentinel(prio)) {
-          auto wakeState = fallback_wake_states[prio].state.exchange(
+          auto wakeState = fallback_wake_states[prio].exchange(
             FALLBACK_WAKE_WAIT, std::memory_order_seq_cst
           );
           if (wakeState == FALLBACK_WAKE_WAKE) {
-            fallback_wake_states[prio].state.store(
-              FALLBACK_WAKE_NONE, std::memory_order_seq_cst
+            fallback_wake_states[prio].store(
+              FALLBACK_WAKE_NONE, std::memory_order_release
             );
             skipWait = true;
           }
@@ -699,10 +698,8 @@ void ex_cpu::init() {
   NO_TASK_RUNNING = PRIORITY_COUNT;
 #endif
   task_stopper_bitsets = new tmc::detail::atomic_bitmap[PRIORITY_COUNT];
-  fallback_wake_states.resize(PRIORITY_COUNT);
   for (size_t prio = 0; prio < PRIORITY_COUNT; ++prio) {
-    fallback_wake_states.emplace_at(prio);
-    fallback_wake_states[prio].state.store(
+    fallback_wake_states[prio].store(
       FALLBACK_WAKE_NONE, std::memory_order_relaxed
     );
   }
@@ -1309,7 +1306,6 @@ void ex_cpu::teardown() {
   work_queues.clear();
   working_threads_bitset.clear();
   spinning_threads_bitset.clear();
-  fallback_wake_states.clear();
   if (task_stopper_bitsets != nullptr) {
     delete[] task_stopper_bitsets;
     task_stopper_bitsets = nullptr;

--- a/include/tmc/detail/ex_cpu.ipp
+++ b/include/tmc/detail/ex_cpu.ipp
@@ -555,21 +555,16 @@ auto ex_cpu::make_worker(
 
     // Initialization complete, commence runloop
     size_t previousPrio = NO_TASK_RUNNING;
-    auto isFallbackSentinel = [this, Slot](size_t Prio) {
-      return waker_matrix[Prio].get_row(0)[0] == Slot;
-    };
-    auto clearFallbackWakeStates = [&]() {
+  TOP:
+    while (true) {
+      bool spinning = true;
       for (size_t prio = PriorityRangeBegin; prio < PriorityRangeEnd; ++prio) {
-        if (isFallbackSentinel(prio)) {
+        if (waker_matrix[prio].get_row(0)[0] == Slot) {
           fallback_wake_states[prio].store(
             FALLBACK_WAKE_NONE, std::memory_order_release
           );
         }
       }
-    };
-  TOP:
-    while (true) {
-      bool spinning = true;
     AGAIN:
       if (!try_run_some(
             ThreadStopToken, Slot, PriorityRangeBegin, PriorityRangeEnd,
@@ -624,17 +619,13 @@ auto ex_cpu::make_worker(
       // Transition from spinning to sleeping.
       auto waitValue =
         thread_states[Slot].sleep_wait.load(std::memory_order_relaxed);
-      bool skipWait = false;
       for (size_t prio = PriorityRangeBegin; prio < PriorityRangeEnd; ++prio) {
-        if (isFallbackSentinel(prio)) {
+        if (waker_matrix[prio].get_row(0)[0] == Slot) {
           auto wakeState = fallback_wake_states[prio].exchange(
             FALLBACK_WAKE_WAIT, std::memory_order_seq_cst
           );
           if (wakeState == FALLBACK_WAKE_WAKE) {
-            fallback_wake_states[prio].store(
-              FALLBACK_WAKE_NONE, std::memory_order_release
-            );
-            skipWait = true;
+            goto TOP;
           }
         }
       }
@@ -645,13 +636,11 @@ auto ex_cpu::make_worker(
 
       // Double-check for work
       if (!thread_states[Slot].inbox->empty()) {
-        clearFallbackWakeStates();
         spinning_threads_bitset.set_bit(Slot);
         goto TOP;
       }
       for (size_t prio = PriorityRangeBegin; prio < PriorityRangeEnd; ++prio) {
         if (!work_queues[prio].empty()) {
-          clearFallbackWakeStates();
           spinning_threads_bitset.set_bit(Slot);
           goto TOP;
         }
@@ -659,13 +648,9 @@ auto ex_cpu::make_worker(
 
       // No work found. Go to sleep.
       if (ThreadStopToken.stop_requested()) [[unlikely]] {
-        clearFallbackWakeStates();
         break;
       }
-      if (!skipWait) {
-        thread_states[Slot].sleep_wait.wait(waitValue);
-      }
-      clearFallbackWakeStates();
+      thread_states[Slot].sleep_wait.wait(waitValue);
       spinning_threads_bitset.set_bit(Slot);
     }
 

--- a/include/tmc/detail/ex_cpu.ipp
+++ b/include/tmc/detail/ex_cpu.ipp
@@ -265,8 +265,23 @@ INTERRUPT_DONE:
 #endif
     else {
       // If we get here, no sleeping thread was found, and this thread isn't
-      // part of the allowed priority group. Wake 1 thread to prevent lost
-      // wakeups.
+      // part of the allowed priority group. This is a last-chance fallback to
+      // prevent the whole priority group from sleeping with queued work. The
+      // priority's sentinel thread publishes intent before its final queue
+      // check; producers that see that intent claim the wake by swapping in
+      // WAKE. If the state is not WAIT, the sentinel is either running/spinning
+      // or a different producer already claimed the fallback wake.
+      tmc::detail::memory_barrier();
+      if (FALLBACK_WAKE_WAIT !=
+          fallback_wake_states[Priority].state.load(std::memory_order_acquire)) {
+        return;
+      }
+      if (FALLBACK_WAKE_WAIT !=
+          fallback_wake_states[Priority].state.exchange(
+            FALLBACK_WAKE_WAKE, std::memory_order_acq_rel
+          )) {
+        return;
+      }
       slot = waker_matrix[Priority].get_row(0)[0];
     }
     thread_states[slot].sleep_wait.fetch_add(1, std::memory_order_acq_rel);
@@ -541,6 +556,18 @@ auto ex_cpu::make_worker(
 
     // Initialization complete, commence runloop
     size_t previousPrio = NO_TASK_RUNNING;
+    auto isFallbackSentinel = [this, Slot](size_t Prio) {
+      return waker_matrix[Prio].get_row(0)[0] == Slot;
+    };
+    auto clearFallbackWakeStates = [&]() {
+      for (size_t prio = PriorityRangeBegin; prio < PriorityRangeEnd; ++prio) {
+        if (isFallbackSentinel(prio)) {
+          fallback_wake_states[prio].state.store(
+            FALLBACK_WAKE_NONE, std::memory_order_seq_cst
+          );
+        }
+      }
+    };
   TOP:
     while (true) {
       bool spinning = true;
@@ -577,7 +604,8 @@ auto ex_cpu::make_worker(
           if (!thread_states[Slot].inbox->empty()) {
             goto TOP;
           }
-          for (size_t prio = 0; prio < PRIORITY_COUNT; ++prio) {
+          for (size_t prio = PriorityRangeBegin; prio < PriorityRangeEnd;
+               ++prio) {
             if (!work_queues[prio].empty()) {
               goto TOP;
             }
@@ -597,6 +625,20 @@ auto ex_cpu::make_worker(
       // Transition from spinning to sleeping.
       auto waitValue =
         thread_states[Slot].sleep_wait.load(std::memory_order_relaxed);
+      bool skipWait = false;
+      for (size_t prio = PriorityRangeBegin; prio < PriorityRangeEnd; ++prio) {
+        if (isFallbackSentinel(prio)) {
+          auto wakeState = fallback_wake_states[prio].state.exchange(
+            FALLBACK_WAKE_WAIT, std::memory_order_seq_cst
+          );
+          if (wakeState == FALLBACK_WAKE_WAKE) {
+            fallback_wake_states[prio].state.store(
+              FALLBACK_WAKE_NONE, std::memory_order_seq_cst
+            );
+            skipWait = true;
+          }
+        }
+      }
       spinning_threads_bitset.clr_bit(Slot);
 
       // StoreLoad barrier to prevent lost wakeups
@@ -604,11 +646,13 @@ auto ex_cpu::make_worker(
 
       // Double-check for work
       if (!thread_states[Slot].inbox->empty()) {
+        clearFallbackWakeStates();
         spinning_threads_bitset.set_bit(Slot);
         goto TOP;
       }
-      for (size_t prio = 0; prio < PRIORITY_COUNT; ++prio) {
+      for (size_t prio = PriorityRangeBegin; prio < PriorityRangeEnd; ++prio) {
         if (!work_queues[prio].empty()) {
+          clearFallbackWakeStates();
           spinning_threads_bitset.set_bit(Slot);
           goto TOP;
         }
@@ -616,9 +660,13 @@ auto ex_cpu::make_worker(
 
       // No work found. Go to sleep.
       if (ThreadStopToken.stop_requested()) [[unlikely]] {
+        clearFallbackWakeStates();
         break;
       }
-      thread_states[Slot].sleep_wait.wait(waitValue);
+      if (!skipWait) {
+        thread_states[Slot].sleep_wait.wait(waitValue);
+      }
+      clearFallbackWakeStates();
       spinning_threads_bitset.set_bit(Slot);
     }
 
@@ -651,6 +699,13 @@ void ex_cpu::init() {
   NO_TASK_RUNNING = PRIORITY_COUNT;
 #endif
   task_stopper_bitsets = new tmc::detail::atomic_bitmap[PRIORITY_COUNT];
+  fallback_wake_states.resize(PRIORITY_COUNT);
+  for (size_t prio = 0; prio < PRIORITY_COUNT; ++prio) {
+    fallback_wake_states.emplace_at(prio);
+    fallback_wake_states[prio].state.store(
+      FALLBACK_WAKE_NONE, std::memory_order_relaxed
+    );
+  }
 
   if (init_params == nullptr) {
     init_params = new tmc::detail::InitParams;
@@ -1254,6 +1309,7 @@ void ex_cpu::teardown() {
   work_queues.clear();
   working_threads_bitset.clear();
   spinning_threads_bitset.clear();
+  fallback_wake_states.clear();
   if (task_stopper_bitsets != nullptr) {
     delete[] task_stopper_bitsets;
     task_stopper_bitsets = nullptr;

--- a/include/tmc/detail/ex_cpu.ipp
+++ b/include/tmc/detail/ex_cpu.ipp
@@ -559,6 +559,8 @@ auto ex_cpu::make_worker(
     while (true) {
       bool spinning = true;
       for (size_t prio = PriorityRangeBegin; prio < PriorityRangeEnd; ++prio) {
+        // Only clear the fallback wake if this thread is the sentinel thread
+        // (index 0) for this priority.
         if (waker_matrix[prio].get_row(0)[0] == Slot) {
           fallback_wake_states[prio].store(
             FALLBACK_WAKE_NONE, std::memory_order_release
@@ -620,6 +622,8 @@ auto ex_cpu::make_worker(
       auto waitValue =
         thread_states[Slot].sleep_wait.load(std::memory_order_relaxed);
       for (size_t prio = PriorityRangeBegin; prio < PriorityRangeEnd; ++prio) {
+        // Only set the fallback wake to prevent lost wakeups if this thread is
+        // the sentinel thread (index 0) for this priority.
         if (waker_matrix[prio].get_row(0)[0] == Slot) {
           auto wakeState = fallback_wake_states[prio].exchange(
             FALLBACK_WAKE_WAIT, std::memory_order_seq_cst

--- a/include/tmc/ex_cpu.hpp
+++ b/include/tmc/ex_cpu.hpp
@@ -80,7 +80,7 @@ private:
   // the priority's sentinel thread is not trying to sleep, and coalesces
   // simultaneous fallback producers so only one performs the wake syscall.
   // These are cache-packed because it's likely that a single
-  // thread is the sentinel for most or all of these priorities.
+  // thread is the sentinel for multiple priorities.
   std::array<std::atomic<tmc::detail::atomic_waker_t>, TMC_MAX_PRIORITY_COUNT>
     fallback_wake_states;
   // ref_count prevents a race condition between post() which resumes a task

--- a/include/tmc/ex_cpu.hpp
+++ b/include/tmc/ex_cpu.hpp
@@ -76,16 +76,12 @@ private:
   tmc::detail::atomic_bitmap working_threads_bitset;
   tmc::detail::atomic_bitmap spinning_threads_bitset;
   char pad1[TMC_CACHE_LINE_SIZE - 2 * sizeof(size_t)];
-  static constexpr tmc::detail::atomic_waker_t FALLBACK_WAKE_NONE = 0;
-  static constexpr tmc::detail::atomic_waker_t FALLBACK_WAKE_WAIT = 1;
-  static constexpr tmc::detail::atomic_waker_t FALLBACK_WAKE_WAKE = 2;
-  struct alignas(TMC_CACHE_LINE_SIZE) FallbackWakeState {
-    std::atomic<tmc::detail::atomic_waker_t> state;
-  };
   // Last-chance wake handshake per priority. This avoids the fallback wake when
   // the priority's sentinel thread is not trying to sleep, and coalesces
   // simultaneous fallback producers so only one performs the wake syscall.
-  tmc::detail::tiny_vec<FallbackWakeState, TMC_CACHE_LINE_SIZE>
+  // These are cache-packed because it's likely that a single
+  // thread is the sentinel for most or all of these priorities.
+  std::array<std::atomic<tmc::detail::atomic_waker_t>, TMC_MAX_PRIORITY_COUNT>
     fallback_wake_states;
   // ref_count prevents a race condition between post() which resumes a task
   // that completes and destroys the ex_cpu before the post() call completes -
@@ -105,6 +101,10 @@ private:
   size_t PRIORITY_COUNT;
   size_t NO_TASK_RUNNING;
 #endif
+
+  static constexpr tmc::detail::atomic_waker_t FALLBACK_WAKE_NONE = 0;
+  static constexpr tmc::detail::atomic_waker_t FALLBACK_WAKE_WAIT = 1;
+  static constexpr tmc::detail::atomic_waker_t FALLBACK_WAKE_WAKE = 2;
 
   TMC_DECL bool is_initialized();
 

--- a/include/tmc/ex_cpu.hpp
+++ b/include/tmc/ex_cpu.hpp
@@ -76,6 +76,17 @@ private:
   tmc::detail::atomic_bitmap working_threads_bitset;
   tmc::detail::atomic_bitmap spinning_threads_bitset;
   char pad1[TMC_CACHE_LINE_SIZE - 2 * sizeof(size_t)];
+  static constexpr tmc::detail::atomic_waker_t FALLBACK_WAKE_NONE = 0;
+  static constexpr tmc::detail::atomic_waker_t FALLBACK_WAKE_WAIT = 1;
+  static constexpr tmc::detail::atomic_waker_t FALLBACK_WAKE_WAKE = 2;
+  struct alignas(TMC_CACHE_LINE_SIZE) FallbackWakeState {
+    std::atomic<tmc::detail::atomic_waker_t> state;
+  };
+  // Last-chance wake handshake per priority. This avoids the fallback wake when
+  // the priority's sentinel thread is not trying to sleep, and coalesces
+  // simultaneous fallback producers so only one performs the wake syscall.
+  tmc::detail::tiny_vec<FallbackWakeState, TMC_CACHE_LINE_SIZE>
+    fallback_wake_states;
   // ref_count prevents a race condition between post() which resumes a task
   // that completes and destroys the ex_cpu before the post() call completes -
   // after the enqueue, before the notify_n step. This can only happen when


### PR DESCRIPTION
We use the sleeping_threads_bitset / working_threads_bitset as a hint as to which thread to wake. However, these are not strongly ordered and it's possible for them to be slightly out of date, which could lead to lost wakeups from an external thread. Previously this was solved by always attempting to wake thread 0 as a fallback when no sleeping thread was found to wake when post() / post_bulk() was called by an external thread.

The new design uses a synchronization value that is set only by the lowest-index thread for each priority when that thread goes to sleep. This value is strongly synchronized with the producer threads, and they only wake that thread when they can confirm that it's asleep. This has the most impact when the executor is fully saturated and all threads are working, where the external producer can now skip waking entirely.

This leads to a small but consistent performance improvement in exec_st_roundtrip_bench with the ex_cpu.set_thread_count(1) target.

| bench | old | new |
| --- | --- | --- |
| unloaded (1 producer) | 3.5M ops/sec | 3.6M ops/sec |
| loaded (32 producers) | 8.4M ops/sec | 9.2M ops/sec |