### PR TITLE
ex_braid is built on qu_mpsc instead of channel

### DIFF
--- a/.github/workflows/topology.yml
+++ b/.github/workflows/topology.yml
@@ -1,4 +1,4 @@
-name: x64-linux-clang
+name: topology
 
 on:
   push:
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        PRESET: [clang-linux-debug, clang-linux-release]
-        WORK_ITEM: [CORO, FUNCORO]
+        PRESET: [clang-linux-debug]
+        WORK_ITEM: [CORO]
     steps:
     - name: install-hwloc
       run: sudo apt-get update && sudo apt-get install -y hwloc libhwloc-dev

--- a/include/tmc/detail/coro_functor.hpp
+++ b/include/tmc/detail/coro_functor.hpp
@@ -7,6 +7,7 @@
 
 #include <cassert>
 #include <coroutine>
+#include <cstddef>
 #include <cstdint>
 #include <type_traits>
 
@@ -60,6 +61,14 @@ public:
     return mode == IS_COROUTINE;
   }
 
+  inline bool operator==(std::nullptr_t) const noexcept {
+    return func == nullptr;
+  }
+
+  inline bool operator!=(std::nullptr_t) const noexcept {
+    return func != nullptr;
+  }
+
   /// Returns the pointer as a coroutine handle. This is only valid if this
   /// was constructed with a coroutine type. `as_coroutine()` will not
   /// convert a regular function into a coroutine.
@@ -80,6 +89,12 @@ public:
   inline coro_functor(void (*FreeFunction)()) noexcept {
     func = reinterpret_cast<void*>(FreeFunction);
     obj = reinterpret_cast<void*>(IS_FREE_FUNC);
+  }
+
+  /// Null constructor, used for sentinel values.
+  inline coro_functor(std::nullptr_t) noexcept {
+    func = nullptr;
+    obj = nullptr;
   }
 
 private:

--- a/include/tmc/detail/ex_braid.ipp
+++ b/include/tmc/detail/ex_braid.ipp
@@ -9,24 +9,24 @@
 
 #pragma once
 
-#include "tmc/channel.hpp"
 #include "tmc/detail/impl.hpp" // IWYU pragma: keep
 #include "tmc/detail/thread_locals.hpp"
 #include "tmc/ex_any.hpp"
 #include "tmc/ex_braid.hpp"
 #include "tmc/work_item.hpp"
 
-#include <atomic>
+#include <cassert>
 #include <coroutine>
 
 namespace tmc {
-tmc::task<void> ex_braid::run_loop(
-  tmc::chan_tok<tmc::detail::braid_work_item, tmc::detail::braid_chan_config>
-    Chan
-) {
+tmc::task<void> ex_braid::run_loop(std::shared_ptr<task_queue_t> Queue) {
   auto parentExecutor = tmc::detail::this_thread::executor();
-  while (auto data = co_await Chan.pull()) {
-    auto& item = data.value();
+  while (true) {
+    auto item = co_await Queue->pull();
+    if (item.item == nullptr) {
+      // teardown() was called
+      co_return;
+    }
 
     auto storedContext = tmc::detail::this_thread::this_task();
     tmc::detail::this_thread::this_task().prio = item.prio;
@@ -44,18 +44,14 @@ tmc::task<void> ex_braid::run_loop(
 void ex_braid::post(
   work_item&& Item, size_t Priority, [[maybe_unused]] size_t ThreadHint
 ) {
-  // This may be called from multiple threads. Thus, each call must
-  // maintain its own refcount / hazard pointer.
-  auto tok = queue.new_token();
-  tok.post(
+  assert(Item != nullptr);
+  queue->post(
     tmc::detail::braid_work_item{static_cast<work_item&&>(Item), Priority}
   );
 }
 
 ex_braid::ex_braid(tmc::ex_any* Parent)
-    : queue{tmc::make_channel<
-        tmc::detail::braid_work_item, tmc::detail::braid_chan_config>()},
-      type_erased_this(this) {
+    : queue{std::make_shared<task_queue_t>()}, type_erased_this(this) {
   if (Parent == nullptr) {
     Parent = tmc::detail::g_ex_default.load(std::memory_order_acquire);
   }
@@ -64,16 +60,17 @@ ex_braid::ex_braid(tmc::ex_any* Parent)
 
 ex_braid::ex_braid() : ex_braid(tmc::detail::this_thread::executor()) {}
 
-ex_braid::~ex_braid() { queue.drain_wait(); }
+ex_braid::~ex_braid() {
+  // This queue can't be closed, so post a nullptr sentinel instead.
+  queue->post(tmc::detail::braid_work_item{work_item{nullptr}, 0});
+}
 
 /// Post this task to the braid queue, and attempt to take the lock and
 /// start executing tasks on the braid.
 std::coroutine_handle<>
 ex_braid::dispatch(std::coroutine_handle<> Outer, size_t Priority) {
-  // This may be called from multiple threads. Thus, each call must
-  // maintain its own refcount / hazard pointer.
-  auto tok = queue.new_token();
-  tok.post(tmc::detail::braid_work_item{std::move(Outer), Priority});
+  assert(Outer != nullptr);
+  queue->post(tmc::detail::braid_work_item{std::move(Outer), Priority});
   return std::noop_coroutine();
 }
 

--- a/include/tmc/detail/ex_braid.ipp
+++ b/include/tmc/detail/ex_braid.ipp
@@ -62,7 +62,14 @@ ex_braid::ex_braid() : ex_braid(tmc::detail::this_thread::executor()) {}
 
 ex_braid::~ex_braid() {
   // This queue can't be closed, so post a nullptr sentinel instead.
-  queue->post(tmc::detail::braid_work_item{work_item{nullptr}, 0});
+  // If the braid loop is already waiting for work, resume it inline so it can
+  // consume the sentinel and destroy its coroutine frame without depending on
+  // the parent executor to run again during teardown.
+  // This prevents issues when the parent executor is being destroyed at the
+  // same time as the braid.
+  queue->post_inline_resume(
+    tmc::detail::braid_work_item{work_item{nullptr}, 0}
+  );
 }
 
 /// Post this task to the braid queue, and attempt to take the lock and

--- a/include/tmc/detail/qu_mpsc.hpp
+++ b/include/tmc/detail/qu_mpsc.hpp
@@ -164,9 +164,8 @@ private:
 
     // If this returns false, data is ready and consumer should not wait.
     bool try_wait(consumer_base* Cons) noexcept {
-      void* prev = flags.exchange(
-        static_cast<void*>(Cons), std::memory_order_acq_rel
-      );
+      void* prev =
+        flags.exchange(static_cast<void*>(Cons), std::memory_order_acq_rel);
       return prev == nullptr;
     }
 
@@ -501,6 +500,24 @@ public:
     element* elem = get_write_ticket(idx);
 
     write_element(elem, static_cast<U&&>(Val));
+  }
+
+  /// Posts a value and resumes a waiting consumer inline instead of posting it
+  /// to its continuation executor. This should only be used when the caller
+  /// knows that the waiting consumer may safely run on the caller's thread.
+  template <typename U>
+  void post_inline_resume(U&& Val) noexcept
+    requires(ConsumerCanSuspend)
+  {
+    // Get write ticket and associated block.
+    size_t idx;
+    element* elem = get_write_ticket(idx);
+
+    elem->data.emplace(static_cast<U&&>(Val));
+    auto cons = elem->set_data_ready_or_get_waiting_consumer();
+    if (cons != nullptr) {
+      cons->continuation.resume();
+    }
   }
 
   template <typename It> void post_bulk(It&& Items, size_t Count) noexcept {

--- a/include/tmc/ex_braid.hpp
+++ b/include/tmc/ex_braid.hpp
@@ -7,15 +7,17 @@
 #include "tmc/detail/impl.hpp" // IWYU pragma: keep
 
 #include "tmc/aw_resume_on.hpp"
-#include "tmc/channel.hpp"
 #include "tmc/detail/compat.hpp"
 #include "tmc/detail/concepts_awaitable.hpp"
+#include "tmc/detail/qu_mpsc.hpp"
 #include "tmc/ex_any.hpp"
 #include "tmc/task.hpp"
 #include "tmc/utils.hpp"
 #include "tmc/work_item.hpp"
 
+#include <cassert>
 #include <coroutine>
+#include <memory>
 
 namespace tmc {
 namespace detail {
@@ -23,10 +25,11 @@ struct braid_work_item {
   work_item item;
   size_t prio;
 };
-struct braid_chan_config : tmc::chan_default_config {
+struct braid_qu_config : tmc::detail::qu_mpsc_default_config {
   static inline constexpr size_t BlockSize = 8192;
-  static inline constexpr size_t PackingLevel = 2;
+  static inline constexpr size_t PackingLevel = 1;
   static inline constexpr bool EmbedFirstBlock = false;
+  static inline constexpr bool ConsumerCanSuspend = true;
 };
 } // namespace detail
 
@@ -47,19 +50,16 @@ class ex_braid {
   friend class aw_ex_scope_enter<ex_braid>;
   friend tmc::detail::executor_traits<ex_braid>;
 
-  using task_queue_t =
-    tmc::chan_tok<tmc::detail::braid_work_item, tmc::detail::braid_chan_config>;
+  using task_queue_t = tmc::detail::qu_mpsc<
+    tmc::detail::braid_work_item, tmc::detail::braid_qu_config>;
 
-  task_queue_t queue;
+  std::shared_ptr<task_queue_t> queue;
 
   tmc::ex_any type_erased_this;
 
   /// The main loop of the braid; only 1 thread is allowed to enter the inner
   /// loop. If the lock is already taken, other threads will return immediately.
-  TMC_DECL tmc::task<void> run_loop(
-    tmc::chan_tok<tmc::detail::braid_work_item, tmc::detail::braid_chan_config>
-      Chan
-  );
+  TMC_DECL tmc::task<void> run_loop(std::shared_ptr<task_queue_t> Queue);
 
   TMC_DECL std::coroutine_handle<>
   dispatch(std::coroutine_handle<> Outer, size_t Priority);
@@ -84,14 +84,17 @@ public:
     It&& Items, size_t Count, size_t Priority = 0,
     [[maybe_unused]] size_t ThreadHint = NO_HINT
   ) {
-    // This may be called from multiple threads. Thus, each call must
-    // maintain its own refcount / hazard pointer.
-    auto tok = queue.new_token();
-    tok.post_bulk(
+    queue->post_bulk(
       tmc::iter_adapter(
         std::forward<It>(Items),
         [Priority](auto Item) -> tmc::detail::braid_work_item {
+#ifndef NDEBUG
+          auto item = std::move(*Item);
+          assert(item != nullptr);
+          return tmc::detail::braid_work_item{std::move(item), Priority};
+#else
           return tmc::detail::braid_work_item{std::move(*Item), Priority};
+#endif
         }
       ),
       Count

--- a/include/tmc/ex_braid.hpp
+++ b/include/tmc/ex_braid.hpp
@@ -38,14 +38,13 @@ struct braid_qu_config : tmc::detail::qu_mpsc_default_config {
 /// currently executing on the braid may change, but only 1 thread is allowed to
 /// enter the braid at a time.
 ///
-/// It's similar in function to `tmc::mutex`, but with different performance
-/// characteristics: `ex_braid` is optimized for higher throughput if you need
-/// to serialize a large number of tasks, whereas `tmc::mutex`
-/// is optimized for lower latency under low contention.
+/// It's similar in function to `tmc::mutex`, but with different
+/// characteristics: `ex_braid` is an executor, so child tasks that are
+/// created within a braid will be bound to it also.
 ///
 /// Additionally, while a `tmc::mutex` can be held across a suspension point,
-/// this will not. If a task suspends while running on a braid, another task may
-/// enter the braid and begin executing.
+/// this will not. If a task suspends or switches to another executor while
+/// running on a braid, another task may enter the braid and begin executing.
 class ex_braid {
   friend class aw_ex_scope_enter<ex_braid>;
   friend tmc::detail::executor_traits<ex_braid>;
@@ -121,6 +120,9 @@ public:
       : ex_braid(
           tmc::detail::get_executor_traits<Executor>::type_erased(Parent)
         ) {}
+
+  /// You must ensure that all tasks running on the braid have completed before
+  /// destroying it.
   TMC_DECL ~ex_braid();
 
 private:

--- a/include/tmc/ex_braid.hpp
+++ b/include/tmc/ex_braid.hpp
@@ -88,9 +88,10 @@ public:
         std::forward<It>(Items),
         [Priority](auto Item) -> tmc::detail::braid_work_item {
 #ifndef NDEBUG
-          auto item = std::move(*Item);
-          assert(item != nullptr);
-          return tmc::detail::braid_work_item{std::move(item), Priority};
+          auto item =
+            tmc::detail::braid_work_item{std::move(*Item), Priority};
+          assert(item.item != nullptr);
+          return item;
 #else
           return tmc::detail::braid_work_item{std::move(*Item), Priority};
 #endif


### PR DESCRIPTION
Now that qu_mpsc supports suspending, it is a more natural fit, and much faster queue to build ex_braid on, compared to the channel-based version. The primary gain is that channel requires each ephemeral producer to acquire and release a hazard pointer, and qu_mpsc doesn't.

Performance improvements from exec_st_roundtrip_bench:
| bench | old | new |
| --- | --- | --- |
| unloaded (1 producer) | 12.7M ops/sec | 22.2M ops/sec |
| loaded (32 producers) | 12.7M ops/sec | 22.2M ops/sec |