### PR TITLE
disable copy compile commands in CI

### DIFF
--- a/.github/workflows/arm64-macos-clang.yml
+++ b/.github/workflows/arm64-macos-clang.yml
@@ -36,7 +36,7 @@ jobs:
       # continue-on-error: true # this should never fail if triggered from TMC workflow
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_COPY_COMPILE_COMMANDS=OFF -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(sysctl -n hw.logicalcpu) --target all
     - name: run tests

--- a/.github/workflows/coverage-bitmaps.yml
+++ b/.github/workflows/coverage-bitmaps.yml
@@ -40,7 +40,7 @@ jobs:
       # continue-on-error: true # this should never fail if triggered from TMC workflow
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_USE_HWLOC=${{matrix.HWLOC}} -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} ${{matrix.THREADS == 'ON' && '-DTMC_MORE_THREADS=ON' || ''}} ${{matrix.WORK_ITEM == 'FUNC' && '-DTMC_TRIVIAL_TASK=ON' || ''}} -DCMD_COMPILE_FLAGS='-Werror;-fprofile-instr-generate;-fcoverage-mapping' -DCMD_LINK_FLAGS='-Wl,--build-id;-fprofile-instr-generate;-fcoverage-mapping' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_COPY_COMPILE_COMMANDS=OFF -DTMC_USE_HWLOC=${{matrix.HWLOC}} -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} ${{matrix.THREADS == 'ON' && '-DTMC_MORE_THREADS=ON' || ''}} ${{matrix.WORK_ITEM == 'FUNC' && '-DTMC_TRIVIAL_TASK=ON' || ''}} -DCMD_COMPILE_FLAGS='-Werror;-fprofile-instr-generate;-fcoverage-mapping' -DCMD_LINK_FLAGS='-Wl,--build-id;-fprofile-instr-generate;-fcoverage-mapping' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests

--- a/.github/workflows/coverage-docker.yml
+++ b/.github/workflows/coverage-docker.yml
@@ -41,7 +41,7 @@ jobs:
         RUN apt-get update && apt-get install -y cmake ninja-build git libhwloc-dev hwloc
         WORKDIR /src
         COPY . .
-        RUN cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_USE_HWLOC=${{matrix.HWLOC}} -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} ${{matrix.WORK_ITEM == 'FUNC' && '-DTMC_TRIVIAL_TASK=ON' || ''}} -DCMD_COMPILE_FLAGS='-Werror;-fprofile-instr-generate;-fcoverage-mapping' -DCMD_LINK_FLAGS='-Wl,--build-id;-fprofile-instr-generate;-fcoverage-mapping' --preset ${{matrix.PRESET}} .
+        RUN cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_COPY_COMPILE_COMMANDS=OFF -DTMC_USE_HWLOC=${{matrix.HWLOC}} -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} ${{matrix.WORK_ITEM == 'FUNC' && '-DTMC_TRIVIAL_TASK=ON' || ''}} -DCMD_COMPILE_FLAGS='-Werror;-fprofile-instr-generate;-fcoverage-mapping' -DCMD_LINK_FLAGS='-Wl,--build-id;-fprofile-instr-generate;-fcoverage-mapping' --preset ${{matrix.PRESET}} .
         RUN cmake --build ./build/${{matrix.PRESET}} --parallel 16 --target test_container
         WORKDIR /src/build/${{matrix.PRESET}}/tests
         EOF

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -39,7 +39,7 @@ jobs:
       # continue-on-error: true # this should never fail if triggered from TMC workflow
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_USE_HWLOC=${{matrix.HWLOC}} -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} ${{matrix.WORK_ITEM == 'FUNC' && '-DTMC_TRIVIAL_TASK=ON' || ''}} -DCMD_COMPILE_FLAGS='-Werror;-fprofile-instr-generate;-fcoverage-mapping' -DCMD_LINK_FLAGS='-Wl,--build-id;-fprofile-instr-generate;-fcoverage-mapping' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_COPY_COMPILE_COMMANDS=OFF -DTMC_USE_HWLOC=${{matrix.HWLOC}} -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} ${{matrix.WORK_ITEM == 'FUNC' && '-DTMC_TRIVIAL_TASK=ON' || ''}} -DCMD_COMPILE_FLAGS='-Werror;-fprofile-instr-generate;-fcoverage-mapping' -DCMD_LINK_FLAGS='-Wl,--build-id;-fprofile-instr-generate;-fcoverage-mapping' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests

--- a/.github/workflows/topology.yml
+++ b/.github/workflows/topology.yml
@@ -38,7 +38,7 @@ jobs:
       # continue-on-error: true # this should never fail if triggered from TMC workflow
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_COPY_COMPILE_COMMANDS=OFF -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target hwloc_topo
     - name: run tests

--- a/.github/workflows/x64-linux-clang-asan.yml
+++ b/.github/workflows/x64-linux-clang-asan.yml
@@ -36,7 +36,7 @@ jobs:
       # continue-on-error: true # this should never fail if triggered from TMC workflow
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror;-fsanitize=address' -DCMD_LINK_FLAGS='-fsanitize=address' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_COPY_COMPILE_COMMANDS=OFF -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror;-fsanitize=address' -DCMD_LINK_FLAGS='-fsanitize=address' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests

--- a/.github/workflows/x64-linux-clang-tsan.yml
+++ b/.github/workflows/x64-linux-clang-tsan.yml
@@ -36,7 +36,7 @@ jobs:
       # continue-on-error: true # this should never fail if triggered from TMC workflow
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror;-fsanitize=thread' -DCMD_LINK_FLAGS='-fsanitize=thread' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_COPY_COMPILE_COMMANDS=OFF -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror;-fsanitize=thread' -DCMD_LINK_FLAGS='-fsanitize=thread' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests

--- a/.github/workflows/x64-linux-clang-ubsan.yml
+++ b/.github/workflows/x64-linux-clang-ubsan.yml
@@ -36,7 +36,7 @@ jobs:
       # continue-on-error: true # this should never fail if triggered from TMC workflow
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror;-fsanitize=undefined;-fno-sanitize-recover' -DCMD_LINK_FLAGS='-fsanitize=undefined' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_COPY_COMPILE_COMMANDS=OFF -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror;-fsanitize=undefined;-fno-sanitize-recover' -DCMD_LINK_FLAGS='-fsanitize=undefined' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests

--- a/.github/workflows/x64-linux-clang.yml
+++ b/.github/workflows/x64-linux-clang.yml
@@ -36,7 +36,7 @@ jobs:
       # continue-on-error: true # this should never fail if triggered from TMC workflow
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_COPY_COMPILE_COMMANDS=OFF -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests

--- a/.github/workflows/x64-linux-gcc.yml
+++ b/.github/workflows/x64-linux-gcc.yml
@@ -36,7 +36,7 @@ jobs:
       # continue-on-error: true # this should never fail if triggered from TMC workflow
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_COPY_COMPILE_COMMANDS=OFF -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests

--- a/.github/workflows/x64-windows-clang-cl.yml
+++ b/.github/workflows/x64-windows-clang-cl.yml
@@ -35,7 +35,7 @@ jobs:
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - uses: ilammy/msvc-dev-cmd@v1
     - name: configure
-      run: cmake -G "Ninja" -DTMC_AS_SUBMODULE=ON -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Ninja" -DTMC_AS_SUBMODULE=ON -DTMC_COPY_COMPILE_COMMANDS=OFF -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --target all
     - name: run tests

--- a/.github/workflows/x86-linux-clang.yml
+++ b/.github/workflows/x86-linux-clang.yml
@@ -36,7 +36,7 @@ jobs:
       # continue-on-error: true # this should never fail if triggered from TMC workflow
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_USE_HWLOC=OFF -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror;-m32' -DCMD_LINK_FLAGS='-m32' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DTMC_AS_SUBMODULE=ON -DTMC_COPY_COMPILE_COMMANDS=OFF -DTMC_USE_HWLOC=OFF -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror;-m32' -DCMD_LINK_FLAGS='-m32' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests

--- a/.github/workflows/x86-linux-gcc.yml
+++ b/.github/workflows/x86-linux-gcc.yml
@@ -36,7 +36,7 @@ jobs:
       # continue-on-error: true # this should never fail if triggered from TMC workflow
       run: cd submodules/TooManyCooks && git fetch && git checkout ${{env.BRANCH_NAME}}
     - name: configure
-      run: cmake -G "Unix Makefiles" -DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14 -DTMC_AS_SUBMODULE=ON -DTMC_USE_HWLOC=OFF -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror;-m32' -DCMD_LINK_FLAGS='-m32' --preset ${{matrix.PRESET}} .
+      run: cmake -G "Unix Makefiles" -DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14 -DTMC_AS_SUBMODULE=ON -DTMC_COPY_COMPILE_COMMANDS=OFF -DTMC_USE_HWLOC=OFF -DTMC_WORK_ITEM=${{matrix.WORK_ITEM}} -DCMD_COMPILE_FLAGS='-Werror;-m32' -DCMD_LINK_FLAGS='-m32' --preset ${{matrix.PRESET}} .
     - name: build
       run: cmake --build ./build/${{matrix.PRESET}} --parallel $(nproc) --target all
     - name: run tests


### PR DESCRIPTION
The "copy compile_commands.json" step which is needed for clangd to detect the compilation database when there are multiple build subfolders has been a frequent source of errors in the CI pipeline. I suspect that there is a conflict when multiple parallel builds try to copy this file at the same time. This error does not occur when building locally.

This file is unneeded in CI anyway so just disable this copy.