### PR TITLE
add `tmc::qu_unbounded_spsc`

### DIFF
--- a/include/tmc/all_headers.hpp
+++ b/include/tmc/all_headers.hpp
@@ -28,6 +28,7 @@
 #include "tmc/manual_reset_event.hpp" // IWYU pragma: export
 #include "tmc/mutex.hpp"              // IWYU pragma: export
 #include "tmc/qu_unbounded_mpsc.hpp"  // IWYU pragma: export
+#include "tmc/qu_unbounded_spsc.hpp"  // IWYU pragma: export
 #include "tmc/semaphore.hpp"          // IWYU pragma: export
 #include "tmc/spawn.hpp"              // IWYU pragma: export
 #include "tmc/spawn_func.hpp"         // IWYU pragma: export

--- a/include/tmc/qu_unbounded_mpsc.hpp
+++ b/include/tmc/qu_unbounded_mpsc.hpp
@@ -141,7 +141,6 @@ class qu_unbounded_mpsc {
   static inline constexpr uintptr_t DATA_BIT = TMC_ONE_BIT;
   static inline constexpr uintptr_t CLOSED_BIT = TMC_ONE_BIT << 1;
 
-private:
   struct element_t;
 
   struct consumer_base {

--- a/include/tmc/qu_unbounded_mpsc.hpp
+++ b/include/tmc/qu_unbounded_mpsc.hpp
@@ -431,12 +431,15 @@ public:
     }
 
     /// Returns a reference to the object in the queue storage.
+    /// Only valid to call if operator bool() is true.
     T& get() noexcept { return elem->data.value; }
 
     /// Returns a reference to the object in the queue storage.
+    /// Only valid to call if operator bool() is true.
     T& operator*() noexcept { return elem->data.value; }
 
     /// Returns a pointer to the object in the queue storage.
+    /// Only valid to call if operator bool() is true.
     T* operator->() noexcept { return &elem->data.value; }
 
     /// Destroys the object in the queue storage and releases the queue slot.

--- a/include/tmc/qu_unbounded_spsc.hpp
+++ b/include/tmc/qu_unbounded_spsc.hpp
@@ -88,6 +88,10 @@ template <typename T> struct qu_unbounded_spsc_storage {
 } // namespace detail
 
 struct qu_unbounded_spsc_default_config {
+  /// If true, enables the suspending pull() operation. This adds a locked
+  /// operation to the producer path to check for a waiting consumer.
+  static inline constexpr bool ConsumerCanSuspend = true;
+
   /// The number of elements that can be stored in each block in the
   /// qu_unbounded_spsc linked list.
   static inline constexpr size_t BlockSize = 4096;
@@ -102,10 +106,6 @@ struct qu_unbounded_spsc_default_config {
   /// object (instead of dynamically allocated). Subsequent storage blocks are
   /// always dynamically allocated.
   static inline constexpr bool EmbedFirstBlock = false;
-
-  /// If true, enables the suspending pull() operation. This adds a locked
-  /// operation to the producer path to check for a waiting consumer.
-  static inline constexpr bool ConsumerCanSuspend = true;
 };
 
 // Status code returned by qu_unbounded_spsc try_pull operations.
@@ -131,7 +131,6 @@ class qu_unbounded_spsc {
     "represented by a platform word"
   );
 
-private:
   static inline constexpr uintptr_t DATA_BIT = TMC_ONE_BIT;
   static inline constexpr uintptr_t CLOSED_BIT = TMC_ONE_BIT << 1;
 
@@ -143,8 +142,6 @@ private:
     size_t prio;
     element_t* elem;
   };
-
-  static_assert(alignof(consumer_base*) >= 4);
 
   struct element_t {
     std::atomic<void*> flags;
@@ -223,6 +220,8 @@ private:
 
     void reset() noexcept { flags.store(nullptr, std::memory_order_relaxed); }
   };
+
+  static_assert(alignof(consumer_base*) >= 4);
 
   using element = element_t;
   static_assert(Config::PackingLevel < 2);
@@ -316,15 +315,6 @@ public:
       Other.err = tmc::qu_unbounded_spsc_err::EMPTY;
     }
 
-    /// Returns true if this scope holds a value from the queue.
-    explicit operator bool() const noexcept { return elem != nullptr; }
-
-    /// Returns true if this scope holds a value from the queue.
-    bool has_value() const noexcept { return elem != nullptr; }
-
-    /// Returns the status of this pull: OK, EMPTY, or CLOSED.
-    tmc::qu_unbounded_spsc_err::value status() const noexcept { return err; }
-
     try_pull_zc_scope& operator=(try_pull_zc_scope&& Other) noexcept {
       if (this != &Other) {
         if (elem != nullptr) {
@@ -341,6 +331,15 @@ public:
       }
       return *this;
     }
+
+    /// Returns true if this scope holds a value from the queue.
+    explicit operator bool() const noexcept { return elem != nullptr; }
+
+    /// Returns true if this scope holds a value from the queue.
+    bool has_value() const noexcept { return elem != nullptr; }
+
+    /// Returns the status of this pull: OK, EMPTY, or CLOSED.
+    tmc::qu_unbounded_spsc_err::value status() const noexcept { return err; }
 
     /// Returns a reference to the object in the queue storage.
     T& get() noexcept { return elem->data.value; }
@@ -747,6 +746,53 @@ public:
     }
   }
 
+  /// Closes the queue. May only be called from the single producer thread.
+  /// After close() returns, the producer must not call post() or post_bulk()
+  /// again. Consumers continue to drain pending values until the
+  /// queue is empty; once empty, they return false or CLOSED. Any currently
+  /// waiting consumers will by woken up.
+  ///
+  /// close() is idempotent.
+  void close() noexcept {
+    bool expected = false;
+    if (!closed.compare_exchange_strong(
+          expected, true, std::memory_order_release, std::memory_order_acquire
+        )) {
+      // Already closed.
+      return;
+    }
+
+    // Because close() is only called from the single producer thread, there is
+    // no concurrent producer that could reserve a slot past the close cutoff.
+    // The next slot the producer would have used is write_offset (writes are
+    // published by storing write_offset *after* the data); this is the only
+    // slot the consumer could still be waiting on.
+    //
+    // No `closed_ready` handshake is required (unlike qu_mpsc), because no
+    // other producer is racing with the closer to learn the cutoff.
+    size_t woff = write_offset.load(std::memory_order_relaxed);
+    write_closed_at.store(woff, std::memory_order_release);
+
+    // Publish the CLOSED sentinel at slot woff. This races with the consumer's
+    // try_wait() on that element; exactly one of the two RMWs goes first.
+    //   - If the consumer's exchange goes first, it installed its
+    //     consumer_base pointer; our exchange returns that pointer and we
+    //     post the resumption.
+    //   - If our exchange goes first, the slot now contains CLOSED_BIT; when
+    //     the consumer later runs try_wait() it observes CLOSED_BIT and
+    //     returns CLOSED without suspending.
+    data_block* block = find_write_block(woff);
+    element* elem = &block->values[woff & BlockSizeMask];
+    consumer_base* cons = elem->set_closed_or_get_waiting_consumer();
+    if (cons != nullptr) {
+      // Setting elem to nullptr marks the pull_zc_scope as empty (closed).
+      cons->elem = nullptr;
+      tmc::detail::post_checked(
+        cons->continuation_executor, std::move(cons->continuation), cons->prio
+      );
+    }
+  }
+
   /// Returns true if the queue appears to be empty.
   /// This is an unsynchronized read (like try_pull()) and is at best a hint.
   /// Only safe to call from the single consumer.
@@ -857,53 +903,6 @@ public:
       return try_pull_zc_scope(tmc::qu_unbounded_spsc_err::CLOSED);
     }
     return try_pull_zc_scope(tmc::qu_unbounded_spsc_err::EMPTY);
-  }
-
-  /// Closes the queue. May only be called from the single producer thread.
-  /// After close() returns, the producer must not call post() or post_bulk()
-  /// again. Consumers continue to drain pending values until the
-  /// queue is empty; once empty, they return false or CLOSED. Any currently
-  /// waiting consumers will by woken up.
-  ///
-  /// close() is idempotent.
-  void close() noexcept {
-    bool expected = false;
-    if (!closed.compare_exchange_strong(
-          expected, true, std::memory_order_release, std::memory_order_acquire
-        )) {
-      // Already closed.
-      return;
-    }
-
-    // Because close() is only called from the single producer thread, there is
-    // no concurrent producer that could reserve a slot past the close cutoff.
-    // The next slot the producer would have used is write_offset (writes are
-    // published by storing write_offset *after* the data); this is the only
-    // slot the consumer could still be waiting on.
-    //
-    // No `closed_ready` handshake is required (unlike qu_mpsc), because no
-    // other producer is racing with the closer to learn the cutoff.
-    size_t woff = write_offset.load(std::memory_order_relaxed);
-    write_closed_at.store(woff, std::memory_order_release);
-
-    // Publish the CLOSED sentinel at slot woff. This races with the consumer's
-    // try_wait() on that element; exactly one of the two RMWs goes first.
-    //   - If the consumer's exchange goes first, it installed its
-    //     consumer_base pointer; our exchange returns that pointer and we
-    //     post the resumption.
-    //   - If our exchange goes first, the slot now contains CLOSED_BIT; when
-    //     the consumer later runs try_wait() it observes CLOSED_BIT and
-    //     returns CLOSED without suspending.
-    data_block* block = find_write_block(woff);
-    element* elem = &block->values[woff & BlockSizeMask];
-    consumer_base* cons = elem->set_closed_or_get_waiting_consumer();
-    if (cons != nullptr) {
-      // Setting elem to nullptr marks the pull_zc_scope as empty (closed).
-      cons->elem = nullptr;
-      tmc::detail::post_checked(
-        cons->continuation_executor, std::move(cons->continuation), cons->prio
-      );
-    }
   }
 
   /// Destroys any remaining values in the queue and frees all storage blocks.

--- a/include/tmc/qu_unbounded_spsc.hpp
+++ b/include/tmc/qu_unbounded_spsc.hpp
@@ -88,8 +88,8 @@ template <typename T> struct qu_unbounded_spsc_storage {
 } // namespace detail
 
 struct qu_unbounded_spsc_default_config {
-  /// If true, enables the suspending pull() operation. This adds a locked
-  /// operation to the producer path to check for a waiting consumer.
+  /// If true, enables the suspending pull() operation. This costs the producer
+  /// an additional locked operation to check for a waiting consumer.
   static inline constexpr bool ConsumerCanSuspend = true;
 
   /// The number of elements that can be stored in each block in the
@@ -99,7 +99,6 @@ struct qu_unbounded_spsc_default_config {
   /// At level 0, queue elements will be padded up to the next increment of 64
   /// bytes. This reduces false sharing between neighboring elements.
   /// At level 1, no padding will be applied.
-  /// SPSC defaults to packed since there is no cross-producer sharing.
   static inline constexpr size_t PackingLevel = 1;
 
   /// If true, the first storage block will be a member of the qu_unbounded_spsc
@@ -108,7 +107,7 @@ struct qu_unbounded_spsc_default_config {
   static inline constexpr bool EmbedFirstBlock = false;
 };
 
-// Status code returned by qu_unbounded_spsc try_pull operations.
+/// Status code returned by qu_unbounded_spsc.try_pull().status()
 struct qu_unbounded_spsc_err {
   enum value { OK = 0u, EMPTY = 1u, CLOSED = 2u };
 };
@@ -221,7 +220,7 @@ class qu_unbounded_spsc {
     void reset() noexcept { flags.store(nullptr, std::memory_order_relaxed); }
   };
 
-  static_assert(alignof(consumer_base*) >= 4);
+  static_assert(alignof(consumer_base) >= 4);
 
   using element = element_t;
   static_assert(Config::PackingLevel < 2);
@@ -253,17 +252,17 @@ class qu_unbounded_spsc {
   char pad0[TMC_CACHE_LINE_SIZE];
   std::atomic<size_t> write_offset;
   std::atomic<data_block*> write_block;
-  // Cold close-related fields. Only the single producer writes them (via
-  // close()); the consumer reads `closed` from is_closed(). No `closed_ready`
-  // handshake is required because the closer IS the single producer, so no
-  // other producer can race with publication of write_closed_at.
+  // Cold close-related fields: only written once by close() itself. No
+  // `closed_ready` handshake is required (unlike qu_mpsc) because the closer
+  // IS the single producer, so no other producer can race with publication of
+  // write_closed_at.
   std::atomic<bool> closed;
   std::atomic<size_t> write_closed_at;
-  char pad1[TMC_CACHE_LINE_SIZE];
+  char pad1[TMC_CACHE_LINE_SIZE - sizeof(size_t)];
   size_t read_offset;
   data_block* head_block; // aka read_block
   data_block* tail_block;
-  char pad2[TMC_CACHE_LINE_SIZE];
+  char pad2[TMC_CACHE_LINE_SIZE - sizeof(void*)];
 
   struct empty {};
   using EmbeddedBlock =
@@ -342,12 +341,15 @@ public:
     tmc::qu_unbounded_spsc_err::value status() const noexcept { return err; }
 
     /// Returns a reference to the object in the queue storage.
+    /// Only valid to call if status() is OK / operator bool() is true.
     T& get() noexcept { return elem->data.value; }
 
     /// Returns a reference to the object in the queue storage.
+    /// Only valid to call if status() is OK / operator bool() is true.
     T& operator*() noexcept { return elem->data.value; }
 
     /// Returns a pointer to the object in the queue storage.
+    /// Only valid to call if status() is OK / operator bool() is true.
     T* operator->() noexcept { return &elem->data.value; }
 
     /// Destroys the object in the queue storage and releases the queue slot.
@@ -414,12 +416,15 @@ public:
     }
 
     /// Returns a reference to the object in the queue storage.
+    /// Only valid to call if operator bool() is true.
     T& get() noexcept { return elem->data.value; }
 
     /// Returns a reference to the object in the queue storage.
+    /// Only valid to call if operator bool() is true.
     T& operator*() noexcept { return elem->data.value; }
 
     /// Returns a pointer to the object in the queue storage.
+    /// Only valid to call if operator bool() is true.
     T* operator->() noexcept { return &elem->data.value; }
 
     /// Destroys the object in the queue storage and releases the queue slot.
@@ -431,7 +436,6 @@ public:
     }
   };
 
-  /// Constructs an empty queue with an initial storage block.
   qu_unbounded_spsc() noexcept {
     data_block* block;
     if constexpr (Config::EmbedFirstBlock) {
@@ -746,11 +750,46 @@ public:
     }
   }
 
+  /// Calculates the number of elements via `size_t Count = End - Begin;`
+  /// and moves them from the iterator `Begin` into the queue. Only safe to
+  /// call from the single producer thread.
+  ///
+  /// If a consumer is currently suspended waiting for a value, it will be
+  /// resumed.
+  template <typename It> void post_bulk(It&& Begin, It&& End) noexcept {
+    static_assert(
+      std::is_nothrow_move_constructible_v<T>,
+      "post_bulk moves values from the iterator into the queue; T must be "
+      "nothrow move constructible"
+    );
+    post_bulk(static_cast<It&&>(Begin), static_cast<size_t>(End - Begin));
+  }
+
+  /// Calculates the number of elements via
+  /// `size_t Count = Range.end() - Range.begin();` and moves them from the
+  /// beginning of the range into the queue. Only safe to call from the single
+  /// producer thread.
+  ///
+  /// If a consumer is currently suspended waiting for a value, it will be
+  /// resumed.
+  template <typename Range> void post_bulk(Range&& R) noexcept {
+    static_assert(
+      std::is_nothrow_move_constructible_v<T>,
+      "post_bulk moves values from the iterator into the queue; T must be "
+      "nothrow move constructible"
+    );
+    auto begin = static_cast<Range&&>(R).begin();
+    auto end = static_cast<Range&&>(R).end();
+    post_bulk(begin, static_cast<size_t>(end - begin));
+  }
+
   /// Closes the queue. May only be called from the single producer thread.
   /// After close() returns, the producer must not call post() or post_bulk()
-  /// again. Consumers continue to drain pending values until the
-  /// queue is empty; once empty, they return false or CLOSED. Any currently
-  /// waiting consumers will by woken up.
+  /// again. Calls to `pull()` and `try_pull()` will continue to read data
+  /// until all messages have been consumed, at which point all subsequent
+  /// calls will immediately return an empty scope. If the queue was already
+  /// empty, any waiting consumers will be awoken immediately and return an
+  /// empty scope.
   ///
   /// close() is idempotent.
   void close() noexcept {
@@ -785,7 +824,7 @@ public:
     element* elem = &block->values[woff & BlockSizeMask];
     consumer_base* cons = elem->set_closed_or_get_waiting_consumer();
     if (cons != nullptr) {
-      // Setting elem to nullptr marks the pull_zc_scope as empty (closed).
+      // Setting elem to nullptr marks it as closed on the consumer side
       cons->elem = nullptr;
       tmc::detail::post_checked(
         cons->continuation_executor, std::move(cons->continuation), cons->prio
@@ -794,7 +833,7 @@ public:
   }
 
   /// Returns true if the queue appears to be empty.
-  /// This is an unsynchronized read (like try_pull()) and is at best a hint.
+  /// This is an unsynchronized read (like try_pull()), so it is only a hint.
   /// Only safe to call from the single consumer.
   bool empty() {
     size_t Idx = read_offset;
@@ -845,7 +884,7 @@ public:
 
       TMC_AWAIT_RESUME pull_zc_scope await_resume() noexcept {
         // If closed, base.elem was already set to nullptr in await_suspend or
-        // close(). This marks the pull_zc_scope as empty.
+        // close(). This marks the zc_scope as empty.
         return pull_zc_scope(&queue, base.elem, block, idx);
       }
     };
@@ -854,17 +893,18 @@ public:
     aw_pull_impl operator co_await() && noexcept { return aw_pull_impl(*this); }
   };
 
-  /// Returns a `pull_zc_scope`, which provides a scoped zero-copy reference to
-  /// a value in the queue storage. When the scope is destroyed, any contained
-  /// value will be destroyed and the queue slot freed for reuse. Only safe to
-  /// call from the single consumer thread.
-  ///
-  /// May suspend until a value is available, or until close() is called.
+  /// Await to dequeue. Returns a `zc_scope` which provides a scoped zero-copy
+  /// reference to a value in the queue storage. When the scope is destroyed,
+  /// the referenced value will be destroyed and the queue slot freed for reuse.
+  /// Only safe to call from the single consumer.
   ///
   /// The returned scope's has_value() / operator bool() returns true if a value
-  /// was pulled, or false if the queue has been closed and drained.
+  /// was dequeued, or false if the queue was closed and drained.
   ///
-  /// All `pull_zc_scope`s must be released before the queue is destroyed.
+  /// This scope must be released before the next call to try_pull() or pull().
+  /// It must also be released before the queue is destroyed.
+  ///
+  /// May suspend until a value is available, or until close() is called.
   [[nodiscard(
     "You must co_await pull(). To poll from a non-coroutine function, use "
     "try_pull()."
@@ -875,20 +915,22 @@ public:
     return aw_pull(*this);
   }
 
-  /// Returns a `try_pull_zc_scope` which provides a scoped zero-copy reference
-  /// to a value in the queue storage. When the scope is destroyed, any
-  /// contained value will be destroyed and the queue slot freed for reuse. Only
-  /// safe to call from the single consumer thread.
+  /// Attempts to immediately dequeue, returning a `try_pull_zc_scope`
+  /// which provides a scoped zero-copy reference to a value in the queue
+  /// storage. When the scope is destroyed, the referenced value will be
+  /// destroyed and the queue slot freed for reuse. Only safe to call from the
+  /// single consumer.
   ///
   /// The returned scope's status() returns:
-  ///   - qu_unbounded_spsc_err::OK     - a value was pulled
+  ///   - qu_unbounded_spsc_err::OK     - a value was dequeued
   ///   - qu_unbounded_spsc_err::EMPTY  - no value is currently available
   ///   - qu_unbounded_spsc_err::CLOSED - the queue has been closed and drained
   ///
   /// The returned scope's has_value() / operator bool() returns true if a value
-  /// was pulled, or false if the queue was empty or closed.
+  /// was dequeued, or false if the queue was empty or closed.
   ///
-  /// All `try_pull_zc_scope`s must be released before the queue is destroyed.
+  /// This scope must be released before the next call to try_pull() or pull().
+  /// It must also be released before the queue is destroyed.
   try_pull_zc_scope try_pull() {
     size_t Idx;
     data_block* block;
@@ -896,7 +938,6 @@ public:
 
     auto s = elem->poll();
     if (s == DATA_BIT) {
-      // Data is already ready here.
       return try_pull_zc_scope(this, elem, block, Idx);
     }
     if (s == CLOSED_BIT) {
@@ -905,7 +946,7 @@ public:
     return try_pull_zc_scope(tmc::qu_unbounded_spsc_err::EMPTY);
   }
 
-  /// Destroys any remaining values in the queue and frees all storage blocks.
+  /// If the queue was not empty, destroys any contained data.
   /// If the queue was empty, wakes any waiting consumer by calling close().
   /// This only safely handles consumers that were already waiting; you must
   /// ensure that new producers and consumers do not race with this destructor.
@@ -913,11 +954,12 @@ public:
     close();
     {
       // close() published a CLOSED sentinel at write_closed_at; that slot
-      // holds no data, and (because close() is producer-side and the producer
-      // does not run after close()) no slot at or beyond it can hold data.
+      // holds no data, and no producer can fill any slot at or beyond it.
       size_t end = write_closed_at.load(std::memory_order_relaxed);
       size_t idx = read_offset;
       data_block* block = head_block;
+      // If the consumer stopped consuming before the queue was drained, there
+      // may be leftover data in the queue. Destroy it.
       while (circular_less_than(idx, end)) {
         block = find_block(block, idx);
         element* elem = &block->values[idx & BlockSizeMask];

--- a/include/tmc/qu_unbounded_spsc.hpp
+++ b/include/tmc/qu_unbounded_spsc.hpp
@@ -1,0 +1,953 @@
+// Copyright (c) 2023-2026 Logan McDougall
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+// Unbounded SPSC queue using linked list of blocks. Uses a similar
+// slot acquisition scheme to tmc::channel, but with various changes:
+// - single producer can publish offset after writing data instead of before
+// - single consumer read offset does not need to be atomic
+// - single consumer can recycle blocks immediately after finishing them
+// - close() may only be called by the single producer thread
+
+#include "tmc/detail/compat.hpp"
+#include "tmc/detail/concepts_awaitable.hpp"
+#include "tmc/detail/thread_locals.hpp"
+#include "tmc/ex_any.hpp"
+
+#include <array>
+#include <atomic>
+#include <cassert>
+#include <coroutine>
+#include <type_traits>
+#include <utility>
+
+namespace tmc {
+namespace detail {
+// Allocates elements without constructing them, to be constructed later using
+// placement new. T need not be default, copy, or move constructible.
+// The caller must track whether the element exists, and manually invoke the
+// destructor if necessary.
+template <typename T> struct qu_unbounded_spsc_storage {
+  union alignas(alignof(T)) {
+    T value;
+  };
+#ifndef NDEBUG
+  bool exists = false;
+#endif
+
+  qu_unbounded_spsc_storage() noexcept {}
+
+  template <typename... ConstructArgs>
+  void emplace(ConstructArgs&&... Args) noexcept {
+#ifndef NDEBUG
+    assert(!exists);
+    exists = true;
+#endif
+    ::new (static_cast<void*>(&value)) T(static_cast<ConstructArgs&&>(Args)...);
+  }
+
+  void destroy() noexcept {
+#ifndef NDEBUG
+    assert(exists);
+    exists = false;
+#endif
+    value.~T();
+  }
+
+  // Precondition: Other.value must exist
+  qu_unbounded_spsc_storage(qu_unbounded_spsc_storage&& Other) noexcept {
+    emplace(static_cast<T&&>(Other.value));
+    Other.destroy();
+  }
+  qu_unbounded_spsc_storage&
+  operator=(qu_unbounded_spsc_storage&& Other) noexcept {
+    emplace(static_cast<T&&>(Other.value));
+    Other.destroy();
+    return *this;
+  }
+
+  // If data was present, the caller is responsible for destroying it.
+#ifndef NDEBUG
+  ~qu_unbounded_spsc_storage() { assert(!exists); }
+#else
+  ~qu_unbounded_spsc_storage()
+    requires(std::is_trivially_destructible_v<T>)
+  = default;
+  ~qu_unbounded_spsc_storage()
+    requires(!std::is_trivially_destructible_v<T>)
+  {}
+#endif
+
+  qu_unbounded_spsc_storage(const qu_unbounded_spsc_storage&) = delete;
+  qu_unbounded_spsc_storage&
+  operator=(const qu_unbounded_spsc_storage&) = delete;
+};
+} // namespace detail
+
+struct qu_unbounded_spsc_default_config {
+  /// The number of elements that can be stored in each block in the
+  /// qu_unbounded_spsc linked list.
+  static inline constexpr size_t BlockSize = 4096;
+
+  /// At level 0, queue elements will be padded up to the next increment of 64
+  /// bytes. This reduces false sharing between neighboring elements.
+  /// At level 1, no padding will be applied.
+  /// SPSC defaults to packed since there is no cross-producer sharing.
+  static inline constexpr size_t PackingLevel = 1;
+
+  /// If true, the first storage block will be a member of the qu_unbounded_spsc
+  /// object (instead of dynamically allocated). Subsequent storage blocks are
+  /// always dynamically allocated.
+  static inline constexpr bool EmbedFirstBlock = false;
+
+  /// If true, enables the suspending pull() operation. This adds a locked
+  /// operation to the producer path to check for a waiting consumer.
+  static inline constexpr bool ConsumerCanSuspend = true;
+};
+
+// Status code returned by qu_unbounded_spsc try_pull operations.
+struct qu_unbounded_spsc_err {
+  enum value { OK = 0u, EMPTY = 1u, CLOSED = 2u };
+};
+
+template <typename T, typename Config = tmc::qu_unbounded_spsc_default_config>
+class qu_unbounded_spsc {
+  static inline constexpr size_t BlockSize = Config::BlockSize;
+  static inline constexpr size_t BlockSizeMask = BlockSize - 1;
+  static inline constexpr bool ConsumerCanSuspend = Config::ConsumerCanSuspend;
+  static_assert(
+    BlockSize && ((BlockSize & (BlockSize - 1)) == 0),
+    "BlockSize must be a power of 2"
+  );
+
+  // Ensure that the subtraction of unsigned offsets always results in a value
+  // that can be represented as a signed integer.
+  static_assert(
+    BlockSize <= (TMC_ONE_BIT << (TMC_PLATFORM_BITS - 1)),
+    "BlockSize must not be larger than half the max value that can be "
+    "represented by a platform word"
+  );
+
+private:
+  static inline constexpr uintptr_t DATA_BIT = TMC_ONE_BIT;
+  static inline constexpr uintptr_t CLOSED_BIT = TMC_ONE_BIT << 1;
+
+  struct element_t;
+
+  struct consumer_base {
+    tmc::ex_any* continuation_executor;
+    std::coroutine_handle<> continuation;
+    size_t prio;
+    element_t* elem;
+  };
+
+  static_assert(alignof(consumer_base*) >= 4);
+
+  struct element_t {
+    std::atomic<void*> flags;
+    tmc::detail::qu_unbounded_spsc_storage<T> data;
+
+    static constexpr size_t UNPADLEN =
+      sizeof(std::atomic<void*>) +
+      sizeof(tmc::detail::qu_unbounded_spsc_storage<T>);
+    static constexpr size_t WANTLEN = (UNPADLEN + TMC_CACHE_LINE_SIZE - 1) &
+                                      static_cast<size_t>(
+                                        0 - TMC_CACHE_LINE_SIZE
+                                      ); // round up to TMC_CACHE_LINE_SIZE
+    static constexpr size_t PADLEN =
+      UNPADLEN < WANTLEN ? (WANTLEN - UNPADLEN) : 999;
+
+    struct empty {};
+    using Padding = std::conditional_t<
+      Config::PackingLevel == 0 && PADLEN != 999, char[PADLEN], empty>;
+    TMC_NO_UNIQUE_ADDRESS Padding pad;
+
+    // Attempts to install Cons as a waiting consumer.
+    // Returns the previous flags value: 0 (nullptr) means Cons is now
+    // installed and the consumer should suspend; DATA_BIT means a producer
+    // already published data here; CLOSED_BIT means close() already published
+    // a CLOSED sentinel here.
+    uintptr_t try_wait(consumer_base* Cons) noexcept {
+      return reinterpret_cast<uintptr_t>(
+        flags.exchange(static_cast<void*>(Cons), std::memory_order_acq_rel)
+      );
+    }
+
+    // Sets the data ready flag,
+    // or returns a consumer pointer if that consumer was already waiting.
+    consumer_base* set_data_ready_or_get_waiting_consumer() noexcept
+      requires(ConsumerCanSuspend)
+    {
+      void* prev = flags.exchange(
+        reinterpret_cast<void*>(DATA_BIT), std::memory_order_acq_rel
+      );
+      return static_cast<consumer_base*>(prev);
+    }
+
+    void set_data_ready() noexcept
+      requires(!ConsumerCanSuspend)
+    {
+      flags.store(reinterpret_cast<void*>(DATA_BIT), std::memory_order_release);
+    }
+
+    // Publishes a CLOSED sentinel at this slot. If a consumer was already
+    // waiting, its consumer_base pointer is returned so the caller can wake it.
+    // Used only by close() to mark the cutoff slot.
+    consumer_base* set_closed_or_get_waiting_consumer() noexcept {
+      void* prev = flags.exchange(
+        reinterpret_cast<void*>(CLOSED_BIT), std::memory_order_acq_rel
+      );
+      if (reinterpret_cast<uintptr_t>(prev) < 4) {
+        return nullptr;
+      }
+      return static_cast<consumer_base*>(prev);
+    }
+
+    bool is_data_waiting() noexcept {
+      void* f = flags.load(std::memory_order_acquire);
+      return DATA_BIT == reinterpret_cast<uintptr_t>(f);
+    }
+
+    bool is_closed_sentinel() noexcept {
+      void* f = flags.load(std::memory_order_acquire);
+      return CLOSED_BIT == reinterpret_cast<uintptr_t>(f);
+    }
+
+    // Returns the raw flags value: DATA_BIT, CLOSED_BIT, or 0 (meaning empty).
+    uintptr_t poll() noexcept {
+      return reinterpret_cast<uintptr_t>(flags.load(std::memory_order_acquire));
+    }
+
+    void reset() noexcept { flags.store(nullptr, std::memory_order_relaxed); }
+  };
+
+  using element = element_t;
+  static_assert(Config::PackingLevel < 2);
+
+  struct data_block {
+    std::atomic<size_t> offset;
+    std::atomic<data_block*> next;
+    std::array<element, BlockSize> values;
+
+    void reset_values() noexcept {
+      for (size_t i = 0; i < BlockSize; ++i) {
+        values[i].reset();
+      }
+    }
+
+    data_block(size_t Offset) noexcept {
+      offset.store(Offset, std::memory_order_relaxed);
+      next.store(nullptr, std::memory_order_relaxed);
+      reset_values();
+    }
+
+    data_block() noexcept : data_block(0) {}
+  };
+
+  static_assert(std::atomic<size_t>::is_always_lock_free);
+  static_assert(std::atomic<data_block*>::is_always_lock_free);
+  static_assert(std::atomic<void*>::is_always_lock_free);
+
+  char pad0[TMC_CACHE_LINE_SIZE];
+  std::atomic<size_t> write_offset;
+  std::atomic<data_block*> write_block;
+  // Cold close-related fields. Only the single producer writes them (via
+  // close()); the consumer reads `closed` from is_closed(). No `closed_ready`
+  // handshake is required because the closer IS the single producer, so no
+  // other producer can race with publication of write_closed_at.
+  std::atomic<bool> closed;
+  std::atomic<size_t> write_closed_at;
+  char pad1[TMC_CACHE_LINE_SIZE];
+  size_t read_offset;
+  data_block* head_block; // aka read_block
+  data_block* tail_block;
+  char pad2[TMC_CACHE_LINE_SIZE];
+
+  struct empty {};
+  using EmbeddedBlock =
+    std::conditional_t<Config::EmbedFirstBlock, data_block, empty>;
+  TMC_NO_UNIQUE_ADDRESS EmbeddedBlock embedded_block;
+
+public:
+  class aw_pull;
+
+  /// A zero-copy handle to an object in the queue's storage. The object is
+  /// exclusively available to this handle. When this handle is destroyed, the
+  /// queued object will be destroyed and the queue slot will be freed for
+  /// reuse. All handles must be released before the queue is destroyed.
+  ///
+  /// The status of the pull is exposed via status(): qu_unbounded_spsc_err::OK
+  /// if a value is held, EMPTY if no value was available, or CLOSED if the
+  /// queue has been closed and drained.
+  class try_pull_zc_scope {
+    friend qu_unbounded_spsc;
+    qu_unbounded_spsc* queue;
+    element* elem;
+    data_block* block;
+    size_t idx;
+    tmc::qu_unbounded_spsc_err::value err;
+
+    try_pull_zc_scope(
+      qu_unbounded_spsc* Queue, element* Elem, data_block* Block, size_t Idx
+    ) noexcept
+        : queue{Queue}, elem{Elem}, block{Block}, idx{Idx},
+          err{tmc::qu_unbounded_spsc_err::OK} {}
+
+    explicit try_pull_zc_scope(tmc::qu_unbounded_spsc_err::value Err) noexcept
+        : queue{nullptr}, elem{nullptr}, block{nullptr}, idx{0}, err{Err} {}
+
+  public:
+    /// Constructs an empty zc_scope (status EMPTY). Evaluates to false when
+    /// converted to bool.
+    try_pull_zc_scope() noexcept
+        : queue{nullptr}, elem{nullptr}, block{nullptr}, idx{0},
+          err{tmc::qu_unbounded_spsc_err::EMPTY} {}
+
+    try_pull_zc_scope(const try_pull_zc_scope&) = delete;
+    try_pull_zc_scope& operator=(const try_pull_zc_scope&) = delete;
+
+    try_pull_zc_scope(try_pull_zc_scope&& Other) noexcept
+        : queue{Other.queue}, elem{Other.elem}, block{Other.block},
+          idx{Other.idx}, err{Other.err} {
+      Other.elem = nullptr;
+      Other.err = tmc::qu_unbounded_spsc_err::EMPTY;
+    }
+
+    /// Returns true if this scope holds a value from the queue.
+    explicit operator bool() const noexcept { return elem != nullptr; }
+
+    /// Returns true if this scope holds a value from the queue.
+    bool has_value() const noexcept { return elem != nullptr; }
+
+    /// Returns the status of this pull: OK, EMPTY, or CLOSED.
+    tmc::qu_unbounded_spsc_err::value status() const noexcept { return err; }
+
+    try_pull_zc_scope& operator=(try_pull_zc_scope&& Other) noexcept {
+      if (this != &Other) {
+        if (elem != nullptr) {
+          queue->finish_read(elem, block, idx);
+          elem = nullptr;
+        }
+        queue = Other.queue;
+        elem = Other.elem;
+        block = Other.block;
+        idx = Other.idx;
+        err = Other.err;
+        Other.elem = nullptr;
+        Other.err = tmc::qu_unbounded_spsc_err::EMPTY;
+      }
+      return *this;
+    }
+
+    /// Returns a reference to the object in the queue storage.
+    T& get() noexcept { return elem->data.value; }
+
+    /// Returns a reference to the object in the queue storage.
+    T& operator*() noexcept { return elem->data.value; }
+
+    /// Returns a pointer to the object in the queue storage.
+    T* operator->() noexcept { return &elem->data.value; }
+
+    /// Destroys the object in the queue storage and releases the queue slot.
+    ~try_pull_zc_scope() {
+      if (elem != nullptr) {
+        queue->finish_read(elem, block, idx);
+        elem = nullptr;
+      }
+    }
+  };
+
+  /// A zero-copy handle to an object in the queue's storage. The object is
+  /// exclusively available to this handle. When this handle is destroyed, the
+  /// queued object will be destroyed and the queue slot will be freed for
+  /// reuse. Returned by the suspending `pull()` operation.
+  ///
+  /// If the queue has been closed and is drained, `pull()` will resume
+  /// with an empty `pull_zc_scope` (operator bool returns false).
+  class pull_zc_scope {
+    friend qu_unbounded_spsc;
+    qu_unbounded_spsc* queue;
+    element* elem;
+    data_block* block;
+    size_t idx;
+
+    pull_zc_scope(
+      qu_unbounded_spsc* Queue, element* Elem, data_block* Block, size_t Idx
+    ) noexcept
+        : queue{Queue}, elem{Elem}, block{Block}, idx{Idx} {}
+
+  public:
+    /// Constructs an empty zc_scope. Evaluates to false when converted to bool.
+    pull_zc_scope() noexcept
+        : queue{nullptr}, elem{nullptr}, block{nullptr}, idx{0} {}
+
+    pull_zc_scope(const pull_zc_scope&) = delete;
+    pull_zc_scope& operator=(const pull_zc_scope&) = delete;
+
+    pull_zc_scope(pull_zc_scope&& Other) noexcept
+        : queue{Other.queue}, elem{Other.elem}, block{Other.block},
+          idx{Other.idx} {
+      Other.elem = nullptr;
+    }
+
+    /// Returns true if this scope holds a value from the queue.
+    explicit operator bool() const noexcept { return elem != nullptr; }
+
+    /// Returns true if this scope holds a value from the queue.
+    bool has_value() const noexcept { return elem != nullptr; }
+
+    pull_zc_scope& operator=(pull_zc_scope&& Other) noexcept {
+      if (this != &Other) {
+        if (elem != nullptr) {
+          queue->finish_read(elem, block, idx);
+          elem = nullptr;
+        }
+        queue = Other.queue;
+        elem = Other.elem;
+        block = Other.block;
+        idx = Other.idx;
+        Other.elem = nullptr;
+      }
+      return *this;
+    }
+
+    /// Returns a reference to the object in the queue storage.
+    T& get() noexcept { return elem->data.value; }
+
+    /// Returns a reference to the object in the queue storage.
+    T& operator*() noexcept { return elem->data.value; }
+
+    /// Returns a pointer to the object in the queue storage.
+    T* operator->() noexcept { return &elem->data.value; }
+
+    /// Destroys the object in the queue storage and releases the queue slot.
+    TMC_FORCE_INLINE ~pull_zc_scope() {
+      if (elem != nullptr) [[likely]] {
+        queue->finish_read(elem, block, idx);
+        elem = nullptr;
+      }
+    }
+  };
+
+  /// Constructs an empty queue with an initial storage block.
+  qu_unbounded_spsc() noexcept {
+    data_block* block;
+    if constexpr (Config::EmbedFirstBlock) {
+      block = &embedded_block;
+    } else {
+      block = new data_block(0);
+    }
+    head_block = block;
+    write_block.store(block, std::memory_order_relaxed);
+    tail_block = block;
+    write_offset.store(0, std::memory_order_relaxed);
+    closed.store(false, std::memory_order_relaxed);
+    write_closed_at.store(0, std::memory_order_relaxed);
+    read_offset = 0;
+    tmc::detail::memory_barrier();
+  }
+
+private:
+  static inline bool circular_less_than(size_t a, size_t b) noexcept {
+    return a - b > (TMC_ONE_BIT << (TMC_PLATFORM_BITS - 1));
+  }
+
+  void reclaim_blocks(data_block* OldHead, data_block* NewHead) noexcept {
+    // Reset blocks and move them to the tail of the list in groups of 4.
+    while (true) {
+      std::array<data_block*, 4> unlinked;
+      size_t unlinkedCount = 0;
+      for (; unlinkedCount < unlinked.size(); ++unlinkedCount) {
+        if (OldHead == NewHead) {
+          break;
+        }
+        unlinked[unlinkedCount] = OldHead;
+        OldHead = OldHead->next.load(std::memory_order_acquire);
+      }
+      if (unlinkedCount == 0) {
+        break;
+      }
+
+      for (size_t i = 0; i < unlinkedCount; ++i) {
+        unlinked[i]->reset_values();
+      }
+
+      data_block* tailBlock = tail_block;
+      data_block* next = tailBlock->next.load(std::memory_order_acquire);
+
+      // Iterate forward in case tailBlock is part of unlinked.
+      while (next != nullptr) {
+        tailBlock = next;
+        next = tailBlock->next.load(std::memory_order_acquire);
+      }
+      // Actually unlink the blocks from the head of the queue.
+      // They stay linked to each other.
+      unlinked[unlinkedCount - 1]->next.store(
+        nullptr, std::memory_order_release
+      );
+
+      while (true) {
+        // Update their offsets to the end of the queue.
+        size_t boff =
+          tailBlock->offset.load(std::memory_order_relaxed) + BlockSize;
+        for (size_t i = 0; i < unlinkedCount; ++i) {
+          unlinked[i]->offset.store(boff, std::memory_order_relaxed);
+          boff += BlockSize;
+        }
+
+        // Re-link the tail of the queue to the head of the unlinked blocks.
+        if (tailBlock->next.compare_exchange_strong(
+              next, unlinked[0], std::memory_order_acq_rel,
+              std::memory_order_acquire
+            )) {
+          break;
+        }
+
+        // Tail was out of date, find the new tail.
+        while (next != nullptr) {
+          tailBlock = next;
+          next = tailBlock->next.load(std::memory_order_acquire);
+        }
+      }
+
+      tail_block = unlinked[unlinkedCount - 1];
+    }
+  }
+
+  // Given idx and a starting block, advance it until the block containing idx
+  // is found.
+  static inline data_block* find_block(data_block* Block, size_t Idx) noexcept {
+    size_t offset = Block->offset.load(std::memory_order_relaxed);
+    size_t targetOffset = Idx & ~BlockSizeMask;
+    // Find or allocate the associated block
+    while (offset != targetOffset) {
+      data_block* next = Block->next.load(std::memory_order_acquire);
+      if (next == nullptr) {
+        data_block* newBlock = new data_block(offset + BlockSize);
+        if (Block->next.compare_exchange_strong(
+              next, newBlock, std::memory_order_acq_rel,
+              std::memory_order_acquire
+            )) {
+          next = newBlock;
+        } else {
+          delete newBlock;
+        }
+      }
+      Block = next;
+      offset += BlockSize;
+      assert(Block->offset.load(std::memory_order_relaxed) == offset);
+    }
+
+    assert(
+      Idx >= Block->offset.load(std::memory_order_relaxed) &&
+      Idx <= Block->offset.load(std::memory_order_relaxed) + BlockSize - 1
+    );
+    return Block;
+  }
+
+  // Given idx, advance from write_block until the block containing idx
+  // is found. Update write_block if necessary.
+  inline data_block* find_write_block(size_t Idx) noexcept {
+    data_block* block = write_block.load(std::memory_order_relaxed);
+    size_t offset = block->offset.load(std::memory_order_relaxed);
+    assert(circular_less_than(offset, 1 + Idx));
+    size_t targetOffset = Idx & ~BlockSizeMask;
+    if (offset != targetOffset) {
+      // Find or allocate the associated block
+      do {
+        data_block* next = block->next.load(std::memory_order_acquire);
+        if (next == nullptr) {
+          data_block* newBlock = new data_block(offset + BlockSize);
+          if (block->next.compare_exchange_strong(
+                next, newBlock, std::memory_order_acq_rel,
+                std::memory_order_acquire
+              )) {
+            next = newBlock;
+          } else {
+            delete newBlock;
+          }
+        }
+        block = next;
+        offset += BlockSize;
+        assert(block->offset.load(std::memory_order_relaxed) == offset);
+      } while (offset != targetOffset);
+      write_block.store(block, std::memory_order_relaxed);
+    }
+
+    assert(
+      Idx >= block->offset.load(std::memory_order_relaxed) &&
+      Idx <= block->offset.load(std::memory_order_relaxed) + BlockSize - 1
+    );
+    return block;
+  }
+
+  void try_reclaim_blocks(data_block* NewHead) noexcept {
+    data_block* oldHead = head_block;
+    size_t newHeadOffset = read_offset & ~BlockSizeMask;
+    assert(NewHead->offset.load(std::memory_order_relaxed) == newHeadOffset);
+    size_t oldOff = oldHead->offset.load(std::memory_order_relaxed);
+    if (!circular_less_than(oldOff, newHeadOffset)) {
+      return;
+    }
+
+    head_block = NewHead;
+    reclaim_blocks(oldHead, NewHead);
+  }
+
+  // Idx will be initialized by this function
+  element* get_write_ticket(size_t& Idx) noexcept {
+    // In SPSC mode, write_offset is the committed write offset. The producer
+    // takes the next index from it, advances its block cursor before making a
+    // block-start element visible, and publishes write_offset after writing.
+    Idx = write_offset.load(std::memory_order_relaxed);
+    data_block* block = find_write_block(Idx);
+    element* elem = &block->values[Idx & BlockSizeMask];
+    return elem;
+  }
+
+  element* get_read_ticket(size_t& Idx, data_block*& Block) noexcept {
+    Idx = read_offset;
+    Block = head_block;
+
+    assert(
+      circular_less_than(Block->offset.load(std::memory_order_relaxed), 1 + Idx)
+    );
+
+    Block = find_block(Block, Idx);
+    return &Block->values[Idx & BlockSizeMask];
+  }
+
+  void finish_read(element* Elem, data_block* Block, size_t Idx) noexcept {
+    Elem->data.destroy();
+    read_offset = Idx + 1;
+    // Only try to reclaim once the consumer has entered a new block. In MPSC
+    // mode this is where the producer-visible write head may advance; in SPSC
+    // mode the producer already advanced before making this block-start element
+    // visible, so old blocks can be reclaimed immediately.
+    if ((Idx & BlockSizeMask) == 0) {
+      try_reclaim_blocks(Block);
+    }
+  }
+
+  template <typename... Args>
+  consumer_base*
+  write_element(element* Elem, Args&&... ConstructArgs) noexcept {
+    Elem->data.emplace(std::forward<Args>(ConstructArgs)...);
+    if constexpr (ConsumerCanSuspend) {
+      return Elem->set_data_ready_or_get_waiting_consumer();
+    } else {
+      Elem->set_data_ready();
+      return nullptr;
+    }
+  }
+
+  // StartIdx and EndIdx will be initialized by this function.
+  // Count must be non-zero (enforced by the caller).
+  data_block* get_write_ticket_bulk(
+    size_t Count, size_t& StartIdx, size_t& EndIdx
+  ) noexcept {
+    // In SPSC mode, write_offset is published after all elements in the bulk
+    // operation have been written.
+    StartIdx = write_offset.load(std::memory_order_relaxed);
+    EndIdx = StartIdx + Count;
+    data_block* block = write_block.load(std::memory_order_relaxed);
+
+    assert(circular_less_than(
+      block->offset.load(std::memory_order_relaxed), 1 + StartIdx
+    ));
+
+    // Ensure all blocks for the operation are allocated and available.
+    data_block* startBlock = find_block(block, StartIdx);
+    find_block(startBlock, EndIdx - 1);
+    write_block.store(startBlock, std::memory_order_relaxed);
+    return startBlock;
+  }
+
+public:
+  /// Constructs a new value in the queue, forwarding `ConstructArgs` to T's
+  /// constructor. Only safe to call from the single producer thread.
+  ///
+  /// If a consumer is currently suspended waiting for a value, it will be
+  /// resumed.
+  template <typename... Args> void post(Args&&... ConstructArgs) noexcept {
+    // close() must only be called from the single producer thread, so post()
+    // and close() are sequenced on the same thread. Posting after close() is
+    // a programming error.
+    assert(!closed.load(std::memory_order_relaxed));
+
+    // Get write ticket and associated block.
+    size_t idx;
+    element* elem = get_write_ticket(idx);
+
+    consumer_base* cons =
+      write_element(elem, std::forward<Args>(ConstructArgs)...);
+    write_offset.store(idx + 1, std::memory_order_release);
+    if (cons != nullptr) {
+      tmc::detail::post_checked(
+        cons->continuation_executor, std::move(cons->continuation), cons->prio
+      );
+    }
+  }
+
+  /// Moves `Count` values from the iterator `Items` into the queue. Only safe
+  /// to call from the single producer thread.
+  ///
+  /// If a consumer is currently suspended waiting for a value, it will be
+  /// resumed.
+  template <typename It> void post_bulk(It&& Items, size_t Count) noexcept {
+    static_assert(
+      std::is_nothrow_move_constructible_v<T>,
+      "post_bulk moves values from the iterator into the queue; T must be "
+      "nothrow move constructible"
+    );
+    // close() must only be called from the single producer thread, so
+    // post_bulk() and close() are sequenced on the same thread. Posting after
+    // close() is a programming error.
+    assert(!closed.load(std::memory_order_relaxed));
+    if (Count == 0) [[unlikely]] {
+      return;
+    }
+
+    // Get write ticket and associated block.
+    size_t startIdx, endIdx;
+    data_block* block = get_write_ticket_bulk(Count, startIdx, endIdx);
+
+    size_t idx = startIdx;
+    consumer_base* cons = nullptr;
+    while (idx < endIdx) {
+      element* elem = &block->values[idx & BlockSizeMask];
+
+      TMC_DISABLE_WARNING_PESSIMIZING_MOVE_BEGIN
+      consumer_base* waiting = write_element(elem, std::move(*Items));
+      TMC_DISABLE_WARNING_PESSIMIZING_MOVE_END
+      if (waiting != nullptr) {
+        assert(cons == nullptr);
+        cons = waiting;
+      }
+
+      ++Items;
+      ++idx;
+      if ((idx & BlockSizeMask) == 0) {
+        block = block->next.load(std::memory_order_acquire);
+        // all blocks should have been preallocated for [startIdx, endIdx)
+        assert(block != nullptr || idx >= endIdx);
+        if (idx < endIdx) {
+          write_block.store(block, std::memory_order_relaxed);
+        }
+      }
+    }
+    write_offset.store(endIdx, std::memory_order_release);
+    if (cons != nullptr) {
+      tmc::detail::post_checked(
+        cons->continuation_executor, std::move(cons->continuation), cons->prio
+      );
+    }
+  }
+
+  /// Returns true if the queue appears to be empty.
+  /// This is an unsynchronized read (like try_pull()) and is at best a hint.
+  /// Only safe to call from the single consumer.
+  bool empty() {
+    size_t Idx = read_offset;
+    data_block* block = find_block(head_block, Idx);
+    element* elem = &block->values[Idx & BlockSizeMask];
+
+    bool isEmpty = !elem->is_data_waiting();
+    return isEmpty;
+  }
+
+  class aw_pull final : private tmc::detail::AwaitTagNoGroupCoAwait {
+    friend qu_unbounded_spsc<T, Config>;
+
+    qu_unbounded_spsc& queue;
+
+    aw_pull(qu_unbounded_spsc& Queue) noexcept : queue(Queue) {}
+
+    struct aw_pull_impl final {
+      consumer_base base;
+      qu_unbounded_spsc& queue;
+      data_block* block;
+      size_t idx;
+
+      aw_pull_impl(aw_pull& Parent) noexcept
+          : base{tmc::detail::this_thread::executor(), nullptr,
+                 tmc::detail::this_thread::this_task().prio, nullptr},
+            queue{Parent.queue}, block{nullptr}, idx{0} {}
+
+      bool await_ready() noexcept {
+        element* myElem = queue.get_read_ticket(idx, block);
+        base.elem = myElem;
+        return myElem->poll() == DATA_BIT;
+      }
+
+      bool await_suspend(std::coroutine_handle<> Outer) noexcept {
+        base.continuation = Outer;
+        uintptr_t prev = base.elem->try_wait(&base);
+        if (prev == CLOSED_BIT) [[unlikely]] {
+          // Set the flags back to CLOSED_BIT so that future calls to pull() or
+          // try_pull() see that it is still closed.
+          base.elem->flags.store(
+            reinterpret_cast<void*>(CLOSED_BIT), std::memory_order_release
+          );
+          base.elem = nullptr;
+        }
+        return prev == 0;
+      }
+
+      TMC_AWAIT_RESUME pull_zc_scope await_resume() noexcept {
+        // If closed, base.elem was already set to nullptr in await_suspend or
+        // close(). This marks the pull_zc_scope as empty.
+        return pull_zc_scope(&queue, base.elem, block, idx);
+      }
+    };
+
+  public:
+    aw_pull_impl operator co_await() && noexcept { return aw_pull_impl(*this); }
+  };
+
+  /// Returns a `pull_zc_scope`, which provides a scoped zero-copy reference to
+  /// a value in the queue storage. When the scope is destroyed, any contained
+  /// value will be destroyed and the queue slot freed for reuse. Only safe to
+  /// call from the single consumer thread.
+  ///
+  /// May suspend until a value is available, or until close() is called.
+  ///
+  /// The returned scope's has_value() / operator bool() returns true if a value
+  /// was pulled, or false if the queue has been closed and drained.
+  ///
+  /// All `pull_zc_scope`s must be released before the queue is destroyed.
+  [[nodiscard(
+    "You must co_await pull(). To poll from a non-coroutine function, use "
+    "try_pull()."
+  )]] aw_pull
+  pull() noexcept
+    requires(ConsumerCanSuspend)
+  {
+    return aw_pull(*this);
+  }
+
+  /// Returns a `try_pull_zc_scope` which provides a scoped zero-copy reference
+  /// to a value in the queue storage. When the scope is destroyed, any
+  /// contained value will be destroyed and the queue slot freed for reuse. Only
+  /// safe to call from the single consumer thread.
+  ///
+  /// The returned scope's status() returns:
+  ///   - qu_unbounded_spsc_err::OK     - a value was pulled
+  ///   - qu_unbounded_spsc_err::EMPTY  - no value is currently available
+  ///   - qu_unbounded_spsc_err::CLOSED - the queue has been closed and drained
+  ///
+  /// The returned scope's has_value() / operator bool() returns true if a value
+  /// was pulled, or false if the queue was empty or closed.
+  ///
+  /// All `try_pull_zc_scope`s must be released before the queue is destroyed.
+  try_pull_zc_scope try_pull() {
+    size_t Idx;
+    data_block* block;
+    element* elem = get_read_ticket(Idx, block);
+
+    auto s = elem->poll();
+    if (s == DATA_BIT) {
+      // Data is already ready here.
+      return try_pull_zc_scope(this, elem, block, Idx);
+    }
+    if (s == CLOSED_BIT) {
+      return try_pull_zc_scope(tmc::qu_unbounded_spsc_err::CLOSED);
+    }
+    return try_pull_zc_scope(tmc::qu_unbounded_spsc_err::EMPTY);
+  }
+
+  /// Closes the queue. May only be called from the single producer thread.
+  /// After close() returns, the producer must not call post() or post_bulk()
+  /// again. Consumers continue to drain pending values until the
+  /// queue is empty; once empty, they return false or CLOSED. Any currently
+  /// waiting consumers will by woken up.
+  ///
+  /// close() is idempotent.
+  void close() noexcept {
+    bool expected = false;
+    if (!closed.compare_exchange_strong(
+          expected, true, std::memory_order_release, std::memory_order_acquire
+        )) {
+      // Already closed.
+      return;
+    }
+
+    // Because close() is only called from the single producer thread, there is
+    // no concurrent producer that could reserve a slot past the close cutoff.
+    // The next slot the producer would have used is write_offset (writes are
+    // published by storing write_offset *after* the data); this is the only
+    // slot the consumer could still be waiting on.
+    //
+    // No `closed_ready` handshake is required (unlike qu_mpsc), because no
+    // other producer is racing with the closer to learn the cutoff.
+    size_t woff = write_offset.load(std::memory_order_relaxed);
+    write_closed_at.store(woff, std::memory_order_release);
+
+    // Publish the CLOSED sentinel at slot woff. This races with the consumer's
+    // try_wait() on that element; exactly one of the two RMWs goes first.
+    //   - If the consumer's exchange goes first, it installed its
+    //     consumer_base pointer; our exchange returns that pointer and we
+    //     post the resumption.
+    //   - If our exchange goes first, the slot now contains CLOSED_BIT; when
+    //     the consumer later runs try_wait() it observes CLOSED_BIT and
+    //     returns CLOSED without suspending.
+    data_block* block = find_write_block(woff);
+    element* elem = &block->values[woff & BlockSizeMask];
+    consumer_base* cons = elem->set_closed_or_get_waiting_consumer();
+    if (cons != nullptr) {
+      // Setting elem to nullptr marks the pull_zc_scope as empty (closed).
+      cons->elem = nullptr;
+      tmc::detail::post_checked(
+        cons->continuation_executor, std::move(cons->continuation), cons->prio
+      );
+    }
+  }
+
+  /// Destroys any remaining values in the queue and frees all storage blocks.
+  /// If the queue was empty, wakes any waiting consumer by calling close().
+  /// This only safely handles consumers that were already waiting; you must
+  /// ensure that new producers and consumers do not race with this destructor.
+  ~qu_unbounded_spsc() {
+    close();
+    {
+      // close() published a CLOSED sentinel at write_closed_at; that slot
+      // holds no data, and (because close() is producer-side and the producer
+      // does not run after close()) no slot at or beyond it can hold data.
+      size_t end = write_closed_at.load(std::memory_order_relaxed);
+      size_t idx = read_offset;
+      data_block* block = head_block;
+      while (circular_less_than(idx, end)) {
+        block = find_block(block, idx);
+        element* elem = &block->values[idx & BlockSizeMask];
+        if (elem->is_data_waiting()) {
+          elem->data.destroy();
+        }
+        ++idx;
+      }
+    }
+    {
+      data_block* block = head_block;
+      while (block != nullptr) {
+        data_block* next = block->next.load(std::memory_order_acquire);
+        if constexpr (Config::EmbedFirstBlock) {
+          if (block != &embedded_block) {
+            delete block;
+          }
+        } else {
+          delete block;
+        }
+        block = next;
+      }
+    }
+  }
+
+  qu_unbounded_spsc(const qu_unbounded_spsc&) = delete;
+  qu_unbounded_spsc& operator=(const qu_unbounded_spsc&) = delete;
+  qu_unbounded_spsc(qu_unbounded_spsc&&) = delete;
+  qu_unbounded_spsc& operator=(qu_unbounded_spsc&&) = delete;
+};
+
+} // namespace tmc

--- a/include/tmc/qu_unbounded_spsc.hpp
+++ b/include/tmc/qu_unbounded_spsc.hpp
@@ -785,22 +785,17 @@ public:
     post_bulk(begin, static_cast<size_t>(end - begin));
   }
 
-  /// Closes the queue. May only be called from the single producer thread.
-  /// After close() returns, the producer must not call post() or post_bulk()
-  /// again. Calls to `pull()` and `try_pull()` will continue to read data
-  /// until all messages have been consumed, at which point all subsequent
-  /// calls will immediately return an empty scope. If the queue was already
-  /// empty, any waiting consumers will be awoken immediately and return an
-  /// empty scope.
-  ///
-  /// close() is idempotent.
-  void close() noexcept {
+private:
+  // Performs the common close work and returns the waiting consumer (if any)
+  // that needs to be woken. Returns nullptr if the queue was already closed,
+  // or if no consumer was waiting at the cutoff slot.
+  consumer_base* close_get_waiting_consumer() noexcept {
     bool expected = false;
     if (!closed.compare_exchange_strong(
           expected, true, std::memory_order_release, std::memory_order_acquire
         )) {
       // Already closed.
-      return;
+      return nullptr;
     }
 
     // Because close() is only called from the single producer thread, there is
@@ -828,9 +823,41 @@ public:
     if (cons != nullptr) {
       // Setting elem to nullptr marks it as closed on the consumer side
       cons->elem = nullptr;
+    }
+    return cons;
+  }
+
+public:
+  /// Closes the queue. May only be called from the single producer thread.
+  /// After close() returns, the producer must not call post() or post_bulk()
+  /// again. Calls to `pull()` and `try_pull()` will continue to read data
+  /// until all messages have been consumed, at which point all subsequent
+  /// calls will immediately return an empty scope. If the queue was already
+  /// empty, any waiting consumers will be awoken immediately and return an
+  /// empty scope.
+  ///
+  /// close() is idempotent.
+  void close() noexcept {
+    consumer_base* cons = close_get_waiting_consumer();
+    if (cons != nullptr) {
       tmc::detail::post_checked(
         cons->continuation_executor, std::move(cons->continuation), cons->prio
       );
+    }
+  }
+
+  /// Closes the queue and resumes any waiting consumer inline on the caller's
+  /// thread instead of posting its continuation to its continuation executor.
+  /// This should only be used when the caller knows that the waiting consumer
+  /// may safely run on the caller's thread.
+  ///
+  /// Behaves like close() in all other respects (see close() for details).
+  /// close_resume_inline() is idempotent. May only be called from the single
+  /// producer thread.
+  void close_resume_inline() noexcept {
+    consumer_base* cons = close_get_waiting_consumer();
+    if (cons != nullptr) {
+      cons->continuation.resume();
     }
   }
 

--- a/include/tmc/qu_unbounded_spsc.hpp
+++ b/include/tmc/qu_unbounded_spsc.hpp
@@ -99,6 +99,8 @@ struct qu_unbounded_spsc_default_config {
   /// At level 0, queue elements will be padded up to the next increment of 64
   /// bytes. This reduces false sharing between neighboring elements.
   /// At level 1, no padding will be applied.
+  /// The SPSC queue is packed by default to improve cache coherency for the
+  /// single producer.
   static inline constexpr size_t PackingLevel = 1;
 
   /// If true, the first storage block will be a member of the qu_unbounded_spsc


### PR DESCRIPTION
`tmc::qu_unbounded_spsc` is an unbounded SPSC queue. It is much faster than `tmc::qu_unbounded_mpsc` for SPSC scenarios:
- `tmc::qu_unbounded_spsc`: 200M elems/sec
- `tmc::qu_unbounded_mpsc`: 45M elems/sec (underperforms in SPSC scenarios due to its reclamation scheme)
- `tmc::channel`: 60M elems/sec

Compared to `tmc::channel`:

Advantages of `tmc::qu_unbounded_spsc`:
- Lower latency and higher throughput
- Hazard pointers are not required. This makes it suitable for use inside of a data structure which may have an unknown number of producers, such as an "actor" type.
- Zero-copy API by default (less bloated API)
- No dependency on `std::optional` / `std::variant`. The zero-copy scope objects handle the optionality.

Advantages of `tmc::channel`:
- Supports multi-producer / multi-consumer
- Automatically reference-counted lifetime (this may or may not be an advantage)

Consumer functions (can only be called by the single consumer):
- `pull()`
- `try_pull()`
- `empty()`

Producer functions (can only be called by the single producer):
- `post()`
- `post_bulk()` with overloads taking Begin+Count / Begin+End / Range
- `close()`
- `close_resume_inline()` - When a queue and executor are destroyed nearly simultaneously, and the consumer is running on the executor that's going out of scope, there would be a race condition where close() / destructor post the consumer back to the (soon to be destroyed) executor and then return before it actually finishes. `close_resume_inline()` solves this by setting the close signal and then resuming the awaiter immediately inline. This is a special-purpose tool that should only be used when you can be sure that the coroutine will exit promptly when it receives the close signal. This is recommended for use when building an "actor" class.

It also supports these configurable features:
- `ConsumerCanSuspend` enables the `pull()` operation. This is enabled by default, but can be disabled to enhance the performance of a `try_pull()` only use-case, since suspending pull() adds 1 extra locked operation per producer.
- `BlockSize` / `EmbedFirstBlock` - same as channel
- `PackingLevel` - is set to `1` by default for SPSC since there is a single producer, to enhance cache coherency