### PR TITLE
add waiter_count() method exposed only to tests

### DIFF
--- a/include/tmc/atomic_condvar.hpp
+++ b/include/tmc/atomic_condvar.hpp
@@ -18,6 +18,10 @@
 #include <mutex>
 #include <vector>
 
+namespace tmc::tests {
+class waiter_count_accessor;
+}
+
 namespace tmc {
 template <typename T> class atomic_condvar;
 template <typename T> class aw_atomic_condvar_co_notify;
@@ -124,6 +128,14 @@ template <typename T> class atomic_condvar {
 
   friend class aw_atomic_condvar<T>;
   friend class aw_atomic_condvar_co_notify<T>;
+  friend class ::tmc::tests::waiter_count_accessor;
+
+  // Returns the number of awaiters currently registered (suspended) on this
+  // condvar. For testing purposes. Thread-safe.
+  inline size_t waiter_count() noexcept {
+    std::scoped_lock<std::mutex> l{waiters_lock};
+    return waiters.size();
+  }
 
   // Returns the most recently added waiter that matches the expected
   // condition.

--- a/include/tmc/auto_reset_event.hpp
+++ b/include/tmc/auto_reset_event.hpp
@@ -12,6 +12,10 @@
 #include <atomic>
 #include <coroutine>
 
+namespace tmc::tests {
+class waiter_count_accessor;
+}
+
 namespace tmc {
 class auto_reset_event;
 
@@ -45,6 +49,15 @@ public:
 class auto_reset_event : protected tmc::detail::waiter_data_base {
   friend class aw_acquire;
   friend class aw_auto_reset_event_co_set;
+  friend class ::tmc::tests::waiter_count_accessor;
+
+  // Returns the number of awaiters currently registered (suspended) on this
+  // event. For testing purposes. Thread-safe.
+  inline size_t waiter_count() noexcept {
+    return (value.load(std::memory_order_acquire) >>
+            tmc::detail::WAITERS_OFFSET) &
+           tmc::detail::HALF_MASK;
+  }
 
 public:
   /// The Ready parameter controls the initial state.

--- a/include/tmc/barrier.hpp
+++ b/include/tmc/barrier.hpp
@@ -13,6 +13,10 @@
 #include <coroutine>
 #include <cstddef>
 
+namespace tmc::tests {
+class waiter_count_accessor;
+}
+
 namespace tmc {
 class barrier;
 
@@ -53,6 +57,12 @@ class barrier {
   std::atomic<ptrdiff_t> done_count;
 
   friend class aw_barrier;
+  friend class ::tmc::tests::waiter_count_accessor;
+
+  // Returns the number of awaiters currently registered (suspended) on this
+  // barrier. For testing purposes. Unsafe to use if waiters may be resumed
+  // concurrently.
+  inline size_t waiter_count() noexcept { return waiters.size(); }
 
 public:
   /// Sets the number of awaiters for the barrier. Setting this to 0, 1, or a

--- a/include/tmc/detail/manual_reset_event.ipp
+++ b/include/tmc/detail/manual_reset_event.ipp
@@ -58,6 +58,20 @@ std::coroutine_handle<> aw_manual_reset_event_co_set::await_suspend(
   return toWake->waiter.try_symmetric_transfer(Outer);
 }
 
+size_t manual_reset_event::waiter_count() noexcept {
+  auto h = head.load(std::memory_order_acquire);
+  if (h == NOT_READY || h == READY) {
+    return 0;
+  }
+  size_t count = 0;
+  auto curr = reinterpret_cast<tmc::detail::waiter_list_node*>(h);
+  while (curr != nullptr) {
+    ++count;
+    curr = curr->next;
+  }
+  return count;
+}
+
 void manual_reset_event::set() noexcept {
   auto h = head.exchange(READY, std::memory_order_acq_rel);
   if (READY == h) {

--- a/include/tmc/detail/waiter_list.hpp
+++ b/include/tmc/detail/waiter_list.hpp
@@ -61,6 +61,12 @@ public:
   /// Thread-safe.
   TMC_DECL void wake_all() noexcept;
 
+  /// Returns the number of waiters currently in the list.
+  /// For testing purposes. Safe to use concurrently with new waiters. Not safe
+  /// to use concurrently with new wakers which may cause waiters to be resumed
+  /// and then destroyed.
+  [[nodiscard]] TMC_DECL size_t size() const noexcept;
+
   /// Returns head. Head becomes nullptr.
   /// Thread-safe.
   [[nodiscard]] TMC_DECL waiter_list_node* take_all() noexcept;

--- a/include/tmc/detail/waiter_list.ipp
+++ b/include/tmc/detail/waiter_list.ipp
@@ -87,6 +87,16 @@ waiter_list_node* waiter_list::take_all() noexcept {
   return head.exchange(nullptr, std::memory_order_acq_rel);
 }
 
+size_t waiter_list::size() const noexcept {
+  size_t count = 0;
+  auto curr = head.load(std::memory_order_acquire);
+  while (curr != nullptr) {
+    ++count;
+    curr = curr->next;
+  }
+  return count;
+}
+
 waiter_list_waiter* waiter_list::maybe_wake(
   std::atomic<size_t>& value, size_t v, size_t old, bool symmetric
 ) noexcept {

--- a/include/tmc/latch.hpp
+++ b/include/tmc/latch.hpp
@@ -11,12 +11,23 @@
 #include <atomic>
 #include <cstddef>
 
+namespace tmc::tests {
+class waiter_count_accessor;
+}
+
 namespace tmc {
 /// Similar semantics to std::latch, exposing all operations except
 /// `arrive_and_wait()`.
 class latch {
   tmc::manual_reset_event event;
   std::atomic<ptrdiff_t> count;
+
+  friend class ::tmc::tests::waiter_count_accessor;
+
+  // Returns the number of awaiters currently registered (suspended) on this
+  // latch. For testing purposes. Unsafe to use if waiters may be resumed
+  // concurrently.
+  inline size_t waiter_count() noexcept { return event.waiter_count(); }
 
 public:
   /// Sets the initial value of Count. After `count_down()` has been called

--- a/include/tmc/manual_reset_event.hpp
+++ b/include/tmc/manual_reset_event.hpp
@@ -12,7 +12,12 @@
 #include <atomic>
 #include <coroutine>
 
+namespace tmc::tests {
+class waiter_count_accessor;
+}
+
 namespace tmc {
+class latch;
 class manual_reset_event;
 
 class aw_manual_reset_event {
@@ -78,6 +83,13 @@ class manual_reset_event {
 
   friend class aw_manual_reset_event;
   friend class aw_manual_reset_event_co_set;
+  friend class ::tmc::tests::waiter_count_accessor;
+  friend class latch;
+
+  // Returns the number of awaiters currently registered (suspended) on this
+  // event. For testing purposes. Unsafe to use if waiters may be resumed
+  // concurrently.
+  TMC_DECL size_t waiter_count() noexcept;
 
 public:
   /// The Ready parameter controls the initial state.

--- a/include/tmc/mutex.hpp
+++ b/include/tmc/mutex.hpp
@@ -12,6 +12,10 @@
 #include <atomic>
 #include <coroutine>
 
+namespace tmc::tests {
+class waiter_count_accessor;
+}
+
 namespace tmc {
 class mutex;
 
@@ -95,9 +99,18 @@ class mutex : protected tmc::detail::waiter_data_base {
   friend class aw_acquire;
   friend class aw_mutex_lock_scope;
   friend class aw_mutex_co_unlock;
+  friend class ::tmc::tests::waiter_count_accessor;
 
   static inline constexpr tmc::detail::half_word LOCKED = 0;
   static inline constexpr tmc::detail::half_word UNLOCKED = 1;
+
+  // Returns the number of awaiters currently registered (suspended and
+  // waiting to acquire) on this mutex. For testing purposes. Thread-safe.
+  inline size_t waiter_count() noexcept {
+    return (value.load(std::memory_order_acquire) >>
+            tmc::detail::WAITERS_OFFSET) &
+           tmc::detail::HALF_MASK;
+  }
 
 public:
   /// Mutex begins in the unlocked state.

--- a/include/tmc/semaphore.hpp
+++ b/include/tmc/semaphore.hpp
@@ -13,6 +13,10 @@
 #include <coroutine>
 #include <cstddef>
 
+namespace tmc::tests {
+class waiter_count_accessor;
+}
+
 namespace tmc {
 class semaphore;
 
@@ -99,6 +103,15 @@ class semaphore : protected tmc::detail::waiter_data_base {
   friend class aw_acquire;
   friend class aw_semaphore_acquire_scope;
   friend class aw_semaphore_co_release;
+  friend class ::tmc::tests::waiter_count_accessor;
+
+  // Returns the number of awaiters currently registered (suspended and
+  // waiting to acquire) on this semaphore. For testing purposes. Thread-safe.
+  inline size_t waiter_count() noexcept {
+    return (value.load(std::memory_order_acquire) >>
+            tmc::detail::WAITERS_OFFSET) &
+           tmc::detail::HALF_MASK;
+  }
 
 public:
   /// The count is packed into half a machine word along with the awaiter count.


### PR DESCRIPTION
This method is available on various access control types and is not publicly exposed since it is just a snapshot in time, and for most of the implementations isn't generally thread safe. It's used in the tests to ensure that a waiter has been registered with the data structure before the test proceeds.