### PR TITLE
rename new queues and update docs

### DIFF
--- a/include/tmc/all_headers.hpp
+++ b/include/tmc/all_headers.hpp
@@ -27,9 +27,9 @@
 #include "tmc/latch.hpp"              // IWYU pragma: export
 #include "tmc/manual_reset_event.hpp" // IWYU pragma: export
 #include "tmc/mutex.hpp"              // IWYU pragma: export
-#include "tmc/qu_bounded_spsc.hpp"    // IWYU pragma: export
-#include "tmc/qu_unbounded_mpsc.hpp"  // IWYU pragma: export
-#include "tmc/qu_unbounded_spsc.hpp"  // IWYU pragma: export
+#include "tmc/qu_mpsc_unbounded.hpp"  // IWYU pragma: export
+#include "tmc/qu_spsc_bounded.hpp"    // IWYU pragma: export
+#include "tmc/qu_spsc_unbounded.hpp"  // IWYU pragma: export
 #include "tmc/semaphore.hpp"          // IWYU pragma: export
 #include "tmc/spawn.hpp"              // IWYU pragma: export
 #include "tmc/spawn_func.hpp"         // IWYU pragma: export

--- a/include/tmc/detail/ex_manual_st.ipp
+++ b/include/tmc/detail/ex_manual_st.ipp
@@ -9,7 +9,7 @@
 #include "tmc/detail/thread_locals.hpp"
 #include "tmc/ex_any.hpp"
 #include "tmc/ex_manual_st.hpp"
-#include "tmc/qu_unbounded_mpsc.hpp"
+#include "tmc/qu_mpsc_unbounded.hpp"
 #include "tmc/work_item.hpp"
 
 #include <cassert>

--- a/include/tmc/ex_braid.hpp
+++ b/include/tmc/ex_braid.hpp
@@ -10,7 +10,7 @@
 #include "tmc/detail/compat.hpp"
 #include "tmc/detail/concepts_awaitable.hpp"
 #include "tmc/ex_any.hpp"
-#include "tmc/qu_unbounded_mpsc.hpp"
+#include "tmc/qu_mpsc_unbounded.hpp"
 #include "tmc/task.hpp"
 #include "tmc/utils.hpp"
 #include "tmc/work_item.hpp"
@@ -25,7 +25,7 @@ struct braid_work_item {
   work_item item;
   size_t prio;
 };
-struct braid_qu_config : tmc::qu_unbounded_mpsc_default_config {
+struct braid_qu_config : tmc::qu_mpsc_unbounded_default_config {
   static inline constexpr size_t BlockSize = 8192;
   static inline constexpr size_t PackingLevel = 1;
   static inline constexpr bool EmbedFirstBlock = false;
@@ -49,7 +49,7 @@ class ex_braid {
   friend class aw_ex_scope_enter<ex_braid>;
   friend tmc::detail::executor_traits<ex_braid>;
 
-  using task_queue_t = tmc::qu_unbounded_mpsc<
+  using task_queue_t = tmc::qu_mpsc_unbounded<
     tmc::detail::braid_work_item, tmc::detail::braid_qu_config>;
 
   std::shared_ptr<task_queue_t> queue;

--- a/include/tmc/ex_manual_st.hpp
+++ b/include/tmc/ex_manual_st.hpp
@@ -11,7 +11,7 @@
 #include "tmc/detail/thread_locals.hpp"
 #include "tmc/detail/tiny_vec.hpp"
 #include "tmc/ex_any.hpp"
-#include "tmc/qu_unbounded_mpsc.hpp"
+#include "tmc/qu_mpsc_unbounded.hpp"
 #include "tmc/work_item.hpp"
 
 #include <atomic>
@@ -28,7 +28,7 @@ namespace tmc {
 /// It is safe to post work from any number of threads concurrently, but
 /// `run_*()` must only be called from 1 thread at a time.
 class ex_manual_st {
-  struct qu_cfg : tmc::qu_unbounded_mpsc_default_config {
+  struct qu_cfg : tmc::qu_mpsc_unbounded_default_config {
     static inline constexpr size_t BlockSize = 16384;
     static inline constexpr size_t PackingLevel = 1;
     // static inline constexpr bool EmbedFirstBlock = false;
@@ -41,7 +41,7 @@ class ex_manual_st {
 
   tmc::ex_any type_erased_this;
 
-  using task_queue_t = tmc::qu_unbounded_mpsc<work_item, qu_cfg>;
+  using task_queue_t = tmc::qu_mpsc_unbounded<work_item, qu_cfg>;
   tmc::detail::tiny_vec<task_queue_t> work_queues; // size() == PRIORITY_COUNT
 
   tmc::detail::tiny_vec<std::vector<work_item>>

--- a/include/tmc/qu_mpsc_unbounded.hpp
+++ b/include/tmc/qu_mpsc_unbounded.hpp
@@ -1013,6 +1013,7 @@ public:
     return isEmpty;
   }
 
+  /// Returns a `pull_zc_scope` when awaited.
   class aw_pull final : private tmc::detail::AwaitTagNoGroupCoAwait {
     friend qu_mpsc_unbounded<T, Config>;
 
@@ -1062,10 +1063,10 @@ public:
     aw_pull_impl operator co_await() && noexcept { return aw_pull_impl(*this); }
   };
 
-  /// Await to dequeue. Returns a `zc_scope` which provides a scoped zero-copy
-  /// reference to a value in the queue storage. When the scope is destroyed,
-  /// the referenced value will be destroyed and the queue slot freed for reuse.
-  /// Only safe to call from the single consumer.
+  /// Await to dequeue. Returns a `pull_zc_scope` which provides a scoped
+  /// zero-copy reference to a value in the queue storage. When the scope is
+  /// destroyed, the referenced value will be destroyed and the queue slot freed
+  /// for reuse. Only safe to call from the single consumer.
   ///
   /// The returned scope's has_value() / operator bool() returns true if a value
   /// was dequeued, or false if the queue was closed and drained.

--- a/include/tmc/qu_mpsc_unbounded.hpp
+++ b/include/tmc/qu_mpsc_unbounded.hpp
@@ -355,7 +355,7 @@ public:
 
     /// Returns a reference to the object in the queue storage.
     /// Only valid to call if `status()` is OK / `operator bool()` is true.
-    T& get() noexcept { return elem->data.value; }
+    T& value() noexcept { return elem->data.value; }
 
     /// Returns a reference to the object in the queue storage.
     /// Only valid to call if `status()` is OK / `operator bool()` is true.
@@ -430,7 +430,7 @@ public:
 
     /// Returns a reference to the object in the queue storage.
     /// Only valid to call if `operator bool()` is true.
-    T& get() noexcept { return elem->data.value; }
+    T& value() noexcept { return elem->data.value; }
 
     /// Returns a reference to the object in the queue storage.
     /// Only valid to call if `operator bool()` is true.

--- a/include/tmc/qu_mpsc_unbounded.hpp
+++ b/include/tmc/qu_mpsc_unbounded.hpp
@@ -5,12 +5,18 @@
 
 #pragma once
 
-// Unbounded SPSC queue using linked list of blocks. Uses a similar
-// slot acquisition scheme to tmc::channel, but with various changes:
-// - single producer can publish offset after writing data instead of before
-// - single consumer read offset does not need to be atomic
-// - single consumer can recycle blocks immediately after finishing them
-// - close() may only be called by the single producer thread
+// Unbounded MPSC queue using linked list of blocks. Uses a similar fetch-add
+// slot acquisition scheme to tmc::channel, but optimized for a single consumer.
+
+// Instead of hazard pointers, uses a quiescent-state based reclamation scheme:
+// 1. Producers reserve tickets with write_offset, then load write_block_hint.
+//    If the hint is past their reservation, they fall back to write_block.
+// 2. Producers may advance write_block_hint forward after finding their block.
+// 3. The consumer enters a new block and publishes it as the new write_block.
+// 4. The consumer snapshots write_offset as the reclaim cutoff.
+// 5. Once read_offset reaches that cutoff, producers that may have observed the
+//    old write_block or write_block_hint are done, so old blocks can be
+//    recycled.
 
 #include "tmc/detail/compat.hpp"
 #include "tmc/detail/concepts_awaitable.hpp"
@@ -30,7 +36,7 @@ namespace detail {
 // placement new. T need not be default, copy, or move constructible.
 // The caller must track whether the element exists, and manually invoke the
 // destructor if necessary.
-template <typename T> struct qu_unbounded_spsc_storage {
+template <typename T> struct qu_mpsc_unbounded_storage {
   union alignas(alignof(T)) {
     T value;
   };
@@ -38,7 +44,7 @@ template <typename T> struct qu_unbounded_spsc_storage {
   bool exists = false;
 #endif
 
-  qu_unbounded_spsc_storage() noexcept {}
+  qu_mpsc_unbounded_storage() noexcept {}
 
   template <typename... ConstructArgs>
   void emplace(ConstructArgs&&... Args) noexcept {
@@ -58,12 +64,12 @@ template <typename T> struct qu_unbounded_spsc_storage {
   }
 
   // Precondition: Other.value must exist
-  qu_unbounded_spsc_storage(qu_unbounded_spsc_storage&& Other) noexcept {
+  qu_mpsc_unbounded_storage(qu_mpsc_unbounded_storage&& Other) noexcept {
     emplace(static_cast<T&&>(Other.value));
     Other.destroy();
   }
-  qu_unbounded_spsc_storage&
-  operator=(qu_unbounded_spsc_storage&& Other) noexcept {
+  qu_mpsc_unbounded_storage&
+  operator=(qu_mpsc_unbounded_storage&& Other) noexcept {
     emplace(static_cast<T&&>(Other.value));
     Other.destroy();
     return *this;
@@ -71,51 +77,51 @@ template <typename T> struct qu_unbounded_spsc_storage {
 
   // If data was present, the caller is responsible for destroying it.
 #ifndef NDEBUG
-  ~qu_unbounded_spsc_storage() { assert(!exists); }
+  ~qu_mpsc_unbounded_storage() { assert(!exists); }
 #else
-  ~qu_unbounded_spsc_storage()
+  ~qu_mpsc_unbounded_storage()
     requires(std::is_trivially_destructible_v<T>)
   = default;
-  ~qu_unbounded_spsc_storage()
+  ~qu_mpsc_unbounded_storage()
     requires(!std::is_trivially_destructible_v<T>)
   {}
 #endif
 
-  qu_unbounded_spsc_storage(const qu_unbounded_spsc_storage&) = delete;
-  qu_unbounded_spsc_storage&
-  operator=(const qu_unbounded_spsc_storage&) = delete;
+  qu_mpsc_unbounded_storage(const qu_mpsc_unbounded_storage&) = delete;
+  qu_mpsc_unbounded_storage&
+  operator=(const qu_mpsc_unbounded_storage&) = delete;
 };
 } // namespace detail
 
-struct qu_unbounded_spsc_default_config {
-  /// If true, enables the suspending pull() operation. This costs the producer
+struct qu_mpsc_unbounded_default_config {
+  /// If true, enables the suspending pull() operation. This costs each producer
   /// an additional locked operation to check for a waiting consumer.
   static inline constexpr bool ConsumerCanSuspend = true;
 
   /// The number of elements that can be stored in each block in the
-  /// qu_unbounded_spsc linked list.
+  /// qu_mpsc_unbounded linked list.
   static inline constexpr size_t BlockSize = 4096;
 
   /// At level 0, queue elements will be padded up to the next increment of 64
   /// bytes. This reduces false sharing between neighboring elements.
   /// At level 1, no padding will be applied.
-  /// The SPSC queue is packed by default to improve cache coherency for the
-  /// single producer.
-  static inline constexpr size_t PackingLevel = 1;
+  static inline constexpr size_t PackingLevel = 0;
 
-  /// If true, the first storage block will be a member of the qu_unbounded_spsc
+  /// If true, the first storage block will be a member of the qu_mpsc_unbounded
   /// object (instead of dynamically allocated). Subsequent storage blocks are
   /// always dynamically allocated.
   static inline constexpr bool EmbedFirstBlock = false;
 };
 
-/// Status code returned by qu_unbounded_spsc.try_pull().status()
-struct qu_unbounded_spsc_err {
+/// Status code returned by qu_mpsc_unbounded.try_pull().status()
+struct qu_mpsc_unbounded_err {
   enum value { OK = 0u, EMPTY = 1u, CLOSED = 2u };
 };
 
-template <typename T, typename Config = tmc::qu_unbounded_spsc_default_config>
-class qu_unbounded_spsc {
+template <typename T, typename Config = tmc::qu_mpsc_unbounded_default_config>
+class qu_mpsc_unbounded {
+  static_assert(std::is_nothrow_destructible_v<T>);
+
   static inline constexpr size_t BlockSize = Config::BlockSize;
   static inline constexpr size_t BlockSizeMask = BlockSize - 1;
   static inline constexpr bool ConsumerCanSuspend = Config::ConsumerCanSuspend;
@@ -146,11 +152,11 @@ class qu_unbounded_spsc {
 
   struct element_t {
     std::atomic<void*> flags;
-    tmc::detail::qu_unbounded_spsc_storage<T> data;
+    tmc::detail::qu_mpsc_unbounded_storage<T> data;
 
     static constexpr size_t UNPADLEN =
       sizeof(std::atomic<void*>) +
-      sizeof(tmc::detail::qu_unbounded_spsc_storage<T>);
+      sizeof(tmc::detail::qu_mpsc_unbounded_storage<T>);
     static constexpr size_t WANTLEN = (UNPADLEN + TMC_CACHE_LINE_SIZE - 1) &
                                       static_cast<size_t>(
                                         0 - TMC_CACHE_LINE_SIZE
@@ -253,16 +259,23 @@ class qu_unbounded_spsc {
 
   char pad0[TMC_CACHE_LINE_SIZE];
   std::atomic<size_t> write_offset;
-  std::atomic<data_block*> write_block;
-  // Cold close-related fields: only written once by close() itself. No
-  // `closed_ready` handshake is required (unlike qu_mpsc) because the closer
-  // IS the single producer, so no other producer can race with publication of
-  // write_closed_at.
+  // closed is read by producers on every post() (acquire load). It sits with
+  // write_offset because producers RMW write_offset and immediately check
+  // closed; both are on the same cacheline so the load is essentially free.
   std::atomic<bool> closed;
+  std::atomic<data_block*> write_block_hint;
+  std::atomic<data_block*> write_block;
+  // Cold close-related fields: only read by producers on the close slow path,
+  // and only written once by close() itself.
   std::atomic<size_t> write_closed_at;
+  std::atomic<bool> closed_ready;
   char pad1[TMC_CACHE_LINE_SIZE - sizeof(size_t)];
   size_t read_offset;
-  data_block* head_block; // aka read_block
+  data_block* read_block;
+  data_block* pending_reclaim_old_head;
+  data_block* pending_reclaim_new_head;
+  size_t pending_reclaim_cutoff;
+  data_block* head_block;
   data_block* tail_block;
   char pad2[TMC_CACHE_LINE_SIZE - sizeof(void*)];
 
@@ -279,24 +292,24 @@ public:
   /// queued object will be destroyed and the queue slot will be freed for
   /// reuse. All handles must be released before the queue is destroyed.
   ///
-  /// The status of the pull is exposed via status(): qu_unbounded_spsc_err::OK
+  /// The status of the pull is exposed via status(): qu_mpsc_unbounded_err::OK
   /// if a value is held, EMPTY if no value was available, or CLOSED if the
   /// queue has been closed and drained.
   class try_pull_zc_scope {
-    friend qu_unbounded_spsc;
-    qu_unbounded_spsc* queue;
+    friend qu_mpsc_unbounded;
+    qu_mpsc_unbounded* queue;
     element* elem;
     data_block* block;
     size_t idx;
-    tmc::qu_unbounded_spsc_err::value err;
+    tmc::qu_mpsc_unbounded_err::value err;
 
     try_pull_zc_scope(
-      qu_unbounded_spsc* Queue, element* Elem, data_block* Block, size_t Idx
+      qu_mpsc_unbounded* Queue, element* Elem, data_block* Block, size_t Idx
     ) noexcept
         : queue{Queue}, elem{Elem}, block{Block}, idx{Idx},
-          err{tmc::qu_unbounded_spsc_err::OK} {}
+          err{tmc::qu_mpsc_unbounded_err::OK} {}
 
-    explicit try_pull_zc_scope(tmc::qu_unbounded_spsc_err::value Err) noexcept
+    explicit try_pull_zc_scope(tmc::qu_mpsc_unbounded_err::value Err) noexcept
         : queue{nullptr}, elem{nullptr}, block{nullptr}, idx{0}, err{Err} {}
 
   public:
@@ -304,7 +317,7 @@ public:
     /// converted to bool.
     try_pull_zc_scope() noexcept
         : queue{nullptr}, elem{nullptr}, block{nullptr}, idx{0},
-          err{tmc::qu_unbounded_spsc_err::EMPTY} {}
+          err{tmc::qu_mpsc_unbounded_err::EMPTY} {}
 
     try_pull_zc_scope(const try_pull_zc_scope&) = delete;
     try_pull_zc_scope& operator=(const try_pull_zc_scope&) = delete;
@@ -313,7 +326,7 @@ public:
         : queue{Other.queue}, elem{Other.elem}, block{Other.block},
           idx{Other.idx}, err{Other.err} {
       Other.elem = nullptr;
-      Other.err = tmc::qu_unbounded_spsc_err::EMPTY;
+      Other.err = tmc::qu_mpsc_unbounded_err::EMPTY;
     }
 
     try_pull_zc_scope& operator=(try_pull_zc_scope&& Other) noexcept {
@@ -328,7 +341,7 @@ public:
         idx = Other.idx;
         err = Other.err;
         Other.elem = nullptr;
-        Other.err = tmc::qu_unbounded_spsc_err::EMPTY;
+        Other.err = tmc::qu_mpsc_unbounded_err::EMPTY;
       }
       return *this;
     }
@@ -340,7 +353,7 @@ public:
     bool has_value() const noexcept { return elem != nullptr; }
 
     /// Returns the status of this pull: OK, EMPTY, or CLOSED.
-    tmc::qu_unbounded_spsc_err::value status() const noexcept { return err; }
+    tmc::qu_mpsc_unbounded_err::value status() const noexcept { return err; }
 
     /// Returns a reference to the object in the queue storage.
     /// Only valid to call if status() is OK / operator bool() is true.
@@ -371,14 +384,14 @@ public:
   /// If the queue has been closed and is drained, `pull()` will resume
   /// with an empty `pull_zc_scope` (operator bool returns false).
   class pull_zc_scope {
-    friend qu_unbounded_spsc;
-    qu_unbounded_spsc* queue;
+    friend qu_mpsc_unbounded;
+    qu_mpsc_unbounded* queue;
     element* elem;
     data_block* block;
     size_t idx;
 
     pull_zc_scope(
-      qu_unbounded_spsc* Queue, element* Elem, data_block* Block, size_t Idx
+      qu_mpsc_unbounded* Queue, element* Elem, data_block* Block, size_t Idx
     ) noexcept
         : queue{Queue}, elem{Elem}, block{Block}, idx{Idx} {}
 
@@ -438,7 +451,7 @@ public:
     }
   };
 
-  qu_unbounded_spsc() noexcept {
+  qu_mpsc_unbounded() noexcept {
     data_block* block;
     if constexpr (Config::EmbedFirstBlock) {
       block = &embedded_block;
@@ -447,11 +460,17 @@ public:
     }
     head_block = block;
     write_block.store(block, std::memory_order_relaxed);
+    write_block_hint.store(block, std::memory_order_relaxed);
     tail_block = block;
     write_offset.store(0, std::memory_order_relaxed);
     closed.store(false, std::memory_order_relaxed);
+    closed_ready.store(false, std::memory_order_relaxed);
     write_closed_at.store(0, std::memory_order_relaxed);
     read_offset = 0;
+    read_block = block;
+    pending_reclaim_old_head = nullptr;
+    pending_reclaim_new_head = nullptr;
+    pending_reclaim_cutoff = 0;
     tmc::detail::memory_barrier();
   }
 
@@ -553,43 +572,77 @@ private:
     return Block;
   }
 
-  // Given idx, advance from write_block until the block containing idx
-  // is found. Update write_block if necessary.
-  inline data_block* find_write_block(size_t Idx) noexcept {
-    data_block* block = write_block.load(std::memory_order_relaxed);
-    size_t offset = block->offset.load(std::memory_order_relaxed);
-    assert(circular_less_than(offset, 1 + Idx));
-    size_t targetOffset = Idx & ~BlockSizeMask;
-    if (offset != targetOffset) {
-      // Find or allocate the associated block
-      do {
-        data_block* next = block->next.load(std::memory_order_acquire);
-        if (next == nullptr) {
-          data_block* newBlock = new data_block(offset + BlockSize);
-          if (block->next.compare_exchange_strong(
-                next, newBlock, std::memory_order_acq_rel,
-                std::memory_order_acquire
-              )) {
-            next = newBlock;
-          } else {
-            delete newBlock;
-          }
-        }
-        block = next;
-        offset += BlockSize;
-        assert(block->offset.load(std::memory_order_relaxed) == offset);
-      } while (offset != targetOffset);
-      write_block.store(block, std::memory_order_relaxed);
-    }
-
-    assert(
-      Idx >= block->offset.load(std::memory_order_relaxed) &&
-      Idx <= block->offset.load(std::memory_order_relaxed) + BlockSize - 1
+  static inline bool block_before(data_block* A, data_block* B) noexcept {
+    return circular_less_than(
+      A->offset.load(std::memory_order_relaxed),
+      B->offset.load(std::memory_order_relaxed)
     );
+  }
+
+  void advance_write_block_hint_at_least(
+    data_block* Current, data_block* Target
+  ) noexcept {
+    while (block_before(Current, Target)) {
+      if (write_block_hint.compare_exchange_weak(
+            Current, Target, std::memory_order_seq_cst,
+            std::memory_order_seq_cst
+          )) {
+        return;
+      }
+    }
+  }
+
+  void advance_write_block_hint_at_least(data_block* Target) noexcept {
+    advance_write_block_hint_at_least(
+      write_block_hint.load(std::memory_order_seq_cst), Target
+    );
+  }
+
+  data_block* get_mpsc_write_start_block(size_t Idx) noexcept {
+    data_block* block = write_block_hint.load(std::memory_order_seq_cst);
+    if (!circular_less_than(
+          block->offset.load(std::memory_order_relaxed), 1 + Idx
+        )) {
+      // A later producer may have advanced the hint past this producer's
+      // earlier reservation. Fall back to the consumer-managed reclaim
+      // frontier, which cannot advance past an unproduced reservation.
+      block = write_block.load(std::memory_order_seq_cst);
+      assert(circular_less_than(
+        block->offset.load(std::memory_order_relaxed), 1 + Idx
+      ));
+    }
     return block;
   }
 
-  void try_reclaim_blocks(data_block* NewHead) noexcept {
+  bool try_finish_pending_reclaim() noexcept {
+    if (pending_reclaim_old_head == nullptr) {
+      return false;
+    }
+
+    // The pending blocks were removed from the producer-visible write head
+    // before pending_reclaim_cutoff was read from write_offset. Any producer
+    // that can still be walking from the old write head must therefore have a
+    // reservation before this cutoff. Once the single consumer reaches the
+    // cutoff, those producers have published their elements and no longer touch
+    // the old blocks.
+    if (circular_less_than(read_offset, pending_reclaim_cutoff)) {
+      return false;
+    }
+
+    data_block* oldHead = pending_reclaim_old_head;
+    data_block* newHead = pending_reclaim_new_head;
+    head_block = newHead;
+    pending_reclaim_old_head = nullptr;
+    pending_reclaim_new_head = nullptr;
+    reclaim_blocks(oldHead, newHead);
+    return true;
+  }
+
+  void try_start_reclaim(data_block* NewHead) noexcept {
+    if (pending_reclaim_old_head != nullptr) {
+      return;
+    }
+
     data_block* oldHead = head_block;
     size_t newHeadOffset = read_offset & ~BlockSizeMask;
     assert(NewHead->offset.load(std::memory_order_relaxed) == newHeadOffset);
@@ -598,24 +651,65 @@ private:
       return;
     }
 
-    head_block = NewHead;
-    reclaim_blocks(oldHead, NewHead);
+    // This seq_cst write_block store, seq_cst write_block_hint advancement, and
+    // the following seq_cst write_offset load form the cutoff protocol with
+    // producers, which do a seq_cst fetch_add before a seq_cst load of either
+    // write_block_hint or write_block. A producer that observes the old
+    // write_block or write_block_hint must have a reservation included in the
+    // cutoff.
+    write_block.store(NewHead, std::memory_order_seq_cst);
+    advance_write_block_hint_at_least(NewHead);
+    pending_reclaim_cutoff = write_offset.load(std::memory_order_seq_cst);
+    pending_reclaim_old_head = oldHead;
+    pending_reclaim_new_head = NewHead;
   }
 
-  // Idx will be initialized by this function
+  void try_reclaim_blocks(data_block* NewHead) noexcept {
+    try_finish_pending_reclaim();
+    try_start_reclaim(NewHead);
+    try_finish_pending_reclaim();
+  }
+
+  // Idx will be initialized by this function.
+  // Returns nullptr if the queue is closed and Idx is past the close cutoff;
+  // the caller must not write to the slot in that case.
   element* get_write_ticket(size_t& Idx) noexcept {
-    // In SPSC mode, write_offset is the committed write offset. The producer
-    // takes the next index from it, advances its block cursor before making a
-    // block-start element visible, and publishes write_offset after writing.
-    Idx = write_offset.load(std::memory_order_relaxed);
-    data_block* block = find_write_block(Idx);
+    // seq_cst is needed here so the reader can order its write_block update
+    // and subsequent write_offset load against the producer's reservation and
+    // write_block load. It also forms the producer side of the close protocol:
+    // close()'s release store to `closed` is sequenced-before its own seq_cst
+    // fetch_add on write_offset; if our fetch_add is mod-order after close's,
+    // the RMW chain makes the release store of `closed` happens-before our
+    // subsequent acquire load below.
+    Idx = write_offset.fetch_add(1, std::memory_order_seq_cst);
+
+    if (closed.load(std::memory_order_acquire)) [[unlikely]] {
+      // Wait for write_closed_at to be published by close().
+      while (!closed_ready.load(std::memory_order_acquire)) {
+        TMC_CPU_PAUSE();
+      }
+      if (circular_less_than(
+            write_closed_at.load(std::memory_order_acquire), 1 + Idx
+          )) {
+        return nullptr;
+      }
+    }
+
+    data_block* observed = get_mpsc_write_start_block(Idx);
+
+    assert(circular_less_than(
+      observed->offset.load(std::memory_order_relaxed), 1 + Idx
+    ));
+
+    data_block* block = find_block(observed, Idx);
+    advance_write_block_hint_at_least(observed, block);
     element* elem = &block->values[Idx & BlockSizeMask];
     return elem;
   }
 
   element* get_read_ticket(size_t& Idx, data_block*& Block) noexcept {
     Idx = read_offset;
-    Block = head_block;
+    Block = read_block;
 
     assert(
       circular_less_than(Block->offset.load(std::memory_order_relaxed), 1 + Idx)
@@ -633,6 +727,7 @@ private:
     // mode the producer already advanced before making this block-start element
     // visible, so old blocks can be reclaimed immediately.
     if ((Idx & BlockSizeMask) == 0) {
+      read_block = Block;
       try_reclaim_blocks(Block);
     }
   }
@@ -649,89 +744,122 @@ private:
     }
   }
 
-  // StartIdx and EndIdx will be initialized by this function.
-  // Count must be non-zero (enforced by the caller).
-  data_block* get_write_ticket_bulk(
-    size_t Count, size_t& StartIdx, size_t& EndIdx
-  ) noexcept {
-    // In SPSC mode, write_offset is published after all elements in the bulk
-    // operation have been written.
-    StartIdx = write_offset.load(std::memory_order_relaxed);
-    EndIdx = StartIdx + Count;
-    data_block* block = write_block.load(std::memory_order_relaxed);
-
-    assert(circular_less_than(
-      block->offset.load(std::memory_order_relaxed), 1 + StartIdx
-    ));
-
-    // Ensure all blocks for the operation are allocated and available.
-    data_block* startBlock = find_block(block, StartIdx);
-    find_block(startBlock, EndIdx - 1);
-    write_block.store(startBlock, std::memory_order_relaxed);
-    return startBlock;
-  }
-
-public:
-  /// Constructs a new value in the queue, forwarding `ConstructArgs` to T's
-  /// constructor. Only safe to call from the single producer thread.
-  ///
-  /// If a consumer is currently suspended waiting for a value, it will be
-  /// resumed.
-  template <typename... Args> void post(Args&&... ConstructArgs) noexcept {
-    // close() must only be called from the single producer thread, so post()
-    // and close() are sequenced on the same thread. Posting after close() is
-    // a programming error.
-    assert(!closed.load(std::memory_order_relaxed));
-
-    // Get write ticket and associated block.
-    size_t idx;
-    element* elem = get_write_ticket(idx);
-
-    consumer_base* cons =
-      write_element(elem, std::forward<Args>(ConstructArgs)...);
-    write_offset.store(idx + 1, std::memory_order_release);
-    if (cons != nullptr) {
+  void notify_consumer(consumer_base* Cons) noexcept {
+    if (Cons != nullptr) {
       tmc::detail::post_checked(
-        cons->continuation_executor, std::move(cons->continuation), cons->prio
+        Cons->continuation_executor, std::move(Cons->continuation), Cons->prio
       );
     }
   }
 
-  /// Moves `Count` values from the iterator `Items` into the queue. Only safe
-  /// to call from the single producer thread.
+  // StartIdx and EndIdx will be initialized by this function.
+  // Count must be non-zero (enforced by the caller).
+  // Returns nullptr if the queue is closed and the reservation is entirely
+  // past the close cutoff; the caller must not write any of the slots in
+  // that case. Because close() takes a single fetch_add cutoff, a bulk
+  // reservation cannot straddle the cutoff: it is either all pre-close or
+  // all post-close in the seq_cst total order on write_offset.
+  data_block* get_write_ticket_bulk(
+    size_t Count, size_t& StartIdx, size_t& EndIdx
+  ) noexcept {
+    // seq_cst here serves the same purpose as in get_write_ticket: it orders
+    // the reader's reclaim cutoff AND forms the producer side of the close
+    // protocol (RMW-chain from close()'s release store to `closed`).
+    StartIdx = write_offset.fetch_add(Count, std::memory_order_seq_cst);
+    EndIdx = StartIdx + Count;
+
+    if (closed.load(std::memory_order_acquire)) [[unlikely]] {
+      while (!closed_ready.load(std::memory_order_acquire)) {
+        TMC_CPU_PAUSE();
+      }
+      if (circular_less_than(
+            write_closed_at.load(std::memory_order_acquire), 1 + StartIdx
+          )) {
+        return nullptr;
+      }
+    }
+
+    data_block* observed = get_mpsc_write_start_block(StartIdx);
+
+    assert(circular_less_than(
+      observed->offset.load(std::memory_order_relaxed), 1 + StartIdx
+    ));
+
+    // Ensure all blocks for the operation are allocated and available.
+    data_block* startBlock = find_block(observed, StartIdx);
+    data_block* endBlock = find_block(startBlock, EndIdx - 1);
+    advance_write_block_hint_at_least(observed, endBlock);
+    return startBlock;
+  }
+
+public:
+  /// If the queue is open, this will always return true, indicating that an
+  /// object of type T was enqueued by in-place construction in the queue using
+  /// the provided constructor arguments.
   ///
-  /// If a consumer is currently suspended waiting for a value, it will be
-  /// resumed.
-  template <typename It> void post_bulk(It&& Items, size_t Count) noexcept {
+  /// If the queue is closed, this will return false, and the object will not
+  /// be constructed.
+  ///
+  /// Will not suspend or block.
+  template <typename... Args> bool post(Args&&... ConstructArgs) noexcept {
+    // Implementing handling for throwing construction is not possible with the
+    // current design. This assert will also fire if no matching constructor can
+    // be found for the provided arguments.
+    static_assert(std::is_nothrow_constructible_v<T, Args&&...>);
+
+    // Get write ticket and associated block.
+    size_t idx;
+    element* elem = get_write_ticket(idx);
+    if (elem == nullptr) [[unlikely]] {
+      return false;
+    }
+
+    consumer_base* cons =
+      write_element(elem, std::forward<Args>(ConstructArgs)...);
+    notify_consumer(cons);
+    return true;
+  }
+
+  /// If the channel is open, this will always return true, indicating that
+  /// Count elements, starting from the Begin iterator, were enqueued.
+  ///
+  /// If the channel is closed, this will return false, and no items
+  /// will be enqueued.
+  ///
+  /// Each item is moved (not copied) from the iterator into the channel.
+  ///
+  /// The closed check is performed first, then space is pre-allocated, then all
+  /// Count items are moved into the channel. Thus, there cannot be a partial
+  /// success - either all or none of the items will be moved.
+  ///
+  /// Will not suspend or block.
+  template <typename It> bool post_bulk(It&& Items, size_t Count) noexcept {
+    // Implementing handling for throwing construction is not possible with the
+    // current design. This assert will also fire if no matching constructor can
+    // be found for the iterator's dereferenced value.
     static_assert(
-      std::is_nothrow_move_constructible_v<T>,
-      "post_bulk moves values from the iterator into the queue; T must be "
-      "nothrow move constructible"
+      std::is_nothrow_constructible_v<T, decltype(std::move(*Items))>
     );
-    // close() must only be called from the single producer thread, so
-    // post_bulk() and close() are sequenced on the same thread. Posting after
-    // close() is a programming error.
-    assert(!closed.load(std::memory_order_relaxed));
+
     if (Count == 0) [[unlikely]] {
-      return;
+      return true;
     }
 
     // Get write ticket and associated block.
     size_t startIdx, endIdx;
     data_block* block = get_write_ticket_bulk(Count, startIdx, endIdx);
+    if (block == nullptr) [[unlikely]] {
+      return false;
+    }
 
     size_t idx = startIdx;
-    consumer_base* cons = nullptr;
     while (idx < endIdx) {
       element* elem = &block->values[idx & BlockSizeMask];
 
       TMC_DISABLE_WARNING_PESSIMIZING_MOVE_BEGIN
       consumer_base* waiting = write_element(elem, std::move(*Items));
       TMC_DISABLE_WARNING_PESSIMIZING_MOVE_END
-      if (waiting != nullptr) {
-        assert(cons == nullptr);
-        cons = waiting;
-      }
+      notify_consumer(waiting);
 
       ++Items;
       ++idx;
@@ -739,85 +867,100 @@ public:
         block = block->next.load(std::memory_order_acquire);
         // all blocks should have been preallocated for [startIdx, endIdx)
         assert(block != nullptr || idx >= endIdx);
-        if (idx < endIdx) {
-          write_block.store(block, std::memory_order_relaxed);
-        }
       }
     }
-    write_offset.store(endIdx, std::memory_order_release);
-    if (cons != nullptr) {
-      tmc::detail::post_checked(
-        cons->continuation_executor, std::move(cons->continuation), cons->prio
-      );
-    }
+    return true;
   }
 
   /// Calculates the number of elements via `size_t Count = End - Begin;`
-  /// and moves them from the iterator `Begin` into the queue. Only safe to
-  /// call from the single producer thread.
   ///
-  /// If a consumer is currently suspended waiting for a value, it will be
-  /// resumed.
-  template <typename It> void post_bulk(It&& Begin, It&& End) noexcept {
+  /// If the channel is open, this will always return true, indicating that
+  /// Count elements, starting from the Begin iterator, were enqueued.
+  ///
+  /// If the channel is closed, this will return false, and no items
+  /// will be enqueued.
+  ///
+  /// Each item is moved (not copied) from the iterator into the channel.
+  ///
+  /// The closed check is performed first, then space is pre-allocated, then all
+  /// Count items are moved into the channel. Thus, there cannot be a partial
+  /// success - either all or none of the items will be moved.
+  ///
+  /// Will not suspend or block.
+  template <typename It> bool post_bulk(It&& Begin, It&& End) noexcept {
+    // Implementing handling for throwing construction is not possible with the
+    // current design. This assert will also fire if no matching constructor can
+    // be found for the iterator's dereferenced value.
     static_assert(
-      std::is_nothrow_move_constructible_v<T>,
-      "post_bulk moves values from the iterator into the queue; T must be "
-      "nothrow move constructible"
+      std::is_nothrow_constructible_v<T, decltype(std::move(*Begin))>
     );
-    post_bulk(static_cast<It&&>(Begin), static_cast<size_t>(End - Begin));
+    return post_bulk(
+      static_cast<It&&>(Begin), static_cast<size_t>(End - Begin)
+    );
   }
 
   /// Calculates the number of elements via
-  /// `size_t Count = Range.end() - Range.begin();` and moves them from the
-  /// beginning of the range into the queue. Only safe to call from the single
-  /// producer thread.
+  /// `size_t Count = Range.end() - Range.begin();`
   ///
-  /// If a consumer is currently suspended waiting for a value, it will be
-  /// resumed.
-  template <typename Range> void post_bulk(Range&& R) noexcept {
-    static_assert(
-      std::is_nothrow_move_constructible_v<T>,
-      "post_bulk moves values from the iterator into the queue; T must be "
-      "nothrow move constructible"
-    );
+  /// If the channel is open, this will always return true, indicating that
+  /// Count elements from the beginning of the range were enqueued.
+  ///
+  /// If the channel is closed, this will return false, and no items
+  /// will be enqueued.
+  ///
+  /// Each item is moved (not copied) from the iterator into the channel.
+  ///
+  /// The closed check is performed first, then space is pre-allocated, then all
+  /// Count items are moved into the channel. Thus, there cannot be a partial
+  /// success - either all or none of the items will be moved.
+  ///
+  /// Will not suspend or block.
+  template <typename Range> bool post_bulk(Range&& R) noexcept {
+    // Implementing handling for throwing construction is not possible with the
+    // current design. This assert will also fire if no matching constructor can
+    // be found for the iterator's dereferenced value.
+    static_assert(std::is_nothrow_constructible_v<
+                  T, decltype(std::move(*static_cast<Range&&>(R).begin()))>);
     auto begin = static_cast<Range&&>(R).begin();
     auto end = static_cast<Range&&>(R).end();
-    post_bulk(begin, static_cast<size_t>(end - begin));
+    return post_bulk(begin, static_cast<size_t>(end - begin));
   }
 
 private:
   // Performs the common close work and returns the waiting consumer (if any)
-  // that needs to be woken. Returns nullptr if the queue was already closed,
-  // or if no consumer was waiting at the cutoff slot.
+  // that needs to be woken. Returns nullptr if the queue was already closed
+  // by another thread, or if no consumer was waiting at the cutoff slot.
   consumer_base* close_get_waiting_consumer() noexcept {
     bool expected = false;
     if (!closed.compare_exchange_strong(
           expected, true, std::memory_order_release, std::memory_order_acquire
         )) {
-      // Already closed.
+      // Already closed by another thread.
       return nullptr;
     }
 
-    // Because close() is only called from the single producer thread, there is
-    // no concurrent producer that could reserve a slot past the close cutoff.
-    // The next slot the producer would have used is write_offset (writes are
-    // published by storing write_offset *after* the data); this is the only
-    // slot the consumer could still be waiting on.
-    //
-    // No `closed_ready` handshake is required (unlike qu_mpsc), because no
-    // other producer is racing with the closer to learn the cutoff.
-    size_t woff = write_offset.load(std::memory_order_relaxed);
+    // We are the unique closer. The release store of `closed` above is
+    // sequenced-before the following seq_cst fetch_add; any producer whose
+    // own seq_cst fetch_add on write_offset is mod-order after ours will
+    // synchronize-with us via the RMW chain and see `closed == true` on
+    // its subsequent acquire load.
+    size_t woff = write_offset.fetch_add(1, std::memory_order_seq_cst);
     write_closed_at.store(woff, std::memory_order_release);
+    closed_ready.store(true, std::memory_order_release);
 
-    // Publish the CLOSED sentinel at slot woff. This races with the consumer's
-    // try_wait() on that element; exactly one of the two RMWs goes first.
+    // Publish the CLOSED sentinel at slot woff. The single consumer is
+    // bounded to slot <= woff (slot > woff is unreachable since no producer
+    // ever fills slot woff), so this is the only slot the consumer can be
+    // stuck on. The exchange races with the consumer's try_wait(): exactly
+    // one of the two RMWs on this element's flags goes first.
     //   - If the consumer's exchange goes first, it installed its
     //     consumer_base pointer; our exchange returns that pointer and we
     //     post the resumption.
-    //   - If our exchange goes first, the slot now contains CLOSED_BIT; when
-    //     the consumer later runs try_wait() it observes CLOSED_BIT and
-    //     returns CLOSED without suspending.
-    data_block* block = find_write_block(woff);
+    //   - If our exchange goes first, the slot now contains CLOSED_BIT;
+    //     when the consumer later runs try_wait() it observes CLOSED_BIT
+    //     and returns CLOSED without suspending.
+    data_block* observed = get_mpsc_write_start_block(woff);
+    data_block* block = find_block(observed, woff);
     element* elem = &block->values[woff & BlockSizeMask];
     consumer_base* cons = elem->set_closed_or_get_waiting_consumer();
     if (cons != nullptr) {
@@ -828,15 +971,13 @@ private:
   }
 
 public:
-  /// Closes the queue. May only be called from the single producer thread.
-  /// After close() returns, the producer must not call post() or post_bulk()
-  /// again. Calls to `pull()` and `try_pull()` will continue to read data
-  /// until all messages have been consumed, at which point all subsequent
-  /// calls will immediately return an empty scope. If the queue was already
-  /// empty, any waiting consumers will be awoken immediately and return an
-  /// empty scope.
+  /// All future calls to `post()` and `post_bulk()` will immediately return
+  /// false. Calls to `pull()` and `try_pull()` will continue to read data until
+  /// all messages have been consumed, at which point all subsequent calls will
+  /// immediately return an empty scope. If the queue was already empty, any
+  /// waiting consumers will be awoken immediately and return an empty scope.
   ///
-  /// close() is idempotent.
+  /// close() is idempotent and safe to call from any thread.
   void close() noexcept {
     consumer_base* cons = close_get_waiting_consumer();
     if (cons != nullptr) {
@@ -852,8 +993,7 @@ public:
   /// may safely run on the caller's thread.
   ///
   /// Behaves like close() in all other respects (see close() for details).
-  /// close_resume_inline() is idempotent. May only be called from the single
-  /// producer thread.
+  /// close_resume_inline() is idempotent and safe to call from any thread.
   void close_resume_inline() noexcept {
     consumer_base* cons = close_get_waiting_consumer();
     if (cons != nullptr) {
@@ -866,7 +1006,7 @@ public:
   /// Only safe to call from the single consumer.
   bool empty() {
     size_t Idx = read_offset;
-    data_block* block = find_block(head_block, Idx);
+    data_block* block = find_block(read_block, Idx);
     element* elem = &block->values[Idx & BlockSizeMask];
 
     bool isEmpty = !elem->is_data_waiting();
@@ -874,15 +1014,15 @@ public:
   }
 
   class aw_pull final : private tmc::detail::AwaitTagNoGroupCoAwait {
-    friend qu_unbounded_spsc<T, Config>;
+    friend qu_mpsc_unbounded<T, Config>;
 
-    qu_unbounded_spsc& queue;
+    qu_mpsc_unbounded& queue;
 
-    aw_pull(qu_unbounded_spsc& Queue) noexcept : queue(Queue) {}
+    aw_pull(qu_mpsc_unbounded& Queue) noexcept : queue(Queue) {}
 
     struct aw_pull_impl final {
       consumer_base base;
-      qu_unbounded_spsc& queue;
+      qu_mpsc_unbounded& queue;
       data_block* block;
       size_t idx;
 
@@ -951,9 +1091,9 @@ public:
   /// single consumer.
   ///
   /// The returned scope's status() returns:
-  ///   - qu_unbounded_spsc_err::OK     - a value was dequeued
-  ///   - qu_unbounded_spsc_err::EMPTY  - no value is currently available
-  ///   - qu_unbounded_spsc_err::CLOSED - the queue has been closed and drained
+  ///   - qu_mpsc_unbounded_err::OK     - a value was dequeued
+  ///   - qu_mpsc_unbounded_err::EMPTY  - no value is currently available
+  ///   - qu_mpsc_unbounded_err::CLOSED - the queue has been closed and drained
   ///
   /// The returned scope's has_value() / operator bool() returns true if a value
   /// was dequeued, or false if the queue was empty or closed.
@@ -970,16 +1110,16 @@ public:
       return try_pull_zc_scope(this, elem, block, Idx);
     }
     if (s == CLOSED_BIT) {
-      return try_pull_zc_scope(tmc::qu_unbounded_spsc_err::CLOSED);
+      return try_pull_zc_scope(tmc::qu_mpsc_unbounded_err::CLOSED);
     }
-    return try_pull_zc_scope(tmc::qu_unbounded_spsc_err::EMPTY);
+    return try_pull_zc_scope(tmc::qu_mpsc_unbounded_err::EMPTY);
   }
 
   /// If the queue was not empty, destroys any contained data.
   /// If the queue was empty, wakes any waiting consumer by calling close().
   /// This only safely handles consumers that were already waiting; you must
   /// ensure that new producers and consumers do not race with this destructor.
-  ~qu_unbounded_spsc() {
+  ~qu_mpsc_unbounded() {
     close();
     {
       // close() published a CLOSED sentinel at write_closed_at; that slot
@@ -1014,10 +1154,10 @@ public:
     }
   }
 
-  qu_unbounded_spsc(const qu_unbounded_spsc&) = delete;
-  qu_unbounded_spsc& operator=(const qu_unbounded_spsc&) = delete;
-  qu_unbounded_spsc(qu_unbounded_spsc&&) = delete;
-  qu_unbounded_spsc& operator=(qu_unbounded_spsc&&) = delete;
+  qu_mpsc_unbounded(const qu_mpsc_unbounded&) = delete;
+  qu_mpsc_unbounded& operator=(const qu_mpsc_unbounded&) = delete;
+  qu_mpsc_unbounded(qu_mpsc_unbounded&&) = delete;
+  qu_mpsc_unbounded& operator=(qu_mpsc_unbounded&&) = delete;
 };
 
 } // namespace tmc

--- a/include/tmc/qu_mpsc_unbounded.hpp
+++ b/include/tmc/qu_mpsc_unbounded.hpp
@@ -94,8 +94,8 @@ template <typename T> struct qu_mpsc_unbounded_storage {
 } // namespace detail
 
 struct qu_mpsc_unbounded_default_config {
-  /// If true, enables the suspending pull() operation. This costs each producer
-  /// an additional locked operation to check for a waiting consumer.
+  /// If true, enables the suspending `pull()` operation. This costs each
+  /// producer an additional locked operation to check for a waiting consumer.
   static inline constexpr bool ConsumerCanSuspend = true;
 
   /// The number of elements that can be stored in each block in the
@@ -114,9 +114,7 @@ struct qu_mpsc_unbounded_default_config {
 };
 
 /// Status code returned by qu_mpsc_unbounded.try_pull().status()
-struct qu_mpsc_unbounded_err {
-  enum value { OK = 0u, EMPTY = 1u, CLOSED = 2u };
-};
+enum class qu_mpsc_unbounded_err { OK, EMPTY, CLOSED };
 
 template <typename T, typename Config = tmc::qu_mpsc_unbounded_default_config>
 class qu_mpsc_unbounded {
@@ -290,18 +288,18 @@ public:
   /// A zero-copy handle to an object in the queue's storage. The object is
   /// exclusively available to this handle. When this handle is destroyed, the
   /// queued object will be destroyed and the queue slot will be freed for
-  /// reuse. All handles must be released before the queue is destroyed.
+  /// reuse. Returned by `try_pull()`.
   ///
-  /// The status of the pull is exposed via status(): qu_mpsc_unbounded_err::OK
-  /// if a value is held, EMPTY if no value was available, or CLOSED if the
-  /// queue has been closed and drained.
+  /// The status of the pull is exposed via `status()`:
+  /// `qu_mpsc_unbounded_err::OK` if a value is held, `EMPTY` if no value was
+  /// available, or `CLOSED` if the queue has been closed and drained.
   class try_pull_zc_scope {
     friend qu_mpsc_unbounded;
     qu_mpsc_unbounded* queue;
     element* elem;
     data_block* block;
     size_t idx;
-    tmc::qu_mpsc_unbounded_err::value err;
+    tmc::qu_mpsc_unbounded_err err;
 
     try_pull_zc_scope(
       qu_mpsc_unbounded* Queue, element* Elem, data_block* Block, size_t Idx
@@ -309,11 +307,11 @@ public:
         : queue{Queue}, elem{Elem}, block{Block}, idx{Idx},
           err{tmc::qu_mpsc_unbounded_err::OK} {}
 
-    explicit try_pull_zc_scope(tmc::qu_mpsc_unbounded_err::value Err) noexcept
+    explicit try_pull_zc_scope(tmc::qu_mpsc_unbounded_err Err) noexcept
         : queue{nullptr}, elem{nullptr}, block{nullptr}, idx{0}, err{Err} {}
 
   public:
-    /// Constructs an empty zc_scope (status EMPTY). Evaluates to false when
+    /// Constructs an empty scope (status EMPTY). Evaluates to false when
     /// converted to bool.
     try_pull_zc_scope() noexcept
         : queue{nullptr}, elem{nullptr}, block{nullptr}, idx{0},
@@ -346,25 +344,25 @@ public:
       return *this;
     }
 
-    /// Returns true if this scope holds a value from the queue.
+    /// Returns true if this scope holds a value from the queue (status == OK).
     explicit operator bool() const noexcept { return elem != nullptr; }
 
-    /// Returns true if this scope holds a value from the queue.
+    /// Returns true if this scope holds a value from the queue (status == OK).
     bool has_value() const noexcept { return elem != nullptr; }
 
     /// Returns the status of this pull: OK, EMPTY, or CLOSED.
-    tmc::qu_mpsc_unbounded_err::value status() const noexcept { return err; }
+    tmc::qu_mpsc_unbounded_err status() const noexcept { return err; }
 
     /// Returns a reference to the object in the queue storage.
-    /// Only valid to call if status() is OK / operator bool() is true.
+    /// Only valid to call if `status()` is OK / `operator bool()` is true.
     T& get() noexcept { return elem->data.value; }
 
     /// Returns a reference to the object in the queue storage.
-    /// Only valid to call if status() is OK / operator bool() is true.
+    /// Only valid to call if `status()` is OK / `operator bool()` is true.
     T& operator*() noexcept { return elem->data.value; }
 
     /// Returns a pointer to the object in the queue storage.
-    /// Only valid to call if status() is OK / operator bool() is true.
+    /// Only valid to call if `status()` is OK / `operator bool()` is true.
     T* operator->() noexcept { return &elem->data.value; }
 
     /// Destroys the object in the queue storage and releases the queue slot.
@@ -379,7 +377,7 @@ public:
   /// A zero-copy handle to an object in the queue's storage. The object is
   /// exclusively available to this handle. When this handle is destroyed, the
   /// queued object will be destroyed and the queue slot will be freed for
-  /// reuse. Returned by the suspending `pull()` operation.
+  /// reuse. Returned by `co_await pull()`.
   ///
   /// If the queue has been closed and is drained, `pull()` will resume
   /// with an empty `pull_zc_scope` (operator bool returns false).
@@ -396,7 +394,7 @@ public:
         : queue{Queue}, elem{Elem}, block{Block}, idx{Idx} {}
 
   public:
-    /// Constructs an empty zc_scope. Evaluates to false when converted to bool.
+    /// Constructs an empty scope. Evaluates to false when converted to bool.
     pull_zc_scope() noexcept
         : queue{nullptr}, elem{nullptr}, block{nullptr}, idx{0} {}
 
@@ -431,15 +429,15 @@ public:
     }
 
     /// Returns a reference to the object in the queue storage.
-    /// Only valid to call if operator bool() is true.
+    /// Only valid to call if `operator bool()` is true.
     T& get() noexcept { return elem->data.value; }
 
     /// Returns a reference to the object in the queue storage.
-    /// Only valid to call if operator bool() is true.
+    /// Only valid to call if `operator bool()` is true.
     T& operator*() noexcept { return elem->data.value; }
 
     /// Returns a pointer to the object in the queue storage.
-    /// Only valid to call if operator bool() is true.
+    /// Only valid to call if `operator bool()` is true.
     T* operator->() noexcept { return &elem->data.value; }
 
     /// Destroys the object in the queue storage and releases the queue slot.
@@ -820,16 +818,16 @@ public:
     return true;
   }
 
-  /// If the channel is open, this will always return true, indicating that
+  /// If the queue is open, this will always return true, indicating that
   /// Count elements, starting from the Begin iterator, were enqueued.
   ///
-  /// If the channel is closed, this will return false, and no items
+  /// If the queue is closed, this will return false, and no items
   /// will be enqueued.
   ///
-  /// Each item is moved (not copied) from the iterator into the channel.
+  /// Each item is moved (not copied) from the iterator into the queue.
   ///
   /// The closed check is performed first, then space is pre-allocated, then all
-  /// Count items are moved into the channel. Thus, there cannot be a partial
+  /// Count items are moved into the queue. Thus, there cannot be a partial
   /// success - either all or none of the items will be moved.
   ///
   /// Will not suspend or block.
@@ -874,16 +872,16 @@ public:
 
   /// Calculates the number of elements via `size_t Count = End - Begin;`
   ///
-  /// If the channel is open, this will always return true, indicating that
+  /// If the queue is open, this will always return true, indicating that
   /// Count elements, starting from the Begin iterator, were enqueued.
   ///
-  /// If the channel is closed, this will return false, and no items
+  /// If the queue is closed, this will return false, and no items
   /// will be enqueued.
   ///
-  /// Each item is moved (not copied) from the iterator into the channel.
+  /// Each item is moved (not copied) from the iterator into the queue.
   ///
   /// The closed check is performed first, then space is pre-allocated, then all
-  /// Count items are moved into the channel. Thus, there cannot be a partial
+  /// Count items are moved into the queue. Thus, there cannot be a partial
   /// success - either all or none of the items will be moved.
   ///
   /// Will not suspend or block.
@@ -902,16 +900,16 @@ public:
   /// Calculates the number of elements via
   /// `size_t Count = Range.end() - Range.begin();`
   ///
-  /// If the channel is open, this will always return true, indicating that
+  /// If the queue is open, this will always return true, indicating that
   /// Count elements from the beginning of the range were enqueued.
   ///
-  /// If the channel is closed, this will return false, and no items
+  /// If the queue is closed, this will return false, and no items
   /// will be enqueued.
   ///
-  /// Each item is moved (not copied) from the iterator into the channel.
+  /// Each item is moved (not copied) from the iterator into the queue.
   ///
   /// The closed check is performed first, then space is pre-allocated, then all
-  /// Count items are moved into the channel. Thus, there cannot be a partial
+  /// Count items are moved into the queue. Thus, there cannot be a partial
   /// success - either all or none of the items will be moved.
   ///
   /// Will not suspend or block.
@@ -977,7 +975,7 @@ public:
   /// immediately return an empty scope. If the queue was already empty, any
   /// waiting consumers will be awoken immediately and return an empty scope.
   ///
-  /// close() is idempotent and safe to call from any thread.
+  /// `close()` is idempotent and safe to call from any thread.
   void close() noexcept {
     consumer_base* cons = close_get_waiting_consumer();
     if (cons != nullptr) {
@@ -992,8 +990,8 @@ public:
   /// This should only be used when the caller knows that the waiting consumer
   /// may safely run on the caller's thread.
   ///
-  /// Behaves like close() in all other respects (see close() for details).
-  /// close_resume_inline() is idempotent and safe to call from any thread.
+  /// Behaves like `close()` in all other respects. `close_resume_inline()` is
+  /// idempotent and safe to call from any thread.
   void close_resume_inline() noexcept {
     consumer_base* cons = close_get_waiting_consumer();
     if (cons != nullptr) {
@@ -1002,7 +1000,7 @@ public:
   }
 
   /// Returns true if the queue appears to be empty.
-  /// This is an unsynchronized read (like try_pull()), so it is only a hint.
+  /// This is an unsynchronized read (like `try_pull()`), so it is only a hint.
   /// Only safe to call from the single consumer.
   bool empty() {
     size_t Idx = read_offset;
@@ -1068,13 +1066,13 @@ public:
   /// destroyed, the referenced value will be destroyed and the queue slot freed
   /// for reuse. Only safe to call from the single consumer.
   ///
-  /// The returned scope's has_value() / operator bool() returns true if a value
-  /// was dequeued, or false if the queue was closed and drained.
+  /// The returned scope's `has_value()` / `operator bool()` returns true if a
+  /// value was dequeued, or false if the queue was closed and drained.
   ///
-  /// This scope must be released before the next call to try_pull() or pull().
-  /// It must also be released before the queue is destroyed.
+  /// This scope must be released before the next call to `try_pull()` or
+  /// `pull()`. It must also be released before the queue is destroyed.
   ///
-  /// May suspend until a value is available, or until close() is called.
+  /// May suspend until a value is available, or until `close()` is called.
   [[nodiscard(
     "You must co_await pull(). To poll from a non-coroutine function, use "
     "try_pull()."
@@ -1091,16 +1089,16 @@ public:
   /// destroyed and the queue slot freed for reuse. Only safe to call from the
   /// single consumer.
   ///
-  /// The returned scope's status() returns:
+  /// The returned scope's `status()` returns:
   ///   - qu_mpsc_unbounded_err::OK     - a value was dequeued
   ///   - qu_mpsc_unbounded_err::EMPTY  - no value is currently available
   ///   - qu_mpsc_unbounded_err::CLOSED - the queue has been closed and drained
   ///
-  /// The returned scope's has_value() / operator bool() returns true if a value
-  /// was dequeued, or false if the queue was empty or closed.
+  /// The returned scope's `has_value()` / `operator bool()` returns true if a
+  /// value was dequeued, or false if the queue was empty or closed.
   ///
-  /// This scope must be released before the next call to try_pull() or pull().
-  /// It must also be released before the queue is destroyed.
+  /// This scope must be released before the next call to `try_pull()` or
+  /// `pull()`. It must also be released before the queue is destroyed.
   try_pull_zc_scope try_pull() {
     size_t Idx;
     data_block* block;
@@ -1117,7 +1115,7 @@ public:
   }
 
   /// If the queue was not empty, destroys any contained data.
-  /// If the queue was empty, wakes any waiting consumer by calling close().
+  /// If the queue was empty, wakes any waiting consumer by calling `close()`.
   /// This only safely handles consumers that were already waiting; you must
   /// ensure that new producers and consumers do not race with this destructor.
   ~qu_mpsc_unbounded() {

--- a/include/tmc/qu_spsc_bounded.hpp
+++ b/include/tmc/qu_spsc_bounded.hpp
@@ -341,7 +341,7 @@ public:
 
     /// Returns a reference to the object in the queue storage.
     /// Only valid to call if `status()` is OK / `operator bool()` is true.
-    T& get() noexcept { return elem->data.value; }
+    T& value() noexcept { return elem->data.value; }
 
     /// Returns a reference to the object in the queue storage.
     /// Only valid to call if `status()` is OK / `operator bool()` is true.
@@ -410,7 +410,7 @@ public:
 
     /// Returns a reference to the object in the queue storage.
     /// Only valid to call if `operator bool()` is true.
-    T& get() noexcept { return elem->data.value; }
+    T& value() noexcept { return elem->data.value; }
 
     /// Returns a reference to the object in the queue storage.
     /// Only valid to call if `operator bool()` is true.

--- a/include/tmc/qu_spsc_bounded.hpp
+++ b/include/tmc/qu_spsc_bounded.hpp
@@ -31,7 +31,7 @@ namespace detail {
 // placement new. T need not be default, copy, or move constructible.
 // The caller must track whether the element exists, and manually invoke the
 // destructor if necessary.
-template <typename T> struct qu_bounded_spsc_storage {
+template <typename T> struct qu_spsc_bounded_storage {
   union alignas(alignof(T)) {
     T value;
   };
@@ -39,7 +39,7 @@ template <typename T> struct qu_bounded_spsc_storage {
   bool exists = false;
 #endif
 
-  qu_bounded_spsc_storage() noexcept {}
+  qu_spsc_bounded_storage() noexcept {}
 
   template <typename... ConstructArgs>
   void emplace(ConstructArgs&&... Args) noexcept {
@@ -59,11 +59,11 @@ template <typename T> struct qu_bounded_spsc_storage {
   }
 
   // Precondition: Other.value must exist
-  qu_bounded_spsc_storage(qu_bounded_spsc_storage&& Other) noexcept {
+  qu_spsc_bounded_storage(qu_spsc_bounded_storage&& Other) noexcept {
     emplace(static_cast<T&&>(Other.value));
     Other.destroy();
   }
-  qu_bounded_spsc_storage& operator=(qu_bounded_spsc_storage&& Other) noexcept {
+  qu_spsc_bounded_storage& operator=(qu_spsc_bounded_storage&& Other) noexcept {
     emplace(static_cast<T&&>(Other.value));
     Other.destroy();
     return *this;
@@ -71,22 +71,22 @@ template <typename T> struct qu_bounded_spsc_storage {
 
   // If data was present, the caller is responsible for destroying it.
 #ifndef NDEBUG
-  ~qu_bounded_spsc_storage() { assert(!exists); }
+  ~qu_spsc_bounded_storage() { assert(!exists); }
 #else
-  ~qu_bounded_spsc_storage()
+  ~qu_spsc_bounded_storage()
     requires(std::is_trivially_destructible_v<T>)
   = default;
-  ~qu_bounded_spsc_storage()
+  ~qu_spsc_bounded_storage()
     requires(!std::is_trivially_destructible_v<T>)
   {}
 #endif
 
-  qu_bounded_spsc_storage(const qu_bounded_spsc_storage&) = delete;
-  qu_bounded_spsc_storage& operator=(const qu_bounded_spsc_storage&) = delete;
+  qu_spsc_bounded_storage(const qu_spsc_bounded_storage&) = delete;
+  qu_spsc_bounded_storage& operator=(const qu_spsc_bounded_storage&) = delete;
 };
 } // namespace detail
 
-struct qu_bounded_spsc_default_config {
+struct qu_spsc_bounded_default_config {
   /// If true, enables the suspending pull() operation. This costs the producer
   /// an additional locked operation to check for a waiting consumer.
   static inline constexpr bool ConsumerCanSuspend = true;
@@ -99,13 +99,13 @@ struct qu_bounded_spsc_default_config {
   static inline constexpr size_t PackingLevel = 1;
 };
 
-/// Status code returned by qu_bounded_spsc.try_pull().status()
-struct qu_bounded_spsc_err {
+/// Status code returned by qu_spsc_bounded.try_pull().status()
+struct qu_spsc_bounded_err {
   enum value { OK = 0u, EMPTY = 1u, CLOSED = 2u };
 };
 
-template <typename T, typename Config = tmc::qu_bounded_spsc_default_config>
-class qu_bounded_spsc {
+template <typename T, typename Config = tmc::qu_spsc_bounded_default_config>
+class qu_spsc_bounded {
   static inline constexpr bool ConsumerCanSuspend = Config::ConsumerCanSuspend;
 
   static inline constexpr uintptr_t DATA_BIT = TMC_ONE_BIT;
@@ -128,11 +128,11 @@ class qu_bounded_spsc {
 
   struct element_t {
     std::atomic<void*> flags;
-    tmc::detail::qu_bounded_spsc_storage<T> data;
+    tmc::detail::qu_spsc_bounded_storage<T> data;
 
     static constexpr size_t UNPADLEN =
       sizeof(std::atomic<void*>) +
-      sizeof(tmc::detail::qu_bounded_spsc_storage<T>);
+      sizeof(tmc::detail::qu_spsc_bounded_storage<T>);
     static constexpr size_t WANTLEN = (UNPADLEN + TMC_CACHE_LINE_SIZE - 1) &
                                       static_cast<size_t>(
                                         0 - TMC_CACHE_LINE_SIZE
@@ -281,23 +281,23 @@ public:
   /// queued object will be destroyed and the queue slot will be freed for
   /// reuse. All handles must be released before the queue is destroyed.
   ///
-  /// The status of the pull is exposed via status(): qu_bounded_spsc_err::OK
+  /// The status of the pull is exposed via status(): qu_spsc_bounded_err::OK
   /// if a value is held, EMPTY if no value was available, or CLOSED if the
   /// queue has been closed and drained.
   class try_pull_zc_scope {
-    friend qu_bounded_spsc;
-    qu_bounded_spsc* queue;
+    friend qu_spsc_bounded;
+    qu_spsc_bounded* queue;
     element* elem;
     size_t idx;
-    tmc::qu_bounded_spsc_err::value err;
+    tmc::qu_spsc_bounded_err::value err;
 
     try_pull_zc_scope(
-      qu_bounded_spsc* Queue, element* Elem, size_t Idx
+      qu_spsc_bounded* Queue, element* Elem, size_t Idx
     ) noexcept
         : queue{Queue}, elem{Elem}, idx{Idx},
-          err{tmc::qu_bounded_spsc_err::OK} {}
+          err{tmc::qu_spsc_bounded_err::OK} {}
 
-    explicit try_pull_zc_scope(tmc::qu_bounded_spsc_err::value Err) noexcept
+    explicit try_pull_zc_scope(tmc::qu_spsc_bounded_err::value Err) noexcept
         : queue{nullptr}, elem{nullptr}, idx{0}, err{Err} {}
 
   public:
@@ -305,7 +305,7 @@ public:
     /// converted to bool.
     try_pull_zc_scope() noexcept
         : queue{nullptr}, elem{nullptr}, idx{0},
-          err{tmc::qu_bounded_spsc_err::EMPTY} {}
+          err{tmc::qu_spsc_bounded_err::EMPTY} {}
 
     try_pull_zc_scope(const try_pull_zc_scope&) = delete;
     try_pull_zc_scope& operator=(const try_pull_zc_scope&) = delete;
@@ -313,7 +313,7 @@ public:
     try_pull_zc_scope(try_pull_zc_scope&& Other) noexcept
         : queue{Other.queue}, elem{Other.elem}, idx{Other.idx}, err{Other.err} {
       Other.elem = nullptr;
-      Other.err = tmc::qu_bounded_spsc_err::EMPTY;
+      Other.err = tmc::qu_spsc_bounded_err::EMPTY;
     }
 
     try_pull_zc_scope& operator=(try_pull_zc_scope&& Other) noexcept {
@@ -327,7 +327,7 @@ public:
         idx = Other.idx;
         err = Other.err;
         Other.elem = nullptr;
-        Other.err = tmc::qu_bounded_spsc_err::EMPTY;
+        Other.err = tmc::qu_spsc_bounded_err::EMPTY;
       }
       return *this;
     }
@@ -339,7 +339,7 @@ public:
     bool has_value() const noexcept { return elem != nullptr; }
 
     /// Returns the status of this pull: OK, EMPTY, or CLOSED.
-    tmc::qu_bounded_spsc_err::value status() const noexcept { return err; }
+    tmc::qu_spsc_bounded_err::value status() const noexcept { return err; }
 
     /// Returns a reference to the object in the queue storage.
     /// Only valid to call if status() is OK / operator bool() is true.
@@ -370,12 +370,12 @@ public:
   /// If the queue has been closed and is drained, `pull()` will resume
   /// with an empty `pull_zc_scope` (operator bool returns false).
   class pull_zc_scope {
-    friend qu_bounded_spsc;
-    qu_bounded_spsc* queue;
+    friend qu_spsc_bounded;
+    qu_spsc_bounded* queue;
     element* elem;
     size_t idx;
 
-    pull_zc_scope(qu_bounded_spsc* Queue, element* Elem, size_t Idx) noexcept
+    pull_zc_scope(qu_spsc_bounded* Queue, element* Elem, size_t Idx) noexcept
         : queue{Queue}, elem{Elem}, idx{Idx} {}
 
   public:
@@ -431,8 +431,8 @@ public:
     }
   };
 
-  /// Constructs a qu_bounded_spsc with the given capacity.
-  explicit qu_bounded_spsc(size_t Capacity) noexcept
+  /// Constructs a qu_spsc_bounded with the given capacity.
+  explicit qu_spsc_bounded(size_t Capacity) noexcept
       : capacity{Capacity}, values{std::make_unique<element[]>(Capacity)} {
     assert(Capacity > 0 && "Capacity must be greater than 0");
     // Ensure that the subtraction of unsigned offsets always results in a
@@ -722,9 +722,9 @@ public:
 
   template <typename... Args>
   class aw_post final : private tmc::detail::AwaitTagNoGroupCoAwait {
-    friend qu_bounded_spsc<T, Config>;
+    friend qu_spsc_bounded<T, Config>;
 
-    qu_bounded_spsc& queue;
+    qu_spsc_bounded& queue;
     // Construction args are stored as references (T& for lvalue inputs, T&&
     // for rvalue / temporary inputs) so that we never copy or move them into
     // the awaitable. T itself need not be movable; it will be emplace-
@@ -735,12 +735,12 @@ public:
     // extended across both the suspension and the resumption.
     std::tuple<Args&&...> args;
 
-    aw_post(qu_bounded_spsc& Queue, Args&&... ConstructArgs) noexcept
+    aw_post(qu_spsc_bounded& Queue, Args&&... ConstructArgs) noexcept
         : queue(Queue), args(std::forward<Args>(ConstructArgs)...) {}
 
     struct aw_post_impl final {
       producer_base base;
-      qu_bounded_spsc& queue;
+      qu_spsc_bounded& queue;
       std::tuple<Args&&...>& args;
       element* elem;
       size_t idx;
@@ -813,18 +813,18 @@ public:
 
   template <typename It>
   class aw_post_bulk final : private tmc::detail::AwaitTagNoGroupCoAwait {
-    friend qu_bounded_spsc<T, Config>;
+    friend qu_spsc_bounded<T, Config>;
 
-    qu_bounded_spsc& queue;
+    qu_spsc_bounded& queue;
     It items;
     size_t count;
 
-    aw_post_bulk(qu_bounded_spsc& Queue, It Items, size_t Count) noexcept
+    aw_post_bulk(qu_spsc_bounded& Queue, It Items, size_t Count) noexcept
         : queue(Queue), items(std::move(Items)), count(Count) {}
 
     struct aw_post_bulk_impl final {
       producer_base base;
-      qu_bounded_spsc& queue;
+      qu_spsc_bounded& queue;
       It& items;
       size_t count;
       size_t startIdx;
@@ -921,15 +921,15 @@ public:
   };
 
   class aw_pull final : private tmc::detail::AwaitTagNoGroupCoAwait {
-    friend qu_bounded_spsc<T, Config>;
+    friend qu_spsc_bounded<T, Config>;
 
-    qu_bounded_spsc& queue;
+    qu_spsc_bounded& queue;
 
-    aw_pull(qu_bounded_spsc& Queue) noexcept : queue(Queue) {}
+    aw_pull(qu_spsc_bounded& Queue) noexcept : queue(Queue) {}
 
     struct aw_pull_impl final {
       consumer_base base;
-      qu_bounded_spsc& queue;
+      qu_spsc_bounded& queue;
       size_t idx;
 
       aw_pull_impl(aw_pull& Parent) noexcept
@@ -1007,9 +1007,9 @@ public:
   /// single consumer.
   ///
   /// The returned scope's status() returns:
-  ///   - qu_bounded_spsc_err::OK     - a value was dequeued
-  ///   - qu_bounded_spsc_err::EMPTY  - no value is currently available
-  ///   - qu_bounded_spsc_err::CLOSED - the queue has been closed and drained
+  ///   - qu_spsc_bounded_err::OK     - a value was dequeued
+  ///   - qu_spsc_bounded_err::EMPTY  - no value is currently available
+  ///   - qu_spsc_bounded_err::CLOSED - the queue has been closed and drained
   ///
   /// The returned scope's has_value() / operator bool() returns true if a value
   /// was dequeued, or false if the queue was empty or closed.
@@ -1031,9 +1031,9 @@ public:
       return try_pull_zc_scope(this, elem, Idx);
     }
     if (s == CLOSED_BIT) {
-      return try_pull_zc_scope(tmc::qu_bounded_spsc_err::CLOSED);
+      return try_pull_zc_scope(tmc::qu_spsc_bounded_err::CLOSED);
     }
-    return try_pull_zc_scope(tmc::qu_bounded_spsc_err::EMPTY);
+    return try_pull_zc_scope(tmc::qu_spsc_bounded_err::EMPTY);
   }
 
   /// If the queue was not empty, destroys any contained data.
@@ -1041,7 +1041,7 @@ public:
   /// This only safely handles consumers that were already waiting; you must
   /// ensure that new producers and consumers do not race with this destructor.
   /// This does not wake blocked producers (if the queue was full).
-  ~qu_bounded_spsc() {
+  ~qu_spsc_bounded() {
     close();
     // close() published a CLOSED sentinel at write_closed_at; that slot
     // holds no data, and no producer can fill any slot at or beyond it.
@@ -1058,10 +1058,10 @@ public:
     }
   }
 
-  qu_bounded_spsc(const qu_bounded_spsc&) = delete;
-  qu_bounded_spsc& operator=(const qu_bounded_spsc&) = delete;
-  qu_bounded_spsc(qu_bounded_spsc&&) = delete;
-  qu_bounded_spsc& operator=(qu_bounded_spsc&&) = delete;
+  qu_spsc_bounded(const qu_spsc_bounded&) = delete;
+  qu_spsc_bounded& operator=(const qu_spsc_bounded&) = delete;
+  qu_spsc_bounded(qu_spsc_bounded&&) = delete;
+  qu_spsc_bounded& operator=(qu_spsc_bounded&&) = delete;
 };
 
 } // namespace tmc

--- a/include/tmc/qu_spsc_bounded.hpp
+++ b/include/tmc/qu_spsc_bounded.hpp
@@ -263,7 +263,7 @@ class qu_spsc_bounded {
   size_t capacity;
   std::unique_ptr<element[]> values;
   char pad0[TMC_CACHE_LINE_SIZE - sizeof(size_t)];
-  // Producer's hot field, written on every post
+  // Producer's hot field, written on every push
   std::atomic<size_t> write_offset;
   char pad2[TMC_CACHE_LINE_SIZE - sizeof(size_t)];
   // Read and written only by consumer
@@ -491,7 +491,7 @@ private:
       // CLOSED_BIT alone so that when the consumer wraps around to this
       // same physical slot, its next pull/try_pull observes the closed
       // sentinel directly instead of suspending forever. No producer can be
-      // waiting or race us here because close() forbids any further posts.
+      // waiting or race us here because close() forbids any further pushes.
       Elem->flags.store(
         reinterpret_cast<void*>(CLOSED_BIT), std::memory_order_release
       );
@@ -511,8 +511,8 @@ private:
   }
 
 public:
-  template <typename... Args> class aw_post;
-  template <typename It> class aw_post_bulk;
+  template <typename... Args> class aw_push;
+  template <typename It> class aw_push_bulk;
 
   /// Constructs a new value in the queue, forwarding `ConstructArgs` to T's
   /// constructor. Only safe to call from the single producer thread.
@@ -531,27 +531,27 @@ public:
   /// ```
   /// // Safe: the temporary T's lifetime is extended to the end of the
   /// full-expression.
-  /// co_await q.post(T{...});
+  /// co_await q.push(T{...});
   ///
   /// // Unsafe: `a` holds a dangling reference to the temporary T
-  /// auto a = q.post(T{...});
+  /// auto a = q.push(T{...});
   /// co_await std::move(a);
   ///
   /// // Safe: passing a reference to a named variable
   /// auto v = T{...};
-  /// auto a = q.post(std::move(v));
+  /// auto a = q.push(std::move(v));
   /// co_await std::move(a);
   /// ```
   template <typename... Args>
   [[nodiscard(
-    "You must co_await post(). The value will not be enqueued until co_await."
+    "You must co_await push(). The value will not be enqueued until co_await."
   )]]
-  aw_post<Args...> post(Args&&... ConstructArgs) noexcept {
-    // close() must only be called from the single producer thread, so post()
-    // and close() are sequenced on the same thread. Posting after close() is
+  aw_push<Args...> push(Args&&... ConstructArgs) noexcept {
+    // close() must only be called from the single producer thread, so push()
+    // and close() are sequenced on the same thread. Pushing after close() is
     // a programming error.
     assert(!closed.load(std::memory_order_relaxed));
-    return aw_post<Args...>(*this, std::forward<Args>(ConstructArgs)...);
+    return aw_push<Args...>(*this, std::forward<Args>(ConstructArgs)...);
   }
 
   /// Moves `Count` values from the iterator `Items` into the queue. Only safe
@@ -568,22 +568,22 @@ public:
   /// resumed.
   template <typename It>
   [[nodiscard(
-    "You must co_await post_bulk(). The values will not be enqueued "
+    "You must co_await push_bulk(). The values will not be enqueued "
     "until co_await."
   )]]
-  aw_post_bulk<std::remove_cvref_t<It>>
-  post_bulk(It&& Items, size_t Count) noexcept {
+  aw_push_bulk<std::remove_cvref_t<It>>
+  push_bulk(It&& Items, size_t Count) noexcept {
     static_assert(
       std::is_nothrow_move_constructible_v<T>,
-      "post_bulk moves values from the iterator into the queue; T must be "
+      "push_bulk moves values from the iterator into the queue; T must be "
       "nothrow move constructible"
     );
     // close() must only be called from the single producer thread, so
-    // post_bulk() and close() are sequenced on the same thread. Posting after
+    // push_bulk() and close() are sequenced on the same thread. Pushing after
     // close() is a programming error.
     assert(!closed.load(std::memory_order_relaxed));
     assert(Count <= capacity);
-    return aw_post_bulk<std::remove_cvref_t<It>>(
+    return aw_push_bulk<std::remove_cvref_t<It>>(
       *this, std::forward<It>(Items), Count
     );
   }
@@ -601,17 +601,17 @@ public:
   /// resumed.
   template <typename It>
   [[nodiscard(
-    "You must co_await post_bulk(). The values will not be enqueued "
+    "You must co_await push_bulk(). The values will not be enqueued "
     "until co_await."
   )]]
-  aw_post_bulk<std::remove_cvref_t<It>>
-  post_bulk(It&& Begin, It&& End) noexcept {
+  aw_push_bulk<std::remove_cvref_t<It>>
+  push_bulk(It&& Begin, It&& End) noexcept {
     static_assert(
       std::is_nothrow_move_constructible_v<T>,
-      "post_bulk moves values from the iterator into the queue; T must be "
+      "push_bulk moves values from the iterator into the queue; T must be "
       "nothrow move constructible"
     );
-    return post_bulk(std::forward<It>(Begin), static_cast<size_t>(End - Begin));
+    return push_bulk(std::forward<It>(Begin), static_cast<size_t>(End - Begin));
   }
 
   /// Calculates the number of elements via
@@ -628,18 +628,18 @@ public:
   /// resumed.
   template <typename Range>
   [[nodiscard(
-    "You must co_await post_bulk(). The values will not be enqueued "
+    "You must co_await push_bulk(). The values will not be enqueued "
     "until co_await."
   )]]
-  auto post_bulk(Range&& R) noexcept {
+  auto push_bulk(Range&& R) noexcept {
     static_assert(
       std::is_nothrow_move_constructible_v<T>,
-      "post_bulk moves values from the iterator into the queue; T must be "
+      "push_bulk moves values from the iterator into the queue; T must be "
       "nothrow move constructible"
     );
     auto begin = static_cast<Range&&>(R).begin();
     auto end = static_cast<Range&&>(R).end();
-    return post_bulk(std::move(begin), static_cast<size_t>(end - begin));
+    return push_bulk(std::move(begin), static_cast<size_t>(end - begin));
   }
 
 private:
@@ -677,7 +677,7 @@ private:
 
 public:
   /// Closes the queue. May only be called from the single producer thread.
-  /// After close() returns, the producer must not call post() or post_bulk()
+  /// After close() returns, the producer must not call push() or push_bulk()
   /// again. Calls to `pull()` and `try_pull()` will continue to read data
   /// until all messages have been consumed, at which point all subsequent
   /// calls will immediately return an empty scope. If the queue was already
@@ -720,8 +720,9 @@ public:
     return isEmpty;
   }
 
+  /// Returns void when awaited.
   template <typename... Args>
-  class aw_post final : private tmc::detail::AwaitTagNoGroupCoAwait {
+  class aw_push final : private tmc::detail::AwaitTagNoGroupCoAwait {
     friend qu_spsc_bounded<T, Config>;
 
     qu_spsc_bounded& queue;
@@ -731,21 +732,21 @@ public:
     // constructed directly into the queue slot from these forwarded args.
     //
     // The caller must co_await this awaitable in the same full-expression
-    // (see post()'s docs) so that any referenced temporary's lifetime is
+    // (see push()'s docs) so that any referenced temporary's lifetime is
     // extended across both the suspension and the resumption.
     std::tuple<Args&&...> args;
 
-    aw_post(qu_spsc_bounded& Queue, Args&&... ConstructArgs) noexcept
+    aw_push(qu_spsc_bounded& Queue, Args&&... ConstructArgs) noexcept
         : queue(Queue), args(std::forward<Args>(ConstructArgs)...) {}
 
-    struct aw_post_impl final {
+    struct aw_push_impl final {
       producer_base base;
       qu_spsc_bounded& queue;
       std::tuple<Args&&...>& args;
       element* elem;
       size_t idx;
 
-      aw_post_impl(aw_post& Parent) noexcept
+      aw_push_impl(aw_push& Parent) noexcept
           : base{tmc::detail::this_thread::executor(), nullptr,
                  tmc::detail::this_thread::this_task().prio},
             queue(Parent.queue), args(Parent.args), elem(nullptr), idx(0) {}
@@ -808,21 +809,22 @@ public:
     };
 
   public:
-    aw_post_impl operator co_await() && noexcept { return aw_post_impl(*this); }
+    aw_push_impl operator co_await() && noexcept { return aw_push_impl(*this); }
   };
 
+  /// Returns void when awaited.
   template <typename It>
-  class aw_post_bulk final : private tmc::detail::AwaitTagNoGroupCoAwait {
+  class aw_push_bulk final : private tmc::detail::AwaitTagNoGroupCoAwait {
     friend qu_spsc_bounded<T, Config>;
 
     qu_spsc_bounded& queue;
     It items;
     size_t count;
 
-    aw_post_bulk(qu_spsc_bounded& Queue, It Items, size_t Count) noexcept
+    aw_push_bulk(qu_spsc_bounded& Queue, It Items, size_t Count) noexcept
         : queue(Queue), items(std::move(Items)), count(Count) {}
 
-    struct aw_post_bulk_impl final {
+    struct aw_push_bulk_impl final {
       producer_base base;
       qu_spsc_bounded& queue;
       It& items;
@@ -830,7 +832,7 @@ public:
       size_t startIdx;
       element* lastElem;
 
-      aw_post_bulk_impl(aw_post_bulk& Parent) noexcept
+      aw_push_bulk_impl(aw_push_bulk& Parent) noexcept
           : base{tmc::detail::this_thread::executor(), nullptr,
                  tmc::detail::this_thread::this_task().prio},
             queue(Parent.queue), items(Parent.items), count(Parent.count),
@@ -915,11 +917,12 @@ public:
     };
 
   public:
-    aw_post_bulk_impl operator co_await() && noexcept {
-      return aw_post_bulk_impl(*this);
+    aw_push_bulk_impl operator co_await() && noexcept {
+      return aw_push_bulk_impl(*this);
     }
   };
 
+  /// Returns a `pull_zc_scope` when awaited.
   class aw_pull final : private tmc::detail::AwaitTagNoGroupCoAwait {
     friend qu_spsc_bounded<T, Config>;
 
@@ -978,10 +981,10 @@ public:
     aw_pull_impl operator co_await() && noexcept { return aw_pull_impl(*this); }
   };
 
-  /// Await to dequeue. Returns a `zc_scope` which provides a scoped zero-copy
-  /// reference to a value in the queue storage. When the scope is destroyed,
-  /// the referenced value will be destroyed and the queue slot freed for reuse.
-  /// Only safe to call from the single consumer.
+  /// Await to dequeue. Returns a `pull_zc_scope` which provides a scoped
+  /// zero-copy reference to a value in the queue storage. When the scope is
+  /// destroyed, the referenced value will be destroyed and the queue slot freed
+  /// for reuse. Only safe to call from the single consumer.
   ///
   /// The returned scope's has_value() / operator bool() returns true if a value
   /// was dequeued, or false if the queue was closed and drained.

--- a/include/tmc/qu_spsc_bounded.hpp
+++ b/include/tmc/qu_spsc_bounded.hpp
@@ -87,8 +87,8 @@ template <typename T> struct qu_spsc_bounded_storage {
 } // namespace detail
 
 struct qu_spsc_bounded_default_config {
-  /// If true, enables the suspending pull() operation. This costs the producer
-  /// an additional locked operation to check for a waiting consumer.
+  /// If true, enables the suspending `pull()` operation. This costs the
+  /// producer an additional locked operation to check for a waiting consumer.
   static inline constexpr bool ConsumerCanSuspend = true;
 
   /// At level 0, queue elements will be padded up to the next increment of 64
@@ -100,9 +100,7 @@ struct qu_spsc_bounded_default_config {
 };
 
 /// Status code returned by qu_spsc_bounded.try_pull().status()
-struct qu_spsc_bounded_err {
-  enum value { OK = 0u, EMPTY = 1u, CLOSED = 2u };
-};
+enum class qu_spsc_bounded_err { OK, EMPTY, CLOSED };
 
 template <typename T, typename Config = tmc::qu_spsc_bounded_default_config>
 class qu_spsc_bounded {
@@ -279,17 +277,17 @@ public:
   /// A zero-copy handle to an object in the queue's storage. The object is
   /// exclusively available to this handle. When this handle is destroyed, the
   /// queued object will be destroyed and the queue slot will be freed for
-  /// reuse. All handles must be released before the queue is destroyed.
+  /// reuse. Returned by `try_pull()`.
   ///
-  /// The status of the pull is exposed via status(): qu_spsc_bounded_err::OK
-  /// if a value is held, EMPTY if no value was available, or CLOSED if the
-  /// queue has been closed and drained.
+  /// The status of the pull is exposed via `status()`:
+  /// `qu_spsc_bounded_err::OK` if a value is held, `EMPTY` if no value was
+  /// available, or `CLOSED` if the queue has been closed and drained.
   class try_pull_zc_scope {
     friend qu_spsc_bounded;
     qu_spsc_bounded* queue;
     element* elem;
     size_t idx;
-    tmc::qu_spsc_bounded_err::value err;
+    tmc::qu_spsc_bounded_err err;
 
     try_pull_zc_scope(
       qu_spsc_bounded* Queue, element* Elem, size_t Idx
@@ -297,11 +295,11 @@ public:
         : queue{Queue}, elem{Elem}, idx{Idx},
           err{tmc::qu_spsc_bounded_err::OK} {}
 
-    explicit try_pull_zc_scope(tmc::qu_spsc_bounded_err::value Err) noexcept
+    explicit try_pull_zc_scope(tmc::qu_spsc_bounded_err Err) noexcept
         : queue{nullptr}, elem{nullptr}, idx{0}, err{Err} {}
 
   public:
-    /// Constructs an empty zc_scope (status EMPTY). Evaluates to false when
+    /// Constructs an empty scope (status EMPTY). Evaluates to false when
     /// converted to bool.
     try_pull_zc_scope() noexcept
         : queue{nullptr}, elem{nullptr}, idx{0},
@@ -332,25 +330,25 @@ public:
       return *this;
     }
 
-    /// Returns true if this scope holds a value from the queue.
+    /// Returns true if this scope holds a value from the queue (status == OK).
     explicit operator bool() const noexcept { return elem != nullptr; }
 
-    /// Returns true if this scope holds a value from the queue.
+    /// Returns true if this scope holds a value from the queue (status == OK).
     bool has_value() const noexcept { return elem != nullptr; }
 
     /// Returns the status of this pull: OK, EMPTY, or CLOSED.
-    tmc::qu_spsc_bounded_err::value status() const noexcept { return err; }
+    tmc::qu_spsc_bounded_err status() const noexcept { return err; }
 
     /// Returns a reference to the object in the queue storage.
-    /// Only valid to call if status() is OK / operator bool() is true.
+    /// Only valid to call if `status()` is OK / `operator bool()` is true.
     T& get() noexcept { return elem->data.value; }
 
     /// Returns a reference to the object in the queue storage.
-    /// Only valid to call if status() is OK / operator bool() is true.
+    /// Only valid to call if `status()` is OK / `operator bool()` is true.
     T& operator*() noexcept { return elem->data.value; }
 
     /// Returns a pointer to the object in the queue storage.
-    /// Only valid to call if status() is OK / operator bool() is true.
+    /// Only valid to call if `status()` is OK / `operator bool()` is true.
     T* operator->() noexcept { return &elem->data.value; }
 
     /// Destroys the object in the queue storage and releases the queue slot.
@@ -365,7 +363,7 @@ public:
   /// A zero-copy handle to an object in the queue's storage. The object is
   /// exclusively available to this handle. When this handle is destroyed, the
   /// queued object will be destroyed and the queue slot will be freed for
-  /// reuse. Returned by the suspending `pull()` operation.
+  /// reuse. Returned by `co_await pull()`.
   ///
   /// If the queue has been closed and is drained, `pull()` will resume
   /// with an empty `pull_zc_scope` (operator bool returns false).
@@ -379,7 +377,7 @@ public:
         : queue{Queue}, elem{Elem}, idx{Idx} {}
 
   public:
-    /// Constructs an empty zc_scope. Evaluates to false when converted to bool.
+    /// Constructs an empty scope. Evaluates to false when converted to bool.
     pull_zc_scope() noexcept : queue{nullptr}, elem{nullptr}, idx{0} {}
 
     pull_zc_scope(const pull_zc_scope&) = delete;
@@ -411,15 +409,15 @@ public:
     }
 
     /// Returns a reference to the object in the queue storage.
-    /// Only valid to call if operator bool() is true.
+    /// Only valid to call if `operator bool()` is true.
     T& get() noexcept { return elem->data.value; }
 
     /// Returns a reference to the object in the queue storage.
-    /// Only valid to call if operator bool() is true.
+    /// Only valid to call if `operator bool()` is true.
     T& operator*() noexcept { return elem->data.value; }
 
     /// Returns a pointer to the object in the queue storage.
-    /// Only valid to call if operator bool() is true.
+    /// Only valid to call if `operator bool()` is true.
     T* operator->() noexcept { return &elem->data.value; }
 
     /// Destroys the object in the queue storage and releases the queue slot.
@@ -530,7 +528,7 @@ public:
   /// of the argument can be extended to the end of the full-expression.
   /// ```
   /// // Safe: the temporary T's lifetime is extended to the end of the
-  /// full-expression.
+  /// // full-expression.
   /// co_await q.push(T{...});
   ///
   /// // Unsafe: `a` holds a dangling reference to the temporary T
@@ -677,14 +675,14 @@ private:
 
 public:
   /// Closes the queue. May only be called from the single producer thread.
-  /// After close() returns, the producer must not call push() or push_bulk()
-  /// again. Calls to `pull()` and `try_pull()` will continue to read data
-  /// until all messages have been consumed, at which point all subsequent
-  /// calls will immediately return an empty scope. If the queue was already
-  /// empty, any waiting consumers will be awoken immediately and return an
-  /// empty scope.
+  /// After `close()` returns, the producer must not call `push()` or
+  /// `push_bulk()` again. Calls to `pull()` and `try_pull()` will continue to
+  /// read data until all messages have been consumed, at which point all
+  /// subsequent calls will immediately return an empty scope. If the queue was
+  /// already empty, any waiting consumers will be awoken immediately and return
+  /// an empty scope.
   ///
-  /// close() is idempotent.
+  /// `close()` is idempotent.
   void close() noexcept {
     consumer_base* cons = close_get_waiting_consumer();
     if (cons != nullptr) {
@@ -699,9 +697,8 @@ public:
   /// This should only be used when the caller knows that the waiting consumer
   /// may safely run on the caller's thread.
   ///
-  /// Behaves like close() in all other respects (see close() for details).
-  /// close_resume_inline() is idempotent. May only be called from the single
-  /// producer thread.
+  /// Behaves like `close()` in all other respects. `close_resume_inline()` is
+  /// idempotent. May only be called from the single producer thread.
   void close_resume_inline() noexcept {
     consumer_base* cons = close_get_waiting_consumer();
     if (cons != nullptr) {
@@ -710,7 +707,7 @@ public:
   }
 
   /// Returns true if the queue appears to be empty.
-  /// This is an unsynchronized read (like try_pull()), so it is only a hint.
+  /// This is an unsynchronized read (like `try_pull()`), so it is only a hint.
   /// Only safe to call from the single consumer.
   bool empty() {
     size_t Idx = read_offset;
@@ -720,7 +717,7 @@ public:
     return isEmpty;
   }
 
-  /// Returns void when awaited.
+  /// Returns `void` when awaited.
   template <typename... Args>
   class aw_push final : private tmc::detail::AwaitTagNoGroupCoAwait {
     friend qu_spsc_bounded<T, Config>;
@@ -812,7 +809,7 @@ public:
     aw_push_impl operator co_await() && noexcept { return aw_push_impl(*this); }
   };
 
-  /// Returns void when awaited.
+  /// Returns `void` when awaited.
   template <typename It>
   class aw_push_bulk final : private tmc::detail::AwaitTagNoGroupCoAwait {
     friend qu_spsc_bounded<T, Config>;
@@ -986,13 +983,13 @@ public:
   /// destroyed, the referenced value will be destroyed and the queue slot freed
   /// for reuse. Only safe to call from the single consumer.
   ///
-  /// The returned scope's has_value() / operator bool() returns true if a value
-  /// was dequeued, or false if the queue was closed and drained.
+  /// The returned scope's `has_value()` / `operator bool()` returns true if a
+  /// value was dequeued, or false if the queue was closed and drained.
   ///
-  /// This scope must be released before the next call to try_pull() or pull().
-  /// It must also be released before the queue is destroyed.
+  /// This scope must be released before the next call to `try_pull()` or
+  /// `pull()`. It must also be released before the queue is destroyed.
   ///
-  /// May suspend until a value is available, or until close() is called.
+  /// May suspend until a value is available, or until `close()` is called.
   [[nodiscard(
     "You must co_await pull(). To poll from a non-coroutine function, use "
     "try_pull()."
@@ -1009,16 +1006,16 @@ public:
   /// destroyed and the queue slot freed for reuse. Only safe to call from the
   /// single consumer.
   ///
-  /// The returned scope's status() returns:
+  /// The returned scope's `status()` returns:
   ///   - qu_spsc_bounded_err::OK     - a value was dequeued
   ///   - qu_spsc_bounded_err::EMPTY  - no value is currently available
   ///   - qu_spsc_bounded_err::CLOSED - the queue has been closed and drained
   ///
-  /// The returned scope's has_value() / operator bool() returns true if a value
-  /// was dequeued, or false if the queue was empty or closed.
+  /// The returned scope's `has_value()` / `operator bool()` returns true if a
+  /// value was dequeued, or false if the queue was empty or closed.
   ///
-  /// This scope must be released before the next call to try_pull() or pull().
-  /// It must also be released before the queue is destroyed.
+  /// This scope must be released before the next call to `try_pull()` or
+  /// `pull()`. It must also be released before the queue is destroyed.
   try_pull_zc_scope try_pull() {
     size_t Idx;
     element* elem = get_read_ticket(Idx);
@@ -1040,7 +1037,7 @@ public:
   }
 
   /// If the queue was not empty, destroys any contained data.
-  /// If the queue was empty, wakes any waiting consumer by calling close().
+  /// If the queue was empty, wakes any waiting consumer by calling `close()`.
   /// This only safely handles consumers that were already waiting; you must
   /// ensure that new producers and consumers do not race with this destructor.
   /// This does not wake blocked producers (if the queue was full).

--- a/include/tmc/qu_spsc_unbounded.hpp
+++ b/include/tmc/qu_spsc_unbounded.hpp
@@ -88,8 +88,8 @@ template <typename T> struct qu_spsc_unbounded_storage {
 } // namespace detail
 
 struct qu_spsc_unbounded_default_config {
-  /// If true, enables the suspending pull() operation. This costs the producer
-  /// an additional locked operation to check for a waiting consumer.
+  /// If true, enables the suspending `pull()` operation. This costs the
+  /// producer an additional locked operation to check for a waiting consumer.
   static inline constexpr bool ConsumerCanSuspend = true;
 
   /// The number of elements that can be stored in each block in the
@@ -110,9 +110,7 @@ struct qu_spsc_unbounded_default_config {
 };
 
 /// Status code returned by qu_spsc_unbounded.try_pull().status()
-struct qu_spsc_unbounded_err {
-  enum value { OK = 0u, EMPTY = 1u, CLOSED = 2u };
-};
+enum class qu_spsc_unbounded_err { OK, EMPTY, CLOSED };
 
 template <typename T, typename Config = tmc::qu_spsc_unbounded_default_config>
 class qu_spsc_unbounded {
@@ -277,18 +275,18 @@ public:
   /// A zero-copy handle to an object in the queue's storage. The object is
   /// exclusively available to this handle. When this handle is destroyed, the
   /// queued object will be destroyed and the queue slot will be freed for
-  /// reuse. All handles must be released before the queue is destroyed.
+  /// reuse. Returned by `try_pull()`.
   ///
-  /// The status of the pull is exposed via status(): qu_spsc_unbounded_err::OK
-  /// if a value is held, EMPTY if no value was available, or CLOSED if the
-  /// queue has been closed and drained.
+  /// The status of the pull is exposed via `status()`:
+  /// `qu_spsc_unbounded_err::OK` if a value is held, `EMPTY` if no value was
+  /// available, or `CLOSED` if the queue has been closed and drained.
   class try_pull_zc_scope {
     friend qu_spsc_unbounded;
     qu_spsc_unbounded* queue;
     element* elem;
     data_block* block;
     size_t idx;
-    tmc::qu_spsc_unbounded_err::value err;
+    tmc::qu_spsc_unbounded_err err;
 
     try_pull_zc_scope(
       qu_spsc_unbounded* Queue, element* Elem, data_block* Block, size_t Idx
@@ -296,11 +294,11 @@ public:
         : queue{Queue}, elem{Elem}, block{Block}, idx{Idx},
           err{tmc::qu_spsc_unbounded_err::OK} {}
 
-    explicit try_pull_zc_scope(tmc::qu_spsc_unbounded_err::value Err) noexcept
+    explicit try_pull_zc_scope(tmc::qu_spsc_unbounded_err Err) noexcept
         : queue{nullptr}, elem{nullptr}, block{nullptr}, idx{0}, err{Err} {}
 
   public:
-    /// Constructs an empty zc_scope (status EMPTY). Evaluates to false when
+    /// Constructs an empty scope (status EMPTY). Evaluates to false when
     /// converted to bool.
     try_pull_zc_scope() noexcept
         : queue{nullptr}, elem{nullptr}, block{nullptr}, idx{0},
@@ -333,25 +331,25 @@ public:
       return *this;
     }
 
-    /// Returns true if this scope holds a value from the queue.
+    /// Returns true if this scope holds a value from the queue (status == OK).
     explicit operator bool() const noexcept { return elem != nullptr; }
 
-    /// Returns true if this scope holds a value from the queue.
+    /// Returns true if this scope holds a value from the queue (status == OK).
     bool has_value() const noexcept { return elem != nullptr; }
 
     /// Returns the status of this pull: OK, EMPTY, or CLOSED.
-    tmc::qu_spsc_unbounded_err::value status() const noexcept { return err; }
+    tmc::qu_spsc_unbounded_err status() const noexcept { return err; }
 
     /// Returns a reference to the object in the queue storage.
-    /// Only valid to call if status() is OK / operator bool() is true.
+    /// Only valid to call if `status()` is OK / `operator bool()` is true.
     T& get() noexcept { return elem->data.value; }
 
     /// Returns a reference to the object in the queue storage.
-    /// Only valid to call if status() is OK / operator bool() is true.
+    /// Only valid to call if `status()` is OK / `operator bool()` is true.
     T& operator*() noexcept { return elem->data.value; }
 
     /// Returns a pointer to the object in the queue storage.
-    /// Only valid to call if status() is OK / operator bool() is true.
+    /// Only valid to call if `status()` is OK / `operator bool()` is true.
     T* operator->() noexcept { return &elem->data.value; }
 
     /// Destroys the object in the queue storage and releases the queue slot.
@@ -366,7 +364,7 @@ public:
   /// A zero-copy handle to an object in the queue's storage. The object is
   /// exclusively available to this handle. When this handle is destroyed, the
   /// queued object will be destroyed and the queue slot will be freed for
-  /// reuse. Returned by the suspending `pull()` operation.
+  /// reuse. Returned by `co_await pull()`.
   ///
   /// If the queue has been closed and is drained, `pull()` will resume
   /// with an empty `pull_zc_scope` (operator bool returns false).
@@ -383,7 +381,7 @@ public:
         : queue{Queue}, elem{Elem}, block{Block}, idx{Idx} {}
 
   public:
-    /// Constructs an empty zc_scope. Evaluates to false when converted to bool.
+    /// Constructs an empty scope. Evaluates to false when converted to bool.
     pull_zc_scope() noexcept
         : queue{nullptr}, elem{nullptr}, block{nullptr}, idx{0} {}
 
@@ -418,15 +416,15 @@ public:
     }
 
     /// Returns a reference to the object in the queue storage.
-    /// Only valid to call if operator bool() is true.
+    /// Only valid to call if `operator bool()` is true.
     T& get() noexcept { return elem->data.value; }
 
     /// Returns a reference to the object in the queue storage.
-    /// Only valid to call if operator bool() is true.
+    /// Only valid to call if `operator bool()` is true.
     T& operator*() noexcept { return elem->data.value; }
 
     /// Returns a pointer to the object in the queue storage.
-    /// Only valid to call if operator bool() is true.
+    /// Only valid to call if `operator bool()` is true.
     T* operator->() noexcept { return &elem->data.value; }
 
     /// Destroys the object in the queue storage and releases the queue slot.
@@ -829,14 +827,14 @@ private:
 
 public:
   /// Closes the queue. May only be called from the single producer thread.
-  /// After close() returns, the producer must not call post() or post_bulk()
-  /// again. Calls to `pull()` and `try_pull()` will continue to read data
-  /// until all messages have been consumed, at which point all subsequent
-  /// calls will immediately return an empty scope. If the queue was already
-  /// empty, any waiting consumers will be awoken immediately and return an
-  /// empty scope.
+  /// After `close()` returns, the producer must not call `post()` or
+  /// `post_bulk()` again. Calls to `pull()` and `try_pull()` will continue to
+  /// read data until all messages have been consumed, at which point all
+  /// subsequent calls will immediately return an empty scope. If the queue was
+  /// already empty, any waiting consumers will be awoken immediately and return
+  /// an empty scope.
   ///
-  /// close() is idempotent.
+  /// `close()` is idempotent.
   void close() noexcept {
     consumer_base* cons = close_get_waiting_consumer();
     if (cons != nullptr) {
@@ -851,9 +849,8 @@ public:
   /// This should only be used when the caller knows that the waiting consumer
   /// may safely run on the caller's thread.
   ///
-  /// Behaves like close() in all other respects (see close() for details).
-  /// close_resume_inline() is idempotent. May only be called from the single
-  /// producer thread.
+  /// Behaves like close() in all other respects. `close_resume_inline()` is
+  /// idempotent. May only be called from the single producer thread.
   void close_resume_inline() noexcept {
     consumer_base* cons = close_get_waiting_consumer();
     if (cons != nullptr) {
@@ -862,7 +859,7 @@ public:
   }
 
   /// Returns true if the queue appears to be empty.
-  /// This is an unsynchronized read (like try_pull()), so it is only a hint.
+  /// This is an unsynchronized read (like `try_pull()`), so it is only a hint.
   /// Only safe to call from the single consumer.
   bool empty() {
     size_t Idx = read_offset;
@@ -928,11 +925,11 @@ public:
   /// destroyed, the referenced value will be destroyed and the queue slot freed
   /// for reuse. Only safe to call from the single consumer.
   ///
-  /// The returned scope's has_value() / operator bool() returns true if a value
-  /// was dequeued, or false if the queue was closed and drained.
+  /// The returned scope's `has_value()` / `operator bool()` returns true if a
+  /// value was dequeued, or false if the queue was closed and drained.
   ///
-  /// This scope must be released before the next call to try_pull() or pull().
-  /// It must also be released before the queue is destroyed.
+  /// This scope must be released before the next call to `try_pull()` or
+  /// `pull()`. It must also be released before the queue is destroyed.
   ///
   /// May suspend until a value is available, or until close() is called.
   [[nodiscard(
@@ -951,16 +948,16 @@ public:
   /// destroyed and the queue slot freed for reuse. Only safe to call from the
   /// single consumer.
   ///
-  /// The returned scope's status() returns:
+  /// The returned scope's `status()` returns:
   ///   - qu_spsc_unbounded_err::OK     - a value was dequeued
   ///   - qu_spsc_unbounded_err::EMPTY  - no value is currently available
   ///   - qu_spsc_unbounded_err::CLOSED - the queue has been closed and drained
   ///
-  /// The returned scope's has_value() / operator bool() returns true if a value
-  /// was dequeued, or false if the queue was empty or closed.
+  /// The returned scope's `has_value()` / `operator bool()` returns true if a
+  /// value was dequeued, or false if the queue was empty or closed.
   ///
-  /// This scope must be released before the next call to try_pull() or pull().
-  /// It must also be released before the queue is destroyed.
+  /// This scope must be released before the next call to `try_pull()` or
+  /// `pull()`. It must also be released before the queue is destroyed.
   try_pull_zc_scope try_pull() {
     size_t Idx;
     data_block* block;
@@ -977,7 +974,7 @@ public:
   }
 
   /// If the queue was not empty, destroys any contained data.
-  /// If the queue was empty, wakes any waiting consumer by calling close().
+  /// If the queue was empty, wakes any waiting consumer by calling `close()`.
   /// This only safely handles consumers that were already waiting; you must
   /// ensure that new producers and consumers do not race with this destructor.
   ~qu_spsc_unbounded() {

--- a/include/tmc/qu_spsc_unbounded.hpp
+++ b/include/tmc/qu_spsc_unbounded.hpp
@@ -873,6 +873,7 @@ public:
     return isEmpty;
   }
 
+  /// Returns a `pull_zc_scope` when awaited.
   class aw_pull final : private tmc::detail::AwaitTagNoGroupCoAwait {
     friend qu_spsc_unbounded<T, Config>;
 
@@ -922,10 +923,10 @@ public:
     aw_pull_impl operator co_await() && noexcept { return aw_pull_impl(*this); }
   };
 
-  /// Await to dequeue. Returns a `zc_scope` which provides a scoped zero-copy
-  /// reference to a value in the queue storage. When the scope is destroyed,
-  /// the referenced value will be destroyed and the queue slot freed for reuse.
-  /// Only safe to call from the single consumer.
+  /// Await to dequeue. Returns a `pull_zc_scope` which provides a scoped
+  /// zero-copy reference to a value in the queue storage. When the scope is
+  /// destroyed, the referenced value will be destroyed and the queue slot freed
+  /// for reuse. Only safe to call from the single consumer.
   ///
   /// The returned scope's has_value() / operator bool() returns true if a value
   /// was dequeued, or false if the queue was closed and drained.

--- a/include/tmc/qu_spsc_unbounded.hpp
+++ b/include/tmc/qu_spsc_unbounded.hpp
@@ -5,18 +5,12 @@
 
 #pragma once
 
-// Unbounded MPSC queue using linked list of blocks. Uses a similar fetch-add
-// slot acquisition scheme to tmc::channel, but optimized for a single consumer.
-
-// Instead of hazard pointers, uses a quiescent-state based reclamation scheme:
-// 1. Producers reserve tickets with write_offset, then load write_block_hint.
-//    If the hint is past their reservation, they fall back to write_block.
-// 2. Producers may advance write_block_hint forward after finding their block.
-// 3. The consumer enters a new block and publishes it as the new write_block.
-// 4. The consumer snapshots write_offset as the reclaim cutoff.
-// 5. Once read_offset reaches that cutoff, producers that may have observed the
-//    old write_block or write_block_hint are done, so old blocks can be
-//    recycled.
+// Unbounded SPSC queue using linked list of blocks. Uses a similar
+// slot acquisition scheme to tmc::channel, but with various changes:
+// - single producer can publish offset after writing data instead of before
+// - single consumer read offset does not need to be atomic
+// - single consumer can recycle blocks immediately after finishing them
+// - close() may only be called by the single producer thread
 
 #include "tmc/detail/compat.hpp"
 #include "tmc/detail/concepts_awaitable.hpp"
@@ -36,7 +30,7 @@ namespace detail {
 // placement new. T need not be default, copy, or move constructible.
 // The caller must track whether the element exists, and manually invoke the
 // destructor if necessary.
-template <typename T> struct qu_unbounded_mpsc_storage {
+template <typename T> struct qu_spsc_unbounded_storage {
   union alignas(alignof(T)) {
     T value;
   };
@@ -44,7 +38,7 @@ template <typename T> struct qu_unbounded_mpsc_storage {
   bool exists = false;
 #endif
 
-  qu_unbounded_mpsc_storage() noexcept {}
+  qu_spsc_unbounded_storage() noexcept {}
 
   template <typename... ConstructArgs>
   void emplace(ConstructArgs&&... Args) noexcept {
@@ -64,12 +58,12 @@ template <typename T> struct qu_unbounded_mpsc_storage {
   }
 
   // Precondition: Other.value must exist
-  qu_unbounded_mpsc_storage(qu_unbounded_mpsc_storage&& Other) noexcept {
+  qu_spsc_unbounded_storage(qu_spsc_unbounded_storage&& Other) noexcept {
     emplace(static_cast<T&&>(Other.value));
     Other.destroy();
   }
-  qu_unbounded_mpsc_storage&
-  operator=(qu_unbounded_mpsc_storage&& Other) noexcept {
+  qu_spsc_unbounded_storage&
+  operator=(qu_spsc_unbounded_storage&& Other) noexcept {
     emplace(static_cast<T&&>(Other.value));
     Other.destroy();
     return *this;
@@ -77,51 +71,51 @@ template <typename T> struct qu_unbounded_mpsc_storage {
 
   // If data was present, the caller is responsible for destroying it.
 #ifndef NDEBUG
-  ~qu_unbounded_mpsc_storage() { assert(!exists); }
+  ~qu_spsc_unbounded_storage() { assert(!exists); }
 #else
-  ~qu_unbounded_mpsc_storage()
+  ~qu_spsc_unbounded_storage()
     requires(std::is_trivially_destructible_v<T>)
   = default;
-  ~qu_unbounded_mpsc_storage()
+  ~qu_spsc_unbounded_storage()
     requires(!std::is_trivially_destructible_v<T>)
   {}
 #endif
 
-  qu_unbounded_mpsc_storage(const qu_unbounded_mpsc_storage&) = delete;
-  qu_unbounded_mpsc_storage&
-  operator=(const qu_unbounded_mpsc_storage&) = delete;
+  qu_spsc_unbounded_storage(const qu_spsc_unbounded_storage&) = delete;
+  qu_spsc_unbounded_storage&
+  operator=(const qu_spsc_unbounded_storage&) = delete;
 };
 } // namespace detail
 
-struct qu_unbounded_mpsc_default_config {
-  /// If true, enables the suspending pull() operation. This costs each producer
+struct qu_spsc_unbounded_default_config {
+  /// If true, enables the suspending pull() operation. This costs the producer
   /// an additional locked operation to check for a waiting consumer.
   static inline constexpr bool ConsumerCanSuspend = true;
 
   /// The number of elements that can be stored in each block in the
-  /// qu_unbounded_mpsc linked list.
+  /// qu_spsc_unbounded linked list.
   static inline constexpr size_t BlockSize = 4096;
 
   /// At level 0, queue elements will be padded up to the next increment of 64
   /// bytes. This reduces false sharing between neighboring elements.
   /// At level 1, no padding will be applied.
-  static inline constexpr size_t PackingLevel = 0;
+  /// The SPSC queue is packed by default to improve cache coherency for the
+  /// single producer.
+  static inline constexpr size_t PackingLevel = 1;
 
-  /// If true, the first storage block will be a member of the qu_unbounded_mpsc
+  /// If true, the first storage block will be a member of the qu_spsc_unbounded
   /// object (instead of dynamically allocated). Subsequent storage blocks are
   /// always dynamically allocated.
   static inline constexpr bool EmbedFirstBlock = false;
 };
 
-/// Status code returned by qu_unbounded_mpsc.try_pull().status()
-struct qu_unbounded_mpsc_err {
+/// Status code returned by qu_spsc_unbounded.try_pull().status()
+struct qu_spsc_unbounded_err {
   enum value { OK = 0u, EMPTY = 1u, CLOSED = 2u };
 };
 
-template <typename T, typename Config = tmc::qu_unbounded_mpsc_default_config>
-class qu_unbounded_mpsc {
-  static_assert(std::is_nothrow_destructible_v<T>);
-
+template <typename T, typename Config = tmc::qu_spsc_unbounded_default_config>
+class qu_spsc_unbounded {
   static inline constexpr size_t BlockSize = Config::BlockSize;
   static inline constexpr size_t BlockSizeMask = BlockSize - 1;
   static inline constexpr bool ConsumerCanSuspend = Config::ConsumerCanSuspend;
@@ -152,11 +146,11 @@ class qu_unbounded_mpsc {
 
   struct element_t {
     std::atomic<void*> flags;
-    tmc::detail::qu_unbounded_mpsc_storage<T> data;
+    tmc::detail::qu_spsc_unbounded_storage<T> data;
 
     static constexpr size_t UNPADLEN =
       sizeof(std::atomic<void*>) +
-      sizeof(tmc::detail::qu_unbounded_mpsc_storage<T>);
+      sizeof(tmc::detail::qu_spsc_unbounded_storage<T>);
     static constexpr size_t WANTLEN = (UNPADLEN + TMC_CACHE_LINE_SIZE - 1) &
                                       static_cast<size_t>(
                                         0 - TMC_CACHE_LINE_SIZE
@@ -259,23 +253,16 @@ class qu_unbounded_mpsc {
 
   char pad0[TMC_CACHE_LINE_SIZE];
   std::atomic<size_t> write_offset;
-  // closed is read by producers on every post() (acquire load). It sits with
-  // write_offset because producers RMW write_offset and immediately check
-  // closed; both are on the same cacheline so the load is essentially free.
-  std::atomic<bool> closed;
-  std::atomic<data_block*> write_block_hint;
   std::atomic<data_block*> write_block;
-  // Cold close-related fields: only read by producers on the close slow path,
-  // and only written once by close() itself.
+  // Cold close-related fields: only written once by close() itself. No
+  // `closed_ready` handshake is required (unlike qu_mpsc) because the closer
+  // IS the single producer, so no other producer can race with publication of
+  // write_closed_at.
+  std::atomic<bool> closed;
   std::atomic<size_t> write_closed_at;
-  std::atomic<bool> closed_ready;
   char pad1[TMC_CACHE_LINE_SIZE - sizeof(size_t)];
   size_t read_offset;
-  data_block* read_block;
-  data_block* pending_reclaim_old_head;
-  data_block* pending_reclaim_new_head;
-  size_t pending_reclaim_cutoff;
-  data_block* head_block;
+  data_block* head_block; // aka read_block
   data_block* tail_block;
   char pad2[TMC_CACHE_LINE_SIZE - sizeof(void*)];
 
@@ -292,24 +279,24 @@ public:
   /// queued object will be destroyed and the queue slot will be freed for
   /// reuse. All handles must be released before the queue is destroyed.
   ///
-  /// The status of the pull is exposed via status(): qu_unbounded_mpsc_err::OK
+  /// The status of the pull is exposed via status(): qu_spsc_unbounded_err::OK
   /// if a value is held, EMPTY if no value was available, or CLOSED if the
   /// queue has been closed and drained.
   class try_pull_zc_scope {
-    friend qu_unbounded_mpsc;
-    qu_unbounded_mpsc* queue;
+    friend qu_spsc_unbounded;
+    qu_spsc_unbounded* queue;
     element* elem;
     data_block* block;
     size_t idx;
-    tmc::qu_unbounded_mpsc_err::value err;
+    tmc::qu_spsc_unbounded_err::value err;
 
     try_pull_zc_scope(
-      qu_unbounded_mpsc* Queue, element* Elem, data_block* Block, size_t Idx
+      qu_spsc_unbounded* Queue, element* Elem, data_block* Block, size_t Idx
     ) noexcept
         : queue{Queue}, elem{Elem}, block{Block}, idx{Idx},
-          err{tmc::qu_unbounded_mpsc_err::OK} {}
+          err{tmc::qu_spsc_unbounded_err::OK} {}
 
-    explicit try_pull_zc_scope(tmc::qu_unbounded_mpsc_err::value Err) noexcept
+    explicit try_pull_zc_scope(tmc::qu_spsc_unbounded_err::value Err) noexcept
         : queue{nullptr}, elem{nullptr}, block{nullptr}, idx{0}, err{Err} {}
 
   public:
@@ -317,7 +304,7 @@ public:
     /// converted to bool.
     try_pull_zc_scope() noexcept
         : queue{nullptr}, elem{nullptr}, block{nullptr}, idx{0},
-          err{tmc::qu_unbounded_mpsc_err::EMPTY} {}
+          err{tmc::qu_spsc_unbounded_err::EMPTY} {}
 
     try_pull_zc_scope(const try_pull_zc_scope&) = delete;
     try_pull_zc_scope& operator=(const try_pull_zc_scope&) = delete;
@@ -326,7 +313,7 @@ public:
         : queue{Other.queue}, elem{Other.elem}, block{Other.block},
           idx{Other.idx}, err{Other.err} {
       Other.elem = nullptr;
-      Other.err = tmc::qu_unbounded_mpsc_err::EMPTY;
+      Other.err = tmc::qu_spsc_unbounded_err::EMPTY;
     }
 
     try_pull_zc_scope& operator=(try_pull_zc_scope&& Other) noexcept {
@@ -341,7 +328,7 @@ public:
         idx = Other.idx;
         err = Other.err;
         Other.elem = nullptr;
-        Other.err = tmc::qu_unbounded_mpsc_err::EMPTY;
+        Other.err = tmc::qu_spsc_unbounded_err::EMPTY;
       }
       return *this;
     }
@@ -353,7 +340,7 @@ public:
     bool has_value() const noexcept { return elem != nullptr; }
 
     /// Returns the status of this pull: OK, EMPTY, or CLOSED.
-    tmc::qu_unbounded_mpsc_err::value status() const noexcept { return err; }
+    tmc::qu_spsc_unbounded_err::value status() const noexcept { return err; }
 
     /// Returns a reference to the object in the queue storage.
     /// Only valid to call if status() is OK / operator bool() is true.
@@ -384,14 +371,14 @@ public:
   /// If the queue has been closed and is drained, `pull()` will resume
   /// with an empty `pull_zc_scope` (operator bool returns false).
   class pull_zc_scope {
-    friend qu_unbounded_mpsc;
-    qu_unbounded_mpsc* queue;
+    friend qu_spsc_unbounded;
+    qu_spsc_unbounded* queue;
     element* elem;
     data_block* block;
     size_t idx;
 
     pull_zc_scope(
-      qu_unbounded_mpsc* Queue, element* Elem, data_block* Block, size_t Idx
+      qu_spsc_unbounded* Queue, element* Elem, data_block* Block, size_t Idx
     ) noexcept
         : queue{Queue}, elem{Elem}, block{Block}, idx{Idx} {}
 
@@ -451,7 +438,7 @@ public:
     }
   };
 
-  qu_unbounded_mpsc() noexcept {
+  qu_spsc_unbounded() noexcept {
     data_block* block;
     if constexpr (Config::EmbedFirstBlock) {
       block = &embedded_block;
@@ -460,17 +447,11 @@ public:
     }
     head_block = block;
     write_block.store(block, std::memory_order_relaxed);
-    write_block_hint.store(block, std::memory_order_relaxed);
     tail_block = block;
     write_offset.store(0, std::memory_order_relaxed);
     closed.store(false, std::memory_order_relaxed);
-    closed_ready.store(false, std::memory_order_relaxed);
     write_closed_at.store(0, std::memory_order_relaxed);
     read_offset = 0;
-    read_block = block;
-    pending_reclaim_old_head = nullptr;
-    pending_reclaim_new_head = nullptr;
-    pending_reclaim_cutoff = 0;
     tmc::detail::memory_barrier();
   }
 
@@ -572,77 +553,43 @@ private:
     return Block;
   }
 
-  static inline bool block_before(data_block* A, data_block* B) noexcept {
-    return circular_less_than(
-      A->offset.load(std::memory_order_relaxed),
-      B->offset.load(std::memory_order_relaxed)
-    );
-  }
-
-  void advance_write_block_hint_at_least(
-    data_block* Current, data_block* Target
-  ) noexcept {
-    while (block_before(Current, Target)) {
-      if (write_block_hint.compare_exchange_weak(
-            Current, Target, std::memory_order_seq_cst,
-            std::memory_order_seq_cst
-          )) {
-        return;
-      }
+  // Given idx, advance from write_block until the block containing idx
+  // is found. Update write_block if necessary.
+  inline data_block* find_write_block(size_t Idx) noexcept {
+    data_block* block = write_block.load(std::memory_order_relaxed);
+    size_t offset = block->offset.load(std::memory_order_relaxed);
+    assert(circular_less_than(offset, 1 + Idx));
+    size_t targetOffset = Idx & ~BlockSizeMask;
+    if (offset != targetOffset) {
+      // Find or allocate the associated block
+      do {
+        data_block* next = block->next.load(std::memory_order_acquire);
+        if (next == nullptr) {
+          data_block* newBlock = new data_block(offset + BlockSize);
+          if (block->next.compare_exchange_strong(
+                next, newBlock, std::memory_order_acq_rel,
+                std::memory_order_acquire
+              )) {
+            next = newBlock;
+          } else {
+            delete newBlock;
+          }
+        }
+        block = next;
+        offset += BlockSize;
+        assert(block->offset.load(std::memory_order_relaxed) == offset);
+      } while (offset != targetOffset);
+      write_block.store(block, std::memory_order_relaxed);
     }
-  }
 
-  void advance_write_block_hint_at_least(data_block* Target) noexcept {
-    advance_write_block_hint_at_least(
-      write_block_hint.load(std::memory_order_seq_cst), Target
+    assert(
+      Idx >= block->offset.load(std::memory_order_relaxed) &&
+      Idx <= block->offset.load(std::memory_order_relaxed) + BlockSize - 1
     );
-  }
-
-  data_block* get_mpsc_write_start_block(size_t Idx) noexcept {
-    data_block* block = write_block_hint.load(std::memory_order_seq_cst);
-    if (!circular_less_than(
-          block->offset.load(std::memory_order_relaxed), 1 + Idx
-        )) {
-      // A later producer may have advanced the hint past this producer's
-      // earlier reservation. Fall back to the consumer-managed reclaim
-      // frontier, which cannot advance past an unproduced reservation.
-      block = write_block.load(std::memory_order_seq_cst);
-      assert(circular_less_than(
-        block->offset.load(std::memory_order_relaxed), 1 + Idx
-      ));
-    }
     return block;
   }
 
-  bool try_finish_pending_reclaim() noexcept {
-    if (pending_reclaim_old_head == nullptr) {
-      return false;
-    }
-
-    // The pending blocks were removed from the producer-visible write head
-    // before pending_reclaim_cutoff was read from write_offset. Any producer
-    // that can still be walking from the old write head must therefore have a
-    // reservation before this cutoff. Once the single consumer reaches the
-    // cutoff, those producers have published their elements and no longer touch
-    // the old blocks.
-    if (circular_less_than(read_offset, pending_reclaim_cutoff)) {
-      return false;
-    }
-
-    data_block* oldHead = pending_reclaim_old_head;
-    data_block* newHead = pending_reclaim_new_head;
-    head_block = newHead;
-    pending_reclaim_old_head = nullptr;
-    pending_reclaim_new_head = nullptr;
-    reclaim_blocks(oldHead, newHead);
-    return true;
-  }
-
-  void try_start_reclaim(data_block* NewHead) noexcept {
-    if (pending_reclaim_old_head != nullptr) {
-      return;
-    }
-
+  void try_reclaim_blocks(data_block* NewHead) noexcept {
     data_block* oldHead = head_block;
     size_t newHeadOffset = read_offset & ~BlockSizeMask;
     assert(NewHead->offset.load(std::memory_order_relaxed) == newHeadOffset);
@@ -651,65 +598,24 @@ private:
       return;
     }
 
-    // This seq_cst write_block store, seq_cst write_block_hint advancement, and
-    // the following seq_cst write_offset load form the cutoff protocol with
-    // producers, which do a seq_cst fetch_add before a seq_cst load of either
-    // write_block_hint or write_block. A producer that observes the old
-    // write_block or write_block_hint must have a reservation included in the
-    // cutoff.
-    write_block.store(NewHead, std::memory_order_seq_cst);
-    advance_write_block_hint_at_least(NewHead);
-    pending_reclaim_cutoff = write_offset.load(std::memory_order_seq_cst);
-    pending_reclaim_old_head = oldHead;
-    pending_reclaim_new_head = NewHead;
+    head_block = NewHead;
+    reclaim_blocks(oldHead, NewHead);
   }
 
-  void try_reclaim_blocks(data_block* NewHead) noexcept {
-    try_finish_pending_reclaim();
-    try_start_reclaim(NewHead);
-    try_finish_pending_reclaim();
-  }
-
-  // Idx will be initialized by this function.
-  // Returns nullptr if the queue is closed and Idx is past the close cutoff;
-  // the caller must not write to the slot in that case.
+  // Idx will be initialized by this function
   element* get_write_ticket(size_t& Idx) noexcept {
-    // seq_cst is needed here so the reader can order its write_block update
-    // and subsequent write_offset load against the producer's reservation and
-    // write_block load. It also forms the producer side of the close protocol:
-    // close()'s release store to `closed` is sequenced-before its own seq_cst
-    // fetch_add on write_offset; if our fetch_add is mod-order after close's,
-    // the RMW chain makes the release store of `closed` happens-before our
-    // subsequent acquire load below.
-    Idx = write_offset.fetch_add(1, std::memory_order_seq_cst);
-
-    if (closed.load(std::memory_order_acquire)) [[unlikely]] {
-      // Wait for write_closed_at to be published by close().
-      while (!closed_ready.load(std::memory_order_acquire)) {
-        TMC_CPU_PAUSE();
-      }
-      if (circular_less_than(
-            write_closed_at.load(std::memory_order_acquire), 1 + Idx
-          )) {
-        return nullptr;
-      }
-    }
-
-    data_block* observed = get_mpsc_write_start_block(Idx);
-
-    assert(circular_less_than(
-      observed->offset.load(std::memory_order_relaxed), 1 + Idx
-    ));
-
-    data_block* block = find_block(observed, Idx);
-    advance_write_block_hint_at_least(observed, block);
+    // In SPSC mode, write_offset is the committed write offset. The producer
+    // takes the next index from it, advances its block cursor before making a
+    // block-start element visible, and publishes write_offset after writing.
+    Idx = write_offset.load(std::memory_order_relaxed);
+    data_block* block = find_write_block(Idx);
     element* elem = &block->values[Idx & BlockSizeMask];
     return elem;
   }
 
   element* get_read_ticket(size_t& Idx, data_block*& Block) noexcept {
     Idx = read_offset;
-    Block = read_block;
+    Block = head_block;
 
     assert(
       circular_less_than(Block->offset.load(std::memory_order_relaxed), 1 + Idx)
@@ -727,7 +633,6 @@ private:
     // mode the producer already advanced before making this block-start element
     // visible, so old blocks can be reclaimed immediately.
     if ((Idx & BlockSizeMask) == 0) {
-      read_block = Block;
       try_reclaim_blocks(Block);
     }
   }
@@ -744,122 +649,89 @@ private:
     }
   }
 
-  void notify_consumer(consumer_base* Cons) noexcept {
-    if (Cons != nullptr) {
-      tmc::detail::post_checked(
-        Cons->continuation_executor, std::move(Cons->continuation), Cons->prio
-      );
-    }
-  }
-
   // StartIdx and EndIdx will be initialized by this function.
   // Count must be non-zero (enforced by the caller).
-  // Returns nullptr if the queue is closed and the reservation is entirely
-  // past the close cutoff; the caller must not write any of the slots in
-  // that case. Because close() takes a single fetch_add cutoff, a bulk
-  // reservation cannot straddle the cutoff: it is either all pre-close or
-  // all post-close in the seq_cst total order on write_offset.
   data_block* get_write_ticket_bulk(
     size_t Count, size_t& StartIdx, size_t& EndIdx
   ) noexcept {
-    // seq_cst here serves the same purpose as in get_write_ticket: it orders
-    // the reader's reclaim cutoff AND forms the producer side of the close
-    // protocol (RMW-chain from close()'s release store to `closed`).
-    StartIdx = write_offset.fetch_add(Count, std::memory_order_seq_cst);
+    // In SPSC mode, write_offset is published after all elements in the bulk
+    // operation have been written.
+    StartIdx = write_offset.load(std::memory_order_relaxed);
     EndIdx = StartIdx + Count;
-
-    if (closed.load(std::memory_order_acquire)) [[unlikely]] {
-      while (!closed_ready.load(std::memory_order_acquire)) {
-        TMC_CPU_PAUSE();
-      }
-      if (circular_less_than(
-            write_closed_at.load(std::memory_order_acquire), 1 + StartIdx
-          )) {
-        return nullptr;
-      }
-    }
-
-    data_block* observed = get_mpsc_write_start_block(StartIdx);
+    data_block* block = write_block.load(std::memory_order_relaxed);
 
     assert(circular_less_than(
-      observed->offset.load(std::memory_order_relaxed), 1 + StartIdx
+      block->offset.load(std::memory_order_relaxed), 1 + StartIdx
     ));
 
     // Ensure all blocks for the operation are allocated and available.
-    data_block* startBlock = find_block(observed, StartIdx);
-    data_block* endBlock = find_block(startBlock, EndIdx - 1);
-    advance_write_block_hint_at_least(observed, endBlock);
+    data_block* startBlock = find_block(block, StartIdx);
+    find_block(startBlock, EndIdx - 1);
+    write_block.store(startBlock, std::memory_order_relaxed);
     return startBlock;
   }
 
 public:
-  /// If the queue is open, this will always return true, indicating that an
-  /// object of type T was enqueued by in-place construction in the queue using
-  /// the provided constructor arguments.
+  /// Constructs a new value in the queue, forwarding `ConstructArgs` to T's
+  /// constructor. Only safe to call from the single producer thread.
   ///
-  /// If the queue is closed, this will return false, and the object will not
-  /// be constructed.
-  ///
-  /// Will not suspend or block.
-  template <typename... Args> bool post(Args&&... ConstructArgs) noexcept {
-    // Implementing handling for throwing construction is not possible with the
-    // current design. This assert will also fire if no matching constructor can
-    // be found for the provided arguments.
-    static_assert(std::is_nothrow_constructible_v<T, Args&&...>);
+  /// If a consumer is currently suspended waiting for a value, it will be
+  /// resumed.
+  template <typename... Args> void post(Args&&... ConstructArgs) noexcept {
+    // close() must only be called from the single producer thread, so post()
+    // and close() are sequenced on the same thread. Posting after close() is
+    // a programming error.
+    assert(!closed.load(std::memory_order_relaxed));
 
     // Get write ticket and associated block.
     size_t idx;
     element* elem = get_write_ticket(idx);
-    if (elem == nullptr) [[unlikely]] {
-      return false;
-    }
 
     consumer_base* cons =
       write_element(elem, std::forward<Args>(ConstructArgs)...);
-    notify_consumer(cons);
-    return true;
+    write_offset.store(idx + 1, std::memory_order_release);
+    if (cons != nullptr) {
+      tmc::detail::post_checked(
+        cons->continuation_executor, std::move(cons->continuation), cons->prio
+      );
+    }
   }
 
-  /// If the channel is open, this will always return true, indicating that
-  /// Count elements, starting from the Begin iterator, were enqueued.
+  /// Moves `Count` values from the iterator `Items` into the queue. Only safe
+  /// to call from the single producer thread.
   ///
-  /// If the channel is closed, this will return false, and no items
-  /// will be enqueued.
-  ///
-  /// Each item is moved (not copied) from the iterator into the channel.
-  ///
-  /// The closed check is performed first, then space is pre-allocated, then all
-  /// Count items are moved into the channel. Thus, there cannot be a partial
-  /// success - either all or none of the items will be moved.
-  ///
-  /// Will not suspend or block.
-  template <typename It> bool post_bulk(It&& Items, size_t Count) noexcept {
-    // Implementing handling for throwing construction is not possible with the
-    // current design. This assert will also fire if no matching constructor can
-    // be found for the iterator's dereferenced value.
+  /// If a consumer is currently suspended waiting for a value, it will be
+  /// resumed.
+  template <typename It> void post_bulk(It&& Items, size_t Count) noexcept {
     static_assert(
-      std::is_nothrow_constructible_v<T, decltype(std::move(*Items))>
+      std::is_nothrow_move_constructible_v<T>,
+      "post_bulk moves values from the iterator into the queue; T must be "
+      "nothrow move constructible"
     );
-
+    // close() must only be called from the single producer thread, so
+    // post_bulk() and close() are sequenced on the same thread. Posting after
+    // close() is a programming error.
+    assert(!closed.load(std::memory_order_relaxed));
     if (Count == 0) [[unlikely]] {
-      return true;
+      return;
     }
 
     // Get write ticket and associated block.
     size_t startIdx, endIdx;
     data_block* block = get_write_ticket_bulk(Count, startIdx, endIdx);
-    if (block == nullptr) [[unlikely]] {
-      return false;
-    }
 
     size_t idx = startIdx;
+    consumer_base* cons = nullptr;
     while (idx < endIdx) {
       element* elem = &block->values[idx & BlockSizeMask];
 
       TMC_DISABLE_WARNING_PESSIMIZING_MOVE_BEGIN
       consumer_base* waiting = write_element(elem, std::move(*Items));
       TMC_DISABLE_WARNING_PESSIMIZING_MOVE_END
-      notify_consumer(waiting);
+      if (waiting != nullptr) {
+        assert(cons == nullptr);
+        cons = waiting;
+      }
 
       ++Items;
       ++idx;
@@ -867,100 +739,85 @@ public:
         block = block->next.load(std::memory_order_acquire);
         // all blocks should have been preallocated for [startIdx, endIdx)
         assert(block != nullptr || idx >= endIdx);
+        if (idx < endIdx) {
+          write_block.store(block, std::memory_order_relaxed);
+        }
       }
     }
-    return true;
+    write_offset.store(endIdx, std::memory_order_release);
+    if (cons != nullptr) {
+      tmc::detail::post_checked(
+        cons->continuation_executor, std::move(cons->continuation), cons->prio
+      );
+    }
   }
 
   /// Calculates the number of elements via `size_t Count = End - Begin;`
+  /// and moves them from the iterator `Begin` into the queue. Only safe to
+  /// call from the single producer thread.
   ///
-  /// If the channel is open, this will always return true, indicating that
-  /// Count elements, starting from the Begin iterator, were enqueued.
-  ///
-  /// If the channel is closed, this will return false, and no items
-  /// will be enqueued.
-  ///
-  /// Each item is moved (not copied) from the iterator into the channel.
-  ///
-  /// The closed check is performed first, then space is pre-allocated, then all
-  /// Count items are moved into the channel. Thus, there cannot be a partial
-  /// success - either all or none of the items will be moved.
-  ///
-  /// Will not suspend or block.
-  template <typename It> bool post_bulk(It&& Begin, It&& End) noexcept {
-    // Implementing handling for throwing construction is not possible with the
-    // current design. This assert will also fire if no matching constructor can
-    // be found for the iterator's dereferenced value.
+  /// If a consumer is currently suspended waiting for a value, it will be
+  /// resumed.
+  template <typename It> void post_bulk(It&& Begin, It&& End) noexcept {
     static_assert(
-      std::is_nothrow_constructible_v<T, decltype(std::move(*Begin))>
+      std::is_nothrow_move_constructible_v<T>,
+      "post_bulk moves values from the iterator into the queue; T must be "
+      "nothrow move constructible"
     );
-    return post_bulk(
-      static_cast<It&&>(Begin), static_cast<size_t>(End - Begin)
-    );
+    post_bulk(static_cast<It&&>(Begin), static_cast<size_t>(End - Begin));
   }
 
   /// Calculates the number of elements via
-  /// `size_t Count = Range.end() - Range.begin();`
+  /// `size_t Count = Range.end() - Range.begin();` and moves them from the
+  /// beginning of the range into the queue. Only safe to call from the single
+  /// producer thread.
   ///
-  /// If the channel is open, this will always return true, indicating that
-  /// Count elements from the beginning of the range were enqueued.
-  ///
-  /// If the channel is closed, this will return false, and no items
-  /// will be enqueued.
-  ///
-  /// Each item is moved (not copied) from the iterator into the channel.
-  ///
-  /// The closed check is performed first, then space is pre-allocated, then all
-  /// Count items are moved into the channel. Thus, there cannot be a partial
-  /// success - either all or none of the items will be moved.
-  ///
-  /// Will not suspend or block.
-  template <typename Range> bool post_bulk(Range&& R) noexcept {
-    // Implementing handling for throwing construction is not possible with the
-    // current design. This assert will also fire if no matching constructor can
-    // be found for the iterator's dereferenced value.
-    static_assert(std::is_nothrow_constructible_v<
-                  T, decltype(std::move(*static_cast<Range&&>(R).begin()))>);
+  /// If a consumer is currently suspended waiting for a value, it will be
+  /// resumed.
+  template <typename Range> void post_bulk(Range&& R) noexcept {
+    static_assert(
+      std::is_nothrow_move_constructible_v<T>,
+      "post_bulk moves values from the iterator into the queue; T must be "
+      "nothrow move constructible"
+    );
     auto begin = static_cast<Range&&>(R).begin();
     auto end = static_cast<Range&&>(R).end();
-    return post_bulk(begin, static_cast<size_t>(end - begin));
+    post_bulk(begin, static_cast<size_t>(end - begin));
   }
 
 private:
   // Performs the common close work and returns the waiting consumer (if any)
-  // that needs to be woken. Returns nullptr if the queue was already closed
-  // by another thread, or if no consumer was waiting at the cutoff slot.
+  // that needs to be woken. Returns nullptr if the queue was already closed,
+  // or if no consumer was waiting at the cutoff slot.
   consumer_base* close_get_waiting_consumer() noexcept {
     bool expected = false;
     if (!closed.compare_exchange_strong(
           expected, true, std::memory_order_release, std::memory_order_acquire
         )) {
-      // Already closed by another thread.
+      // Already closed.
       return nullptr;
     }
 
-    // We are the unique closer. The release store of `closed` above is
-    // sequenced-before the following seq_cst fetch_add; any producer whose
-    // own seq_cst fetch_add on write_offset is mod-order after ours will
-    // synchronize-with us via the RMW chain and see `closed == true` on
-    // its subsequent acquire load.
-    size_t woff = write_offset.fetch_add(1, std::memory_order_seq_cst);
+    // Because close() is only called from the single producer thread, there is
+    // no concurrent producer that could reserve a slot past the close cutoff.
+    // The next slot the producer would have used is write_offset (writes are
+    // published by storing write_offset *after* the data); this is the only
+    // slot the consumer could still be waiting on.
+    //
+    // No `closed_ready` handshake is required (unlike qu_mpsc), because no
+    // other producer is racing with the closer to learn the cutoff.
+    size_t woff = write_offset.load(std::memory_order_relaxed);
     write_closed_at.store(woff, std::memory_order_release);
-    closed_ready.store(true, std::memory_order_release);
 
-    // Publish the CLOSED sentinel at slot woff. The single consumer is
-    // bounded to slot <= woff (slot > woff is unreachable since no producer
-    // ever fills slot woff), so this is the only slot the consumer can be
-    // stuck on. The exchange races with the consumer's try_wait(): exactly
-    // one of the two RMWs on this element's flags goes first.
+    // Publish the CLOSED sentinel at slot woff. This races with the consumer's
+    // try_wait() on that element; exactly one of the two RMWs goes first.
     //   - If the consumer's exchange goes first, it installed its
     //     consumer_base pointer; our exchange returns that pointer and we
     //     post the resumption.
-    //   - If our exchange goes first, the slot now contains CLOSED_BIT;
-    //     when the consumer later runs try_wait() it observes CLOSED_BIT
-    //     and returns CLOSED without suspending.
-    data_block* observed = get_mpsc_write_start_block(woff);
-    data_block* block = find_block(observed, woff);
+    //   - If our exchange goes first, the slot now contains CLOSED_BIT; when
+    //     the consumer later runs try_wait() it observes CLOSED_BIT and
+    //     returns CLOSED without suspending.
+    data_block* block = find_write_block(woff);
     element* elem = &block->values[woff & BlockSizeMask];
     consumer_base* cons = elem->set_closed_or_get_waiting_consumer();
     if (cons != nullptr) {
@@ -971,13 +828,15 @@ private:
   }
 
 public:
-  /// All future calls to `post()` and `post_bulk()` will immediately return
-  /// false. Calls to `pull()` and `try_pull()` will continue to read data until
-  /// all messages have been consumed, at which point all subsequent calls will
-  /// immediately return an empty scope. If the queue was already empty, any
-  /// waiting consumers will be awoken immediately and return an empty scope.
+  /// Closes the queue. May only be called from the single producer thread.
+  /// After close() returns, the producer must not call post() or post_bulk()
+  /// again. Calls to `pull()` and `try_pull()` will continue to read data
+  /// until all messages have been consumed, at which point all subsequent
+  /// calls will immediately return an empty scope. If the queue was already
+  /// empty, any waiting consumers will be awoken immediately and return an
+  /// empty scope.
   ///
-  /// close() is idempotent and safe to call from any thread.
+  /// close() is idempotent.
   void close() noexcept {
     consumer_base* cons = close_get_waiting_consumer();
     if (cons != nullptr) {
@@ -993,7 +852,8 @@ public:
   /// may safely run on the caller's thread.
   ///
   /// Behaves like close() in all other respects (see close() for details).
-  /// close_resume_inline() is idempotent and safe to call from any thread.
+  /// close_resume_inline() is idempotent. May only be called from the single
+  /// producer thread.
   void close_resume_inline() noexcept {
     consumer_base* cons = close_get_waiting_consumer();
     if (cons != nullptr) {
@@ -1006,7 +866,7 @@ public:
   /// Only safe to call from the single consumer.
   bool empty() {
     size_t Idx = read_offset;
-    data_block* block = find_block(read_block, Idx);
+    data_block* block = find_block(head_block, Idx);
     element* elem = &block->values[Idx & BlockSizeMask];
 
     bool isEmpty = !elem->is_data_waiting();
@@ -1014,15 +874,15 @@ public:
   }
 
   class aw_pull final : private tmc::detail::AwaitTagNoGroupCoAwait {
-    friend qu_unbounded_mpsc<T, Config>;
+    friend qu_spsc_unbounded<T, Config>;
 
-    qu_unbounded_mpsc& queue;
+    qu_spsc_unbounded& queue;
 
-    aw_pull(qu_unbounded_mpsc& Queue) noexcept : queue(Queue) {}
+    aw_pull(qu_spsc_unbounded& Queue) noexcept : queue(Queue) {}
 
     struct aw_pull_impl final {
       consumer_base base;
-      qu_unbounded_mpsc& queue;
+      qu_spsc_unbounded& queue;
       data_block* block;
       size_t idx;
 
@@ -1091,9 +951,9 @@ public:
   /// single consumer.
   ///
   /// The returned scope's status() returns:
-  ///   - qu_unbounded_mpsc_err::OK     - a value was dequeued
-  ///   - qu_unbounded_mpsc_err::EMPTY  - no value is currently available
-  ///   - qu_unbounded_mpsc_err::CLOSED - the queue has been closed and drained
+  ///   - qu_spsc_unbounded_err::OK     - a value was dequeued
+  ///   - qu_spsc_unbounded_err::EMPTY  - no value is currently available
+  ///   - qu_spsc_unbounded_err::CLOSED - the queue has been closed and drained
   ///
   /// The returned scope's has_value() / operator bool() returns true if a value
   /// was dequeued, or false if the queue was empty or closed.
@@ -1110,16 +970,16 @@ public:
       return try_pull_zc_scope(this, elem, block, Idx);
     }
     if (s == CLOSED_BIT) {
-      return try_pull_zc_scope(tmc::qu_unbounded_mpsc_err::CLOSED);
+      return try_pull_zc_scope(tmc::qu_spsc_unbounded_err::CLOSED);
     }
-    return try_pull_zc_scope(tmc::qu_unbounded_mpsc_err::EMPTY);
+    return try_pull_zc_scope(tmc::qu_spsc_unbounded_err::EMPTY);
   }
 
   /// If the queue was not empty, destroys any contained data.
   /// If the queue was empty, wakes any waiting consumer by calling close().
   /// This only safely handles consumers that were already waiting; you must
   /// ensure that new producers and consumers do not race with this destructor.
-  ~qu_unbounded_mpsc() {
+  ~qu_spsc_unbounded() {
     close();
     {
       // close() published a CLOSED sentinel at write_closed_at; that slot
@@ -1154,10 +1014,10 @@ public:
     }
   }
 
-  qu_unbounded_mpsc(const qu_unbounded_mpsc&) = delete;
-  qu_unbounded_mpsc& operator=(const qu_unbounded_mpsc&) = delete;
-  qu_unbounded_mpsc(qu_unbounded_mpsc&&) = delete;
-  qu_unbounded_mpsc& operator=(qu_unbounded_mpsc&&) = delete;
+  qu_spsc_unbounded(const qu_spsc_unbounded&) = delete;
+  qu_spsc_unbounded& operator=(const qu_spsc_unbounded&) = delete;
+  qu_spsc_unbounded(qu_spsc_unbounded&&) = delete;
+  qu_spsc_unbounded& operator=(qu_spsc_unbounded&&) = delete;
 };
 
 } // namespace tmc

--- a/include/tmc/qu_spsc_unbounded.hpp
+++ b/include/tmc/qu_spsc_unbounded.hpp
@@ -342,7 +342,7 @@ public:
 
     /// Returns a reference to the object in the queue storage.
     /// Only valid to call if `status()` is OK / `operator bool()` is true.
-    T& get() noexcept { return elem->data.value; }
+    T& value() noexcept { return elem->data.value; }
 
     /// Returns a reference to the object in the queue storage.
     /// Only valid to call if `status()` is OK / `operator bool()` is true.
@@ -417,7 +417,7 @@ public:
 
     /// Returns a reference to the object in the queue storage.
     /// Only valid to call if `operator bool()` is true.
-    T& get() noexcept { return elem->data.value; }
+    T& value() noexcept { return elem->data.value; }
 
     /// Returns a reference to the object in the queue storage.
     /// Only valid to call if `operator bool()` is true.


### PR DESCRIPTION
I'm working on the documentation for these queues and have decided that it'll be easier to grok if they have a consistent prefix length. So it's better to make this change sooner rather than later.

Rename all 3 of the recently added queues:
- qu_unbounded_mpsc -> qu_mpsc_unbounded
- qu_unbounded_spsc -> qu_spsc_unbounded
- qu_bounded_spsc -> qu_spsc_bounded

Also renamed:
- qu_spsc_bounded::post() and post_bulk() to push() and push_bulk() for consistency with channel naming (where push() suspends and post() does not).
- pull_zc_scope::get() and try_pull_zc_scope::get() to value() to match std::optional's API

Lots of other doc comments cleanups.