### PR TITLE
async control structures single-wake in FIFO order

### DIFF
--- a/include/tmc/atomic_condvar.hpp
+++ b/include/tmc/atomic_condvar.hpp
@@ -194,6 +194,7 @@ public:
   /// Wakes 1 awaiter that meet the criteria (expected != current value).
   /// The awaiter may be resumed by symmetric transfer if it is eligible
   /// (it resumes on the same executor and priority as the caller).
+  /// Awaiters are woken in LIFO order.
   inline aw_atomic_condvar_co_notify<T>
   co_notify_one(size_t NotifyCount = 1) noexcept {
     return aw_atomic_condvar_co_notify<T>(*this, NotifyCount);
@@ -203,6 +204,7 @@ public:
   /// current value).
   /// Up to one awaiter may be resumed by symmetric transfer if it is eligible
   /// (it resumes on the same executor and priority as the caller).
+  /// Awaiters are woken in LIFO order.
   inline aw_atomic_condvar_co_notify<T>
   co_notify_n(size_t NotifyCount = 1) noexcept {
     return aw_atomic_condvar_co_notify<T>(*this, NotifyCount);
@@ -217,6 +219,7 @@ public:
 
   /// Wakes 1 awaiter that meet the criteria (expected != current value).
   /// Does not symmetric transfer; the awaiter will be posted to its executor.
+  /// Awaiters are woken in LIFO order.
   inline void notify_one() {
     aw_atomic_condvar<T>* toWake = get_one_waiter();
     if (toWake != nullptr) {
@@ -227,6 +230,7 @@ public:
   /// Wakes up to NotifyCount awaiters that meet the criteria (expected !=
   /// current value).
   /// Does not symmetric transfer; awaiters will be posted to their executors.
+  /// Awaiters are woken in LIFO order.
   inline void notify_n(size_t NotifyCount = 1) {
     if (NotifyCount == 0) {
       return;

--- a/include/tmc/detail/waiter_list.hpp
+++ b/include/tmc/detail/waiter_list.hpp
@@ -47,33 +47,50 @@ struct waiter_list_node {
   suspend(waiter_data_base* Parent, std::coroutine_handle<> Outer) noexcept;
 };
 
+/// Two-stack waiter queue with FIFO wake order.
+///
+/// `input` is a lock-free Treiber stack that producers push to via
+/// `add_waiter` (LIFO). `output` is a private, single-consumer list of
+/// waiters in FIFO order, only ever touched by the thread that currently
+/// holds the `maybe_wake` critical section (or callers that the user has
+/// otherwise serialized, such as the barrier's terminal arriver and
+/// destructors). When `output` is empty and a consumer needs a waiter, the
+/// input stack is atomically swapped out and reversed into `output`, which
+/// converts the per-stack LIFO order into overall FIFO wake order.
 class waiter_list {
-  std::atomic<waiter_list_node*> head;
+  std::atomic<waiter_list_node*> input;
+  waiter_list_node* output;
 
 public:
-  inline waiter_list() noexcept : head{nullptr} {}
+  inline waiter_list() noexcept : input{nullptr}, output{nullptr} {}
 
-  /// Adds w to list. Head becomes w.
+  /// Adds w to the input stack. Lock-free.
   /// Thread-safe.
   TMC_DECL void add_waiter(waiter_list_node& w) noexcept;
 
-  /// Wakes all waiters. Head becomes nullptr.
-  /// Thread-safe.
+  /// Wakes all waiters. Not guaranteed to wake in FIFO order (which doesn't
+  /// matter since waking all waiters doesn't guarantee they get *processed* in
+  /// FIFO order either after going through their executor queues). Both lists
+  /// become empty. Thread-safe with concurrent `add_waiter`, but not with
+  /// concurrent consumers (`maybe_wake`, `must_take_1`, `take_all`).
   TMC_DECL void wake_all() noexcept;
 
-  /// Returns the number of waiters currently in the list.
-  /// For testing purposes. Safe to use concurrently with new waiters. Not safe
-  /// to use concurrently with new wakers which may cause waiters to be resumed
-  /// and then destroyed.
+  /// Returns the number of waiters currently in the list (both `output` and
+  /// `input`). For testing purposes. Safe to use concurrently with new
+  /// waiters. Not safe to use concurrently with new wakers which may cause
+  /// waiters to be resumed and then destroyed.
   [[nodiscard]] TMC_DECL size_t size() const noexcept;
 
-  /// Returns head. Head becomes nullptr.
-  /// Thread-safe.
+  /// Returns a singly-linked chain of all waiters. Not guaranteed to take in
+  /// FIFO order. Both lists become empty. Thread-safe with concurrent
+  /// `add_waiter`, but not with concurrent consumers (`maybe_wake`,
+  /// `must_take_1`, `take_all`).
   [[nodiscard]] TMC_DECL waiter_list_node* take_all() noexcept;
 
   /// Assumes at least 1 waiter is in the list.
-  /// Takes 1 waiter.
-  /// Not thread-safe.
+  /// Takes the FIFO-oldest waiter.
+  /// Not thread-safe: only call while holding the `maybe_wake` critical
+  /// section (or another single-consumer guarantee).
   [[nodiscard]] TMC_DECL waiter_list_node* must_take_1() noexcept;
 
   /// Used by mutex and semaphore.

--- a/include/tmc/detail/waiter_list.ipp
+++ b/include/tmc/detail/waiter_list.ipp
@@ -53,7 +53,9 @@ std::coroutine_handle<> waiter_list_waiter::try_symmetric_transfer(
   if (tmc::detail::this_thread::exec_prio_is(
         continuation_executor, continuation_priority
       )) {
-    // Post Outer, symmetric transfer to this
+    // Post Outer, symmetric transfer to this.
+    // We can post Outer to the continuation executor since it is the current
+    // executor, per the above check.
     tmc::detail::post_checked(
       continuation_executor, std::move(Outer), continuation_priority
     );
@@ -65,17 +67,33 @@ std::coroutine_handle<> waiter_list_waiter::try_symmetric_transfer(
   }
 }
 
+namespace {
+// Reverses a singly-linked chain of waiter_list_nodes in place.
+// The caller must have exclusive access to the chain.
+inline tmc::detail::waiter_list_node*
+reverse_chain(tmc::detail::waiter_list_node* curr) noexcept {
+  tmc::detail::waiter_list_node* prev = nullptr;
+  while (curr != nullptr) {
+    auto next = curr->next;
+    curr->next = prev;
+    prev = curr;
+    curr = next;
+  }
+  return prev;
+}
+} // namespace
+
 void waiter_list::add_waiter(tmc::detail::waiter_list_node& w) noexcept {
-  auto h = head.load(std::memory_order_acquire);
+  auto h = input.load(std::memory_order_acquire);
   do {
     w.next = h;
-  } while (!head.compare_exchange_strong(
+  } while (!input.compare_exchange_strong(
     h, &w, std::memory_order_acq_rel, std::memory_order_acquire
   ));
 }
 
 void waiter_list::wake_all() noexcept {
-  auto curr = head.exchange(nullptr, std::memory_order_acq_rel);
+  auto curr = take_all();
   while (curr != nullptr) {
     auto next = curr->next;
     curr->waiter.resume();
@@ -84,15 +102,34 @@ void waiter_list::wake_all() noexcept {
 }
 
 waiter_list_node* waiter_list::take_all() noexcept {
-  return head.exchange(nullptr, std::memory_order_acq_rel);
+  // Drain the input stack. take_all is only used when every waiter will be
+  // woken, so the order doesn't matter; no need to reverse.
+  auto in = input.exchange(nullptr, std::memory_order_acq_rel);
+
+  // If output is empty, the input chain is the entire list.
+  if (output == nullptr) {
+    return in;
+  }
+
+  // Otherwise, splice the input chain onto the end of output.
+  auto result = output;
+  auto tail = output;
+  while (tail->next != nullptr) {
+    tail = tail->next;
+  }
+  tail->next = in;
+  output = nullptr;
+  return result;
 }
 
 size_t waiter_list::size() const noexcept {
   size_t count = 0;
-  auto curr = head.load(std::memory_order_acquire);
-  while (curr != nullptr) {
+  for (auto curr = output; curr != nullptr; curr = curr->next) {
     ++count;
-    curr = curr->next;
+  }
+  for (auto curr = input.load(std::memory_order_acquire); curr != nullptr;
+       curr = curr->next) {
+    ++count;
   }
   return count;
 }
@@ -190,13 +227,16 @@ waiter_list_waiter* waiter_list::maybe_wake(
 }
 
 waiter_list_node* waiter_list::must_take_1() noexcept {
-  auto toWake = head.load(std::memory_order_acquire);
-  do {
+  if (output == nullptr) {
+    // Output is exhausted; atomically drain the input stack and reverse it
+    // into output so that the oldest pusher is at the front.
+    auto chain = input.exchange(nullptr, std::memory_order_acq_rel);
     // should be guaranteed to see at least 1 waiter
-    assert(toWake != nullptr);
-  } while (!head.compare_exchange_strong(
-    toWake, toWake->next, std::memory_order_acq_rel, std::memory_order_acquire
-  ));
+    assert(chain != nullptr);
+    output = reverse_chain(chain);
+  }
+  auto toWake = output;
+  output = output->next;
   return toWake;
 }
 


### PR DESCRIPTION
Previously, control structure APIs that wake a single waiting task would wake them in LIFO order. They now reverse the waiter list internally before waking so that waiters are woken in FIFO order. This reversal is an O(n) operation, but amortized across the wakes to be O(1) per wake.

This affects the following APIs:
- auto_reset_event::set() / co_set()
- mutex::unlock() / co_unlock()
- semaphore::release() / co_release()

atomic_condvar::notify_one() / notify_n() / co_notify_one() / co_notify_n() were not updated and still use LIFO waking. This class uses a mutex + vector for its internal storage, and due to the fact that waiters are not all equivalent (they may be expecting different values) it is likely that vector compaction would be required, which is a more expensive operation than the linked-list reversal. So I've opted to instead document that this still use LIFO waking.

APIs that wake all waiting consumers (manual_reset_event, barrier, etc.) were not changed, since the order of execution of their waiting consumers is indeterminate and subject to the specifics of the executor they run on.
