### PR TITLE
Channel bugfixes

### DIFF
--- a/include/tmc/channel.hpp
+++ b/include/tmc/channel.hpp
@@ -86,6 +86,35 @@ template <typename T, typename Config = tmc::chan_default_config> class channel;
 template <typename T> class chan_zc_scope;
 
 namespace detail {
+// Memory order used for the hazard pointer protection stores (to
+// active_offset) in get_write_ticket() / get_write_ticket_bulk() /
+// get_read_ticket(). Each of these stores is immediately followed by a
+// seq_cst RMW on the offset counter, and must be visible to the reclaimer's
+// seq_cst revalidation load in keep_min() if the owner subsequently observes
+// the pre-CAS value of its block pointer.
+//
+// The C++ memory model requires seq_cst on these stores: a seq_cst RMW on a
+// different object does not order a preceding relaxed store against the
+// reclaimer's loads. However, on x86 and ARM the compiled code is correct
+// with a relaxed store: on x86, a lock-prefixed RMW is a full fence; on
+// AArch64, the RMW's store-release orders the prior str, and the subsequent
+// seq_cst (ldar) loads of the block pointer and of active_offset cannot be
+// reordered before an earlier store-release (RCsc). A seq_cst store would
+// lower to xchg / stlr, adding a second full barrier to every channel
+// operation, so these audited platforms use relaxed. Unaudited platforms get
+// the formally correct seq_cst.
+//
+// Note: the seq_cst store in try_pull() is NOT covered by this and must
+// remain unconditionally seq_cst - it is followed by a plain seq_cst load
+// (not an RMW), which provides no StoreLoad ordering even on x86.
+#if defined(TMC_CPU_X86) || defined(TMC_CPU_ARM)
+inline constexpr std::memory_order hazptr_protect_order =
+  std::memory_order_relaxed;
+#else
+inline constexpr std::memory_order hazptr_protect_order =
+  std::memory_order_seq_cst;
+#endif
+
 // Hazard pointer type used internally by channel to track in-use blocks.
 class alignas(TMC_CACHE_LINE_SIZE) hazard_ptr {
   std::atomic<bool> owned;
@@ -502,6 +531,12 @@ private:
   TMC_DISABLE_WARNING_PADDED_END
   std::atomic<size_t> reclaim_counter;
   std::atomic<data_block*> head_block;
+  // Mirrors the offset of the most recently committed head_block, so that
+  // get_hazard_ptr() never needs to dereference head_block (which may be a
+  // stale pointer to a freed block when racing with try_reclaim_blocks()).
+  // Only updated by committed (non-abandoned) reclaim operations; it may lag
+  // head_block, which is safe - a low value only lowers the protection floor.
+  std::atomic<size_t> head_offset;
   std::atomic<data_block*> tail_block;
 
   struct empty {};
@@ -520,6 +555,7 @@ private:
       block = new data_block(0);
     }
     head_block.store(block, std::memory_order_relaxed);
+    head_offset.store(0, std::memory_order_relaxed);
     tail_block.store(block, std::memory_order_relaxed);
     read_offset.store(0, std::memory_order_relaxed);
     write_offset.store(0, std::memory_order_relaxed);
@@ -674,9 +710,15 @@ private:
   }
 
   // Load src and move it into dst if src < dst.
+  // seq_cst is needed so that this load is ordered (in the seq_cst total
+  // order) after the seq_cst CAS in try_advance_hazptr_block(). Paired with
+  // the protection stores to active_offset in get_*_ticket() / try_pull()
+  // (see hazptr_protect_order), this guarantees that if a token observed the
+  // pre-CAS block pointer, the revalidation here will observe that token's
+  // active_offset protection.
   static inline void
   keep_min(size_t& Dst, std::atomic<size_t> const& Src) noexcept {
-    size_t val = Src.load(std::memory_order_acquire);
+    size_t val = Src.load(std::memory_order_seq_cst);
     if (circular_less_than(val, Dst)) {
       Dst = val;
     }
@@ -905,6 +947,15 @@ private:
       head_block.store(oldHead, std::memory_order_release);
       return;
     }
+    // Publish the committed head's offset. This must be stored after the
+    // head_block store and only on the committed path: a reader that
+    // acquires this offset is then guaranteed to observe a head_block at
+    // least as new as newHead, so the offset it reads can never exceed the
+    // offset of the block pointer it reads (see get_hazard_ptr()). An
+    // abandoned reclaim leaves head_offset stale-low, which is safe.
+    head_offset.store(
+      newHead->offset.load(std::memory_order_relaxed), std::memory_order_release
+    );
     reclaim_blocks(oldHead, newHead);
   }
 
@@ -942,7 +993,7 @@ private:
   // Idx will be initialized by this function
   element* get_write_ticket(hazard_ptr* Haz, size_t& Idx) noexcept {
     size_t actOff = Haz->next_protect_write.load(std::memory_order_relaxed);
-    Haz->active_offset.store(actOff, std::memory_order_relaxed);
+    Haz->active_offset.store(actOff, tmc::detail::hazptr_protect_order);
 
     // seq_cst is needed here to create a StoreLoad barrier between setting
     // hazptr and loading the block
@@ -972,6 +1023,11 @@ private:
       if (circular_less_than(
             write_closed_at.load(std::memory_order_relaxed), 1 + Idx
           )) {
+        // Nothing will be written; release the hazard pointer so that this
+        // token doesn't block reclamation while it is idle.
+        Haz->active_offset.store(
+          Idx + InactiveHazptrOffset, std::memory_order_release
+        );
         return nullptr;
       }
     }
@@ -988,7 +1044,7 @@ private:
     hazard_ptr* Haz, size_t Count, size_t& StartIdx, size_t& EndIdx
   ) noexcept {
     size_t actOff = Haz->next_protect_write.load(std::memory_order_relaxed);
-    Haz->active_offset.store(actOff, std::memory_order_relaxed);
+    Haz->active_offset.store(actOff, tmc::detail::hazptr_protect_order);
 
     // seq_cst is needed here to create a StoreLoad barrier between setting
     // hazptr and loading the block
@@ -1019,6 +1075,11 @@ private:
       if (circular_less_than(
             write_closed_at.load(std::memory_order_relaxed), 1 + StartIdx
           )) {
+        // Nothing will be written; release the hazard pointer so that this
+        // token doesn't block reclamation while it is idle.
+        Haz->active_offset.store(
+          EndIdx + InactiveHazptrOffset, std::memory_order_release
+        );
         return nullptr;
       }
     }
@@ -1046,7 +1107,7 @@ private:
   // Idx will be initialized by this function
   element* get_read_ticket(hazard_ptr* Haz, size_t& Idx) noexcept {
     size_t actOff = Haz->next_protect_read.load(std::memory_order_relaxed);
-    Haz->active_offset.store(actOff, std::memory_order_relaxed);
+    Haz->active_offset.store(actOff, tmc::detail::hazptr_protect_order);
 
     // seq_cst is needed here to create a StoreLoad barrier between setting
     // hazptr and loading the block
@@ -1120,19 +1181,24 @@ private:
     }
   }
 
-  void
-  init_haz_ptr(hazard_ptr* haz, data_block* head, size_t MinCycles) noexcept {
+  // HeadOff is passed in (from head_offset) rather than read from
+  // head->offset: head must not be dereferenced here, as it may be a stale
+  // pointer to a freed block if this races with try_reclaim_blocks(). The
+  // counter handshake in get_hazard_ptr() detects such a race and retries,
+  // but only after this function has already run.
+  void init_haz_ptr(
+    hazard_ptr* haz, data_block* head, size_t HeadOff, size_t MinCycles
+  ) noexcept {
     haz->thread_index.store(
       static_cast<int>(tmc::current_thread_index()), std::memory_order_relaxed
     );
     haz->requested_thread_index.store(-1, std::memory_order_relaxed);
     haz->read_count.store(0, std::memory_order_relaxed);
     haz->write_count.store(0, std::memory_order_relaxed);
-    size_t headOff = head->offset.load(std::memory_order_relaxed);
-    haz->next_protect_write.store(headOff, std::memory_order_relaxed);
-    haz->next_protect_read.store(headOff, std::memory_order_relaxed);
+    haz->next_protect_write.store(HeadOff, std::memory_order_relaxed);
+    haz->next_protect_read.store(HeadOff, std::memory_order_relaxed);
     haz->active_offset.store(
-      headOff + InactiveHazptrOffset, std::memory_order_relaxed
+      HeadOff + InactiveHazptrOffset, std::memory_order_relaxed
     );
     haz->read_block.store(head, std::memory_order_relaxed);
     haz->write_block.store(head, std::memory_order_relaxed);
@@ -1157,7 +1223,14 @@ public:
     size_t reclaimCheck;
     do {
       reclaimCheck = reclaimCount;
-      init_haz_ptr(ptr, head_block.load(std::memory_order_acquire), cycles);
+      // head_offset must be loaded before head_block. It is stored (release)
+      // only after the head_block store of a committed reclaim, so acquiring
+      // it first guarantees the subsequent head_block load observes a block
+      // at least as new - the offset read here can never exceed the offset
+      // of the block read below.
+      size_t headOff = head_offset.load(std::memory_order_acquire);
+      data_block* head = head_block.load(std::memory_order_acquire);
+      init_haz_ptr(ptr, head, headOff, cycles);
       // Signal to try_reclaim_blocks() that we read the value of head_block.
       haz_ptr_counter.fetch_add(1, std::memory_order_seq_cst);
       // Check if try_reclaim_blocks() was running (again)
@@ -1438,6 +1511,11 @@ public:
             );
           }
         }
+        // Release the hazard pointer so that this token doesn't block
+        // reclamation while it is idle.
+        Haz->active_offset.store(
+          Idx + InactiveHazptrOffset, std::memory_order_release
+        );
         return std::variant<T, std::monostate, std::monostate>(
           std::in_place_index<chan_err::EMPTY>
         );
@@ -1488,6 +1566,11 @@ public:
         auto oldIdx = Idx;
         Idx = read_offset.load(std::memory_order_seq_cst);
         if (Idx == oldIdx) {
+          // Release the hazard pointer so that this token doesn't block
+          // reclamation while it is idle.
+          Haz->active_offset.store(
+            Idx + InactiveHazptrOffset, std::memory_order_release
+          );
           return std::variant<T, std::monostate, std::monostate>(
             std::in_place_index<chan_err::EMPTY>
           );

--- a/include/tmc/channel.hpp
+++ b/include/tmc/channel.hpp
@@ -990,6 +990,39 @@ private:
     return Block;
   }
 
+  // Returns true if the channel is closed AND index Idx is at/after the close
+  // point (write_closed_at), so it will never be serviced.
+  //
+  // Regarding memory order:
+  // - Read-side slot claims (get_read_ticket) MUST pass seq_cst. Lost-wakeup
+  //   avoidance there is a Dekker-style store-load pair: close() stores
+  //   `closed` then loads read_offset, while the consumer RMWs read_offset then
+  //   loads `closed` here. close() only *loads* read_offset (it does not RMW
+  //   it), so there is no release sequence to ride; the no-mutual-miss
+  //   guarantee from all 4 of these ops, including this load, being seq_cst.
+  // - Write-side claims may pass acquire: close() does an RMW fetch_add on
+  //   write_offset, so a writer's seq_cst fetch_add synchronizes-with it via
+  //   the release sequence, forcing visibility of `closed` independently of
+  //   this load's order. acquire is still needed so the relaxed write_closed_at
+  //   load below sees the value close() stored before its release of `closed`.
+  // - Non-blocking try_pull may pass acquire: it never blocks, so eventual
+  //   visibility is sufficient.
+  template <std::memory_order Order>
+  bool is_closed_past(size_t Idx) const noexcept {
+    auto closedState = closed.load(Order);
+    if (0 == closedState) [[likely]] {
+      return false;
+    }
+    // Wait for the write_closed_at index to become available.
+    while (0 == (closedState & WRITE_CLOSED_BIT)) {
+      TMC_CPU_PAUSE();
+      closedState = closed.load(std::memory_order_acquire);
+    }
+    return circular_less_than(
+      write_closed_at.load(std::memory_order_relaxed), 1 + Idx
+    );
+  }
+
   // Idx will be initialized by this function
   element* get_write_ticket(hazard_ptr* Haz, size_t& Idx) noexcept {
     size_t actOff = Haz->next_protect_write.load(std::memory_order_relaxed);
@@ -1013,23 +1046,13 @@ private:
     //
     // We may also see it earlier than that, in which case we should not return
     // early (our Idx is less than write_closed_at).
-    auto closedState = closed.load(std::memory_order_acquire);
-    if (0 != closedState) [[unlikely]] {
-      // Wait for the write_closed_at index to become available.
-      while (0 == (closedState & WRITE_CLOSED_BIT)) {
-        TMC_CPU_PAUSE();
-        closedState = closed.load(std::memory_order_acquire);
-      }
-      if (circular_less_than(
-            write_closed_at.load(std::memory_order_relaxed), 1 + Idx
-          )) {
-        // Nothing will be written; release the hazard pointer so that this
-        // token doesn't block reclamation while it is idle.
-        Haz->active_offset.store(
-          Idx + InactiveHazptrOffset, std::memory_order_release
-        );
-        return nullptr;
-      }
+    if (is_closed_past<std::memory_order_acquire>(Idx)) [[unlikely]] {
+      // Nothing will be written; release the hazard pointer so that this
+      // token doesn't block reclamation while it is idle.
+      Haz->active_offset.store(
+        Idx + InactiveHazptrOffset, std::memory_order_release
+      );
+      return nullptr;
     }
     block = find_block(block, Idx);
     // Update last known block.
@@ -1065,23 +1088,13 @@ private:
     //
     // We may also see it earlier than that, in which case we should not return
     // early (our Idx is less than write_closed_at).
-    auto closedState = closed.load(std::memory_order_acquire);
-    if (0 != closedState) [[unlikely]] {
-      // Wait for the write_closed_at index to become available.
-      while (0 == (closedState & WRITE_CLOSED_BIT)) {
-        TMC_CPU_PAUSE();
-        closedState = closed.load(std::memory_order_acquire);
-      }
-      if (circular_less_than(
-            write_closed_at.load(std::memory_order_relaxed), 1 + StartIdx
-          )) {
-        // Nothing will be written; release the hazard pointer so that this
-        // token doesn't block reclamation while it is idle.
-        Haz->active_offset.store(
-          EndIdx + InactiveHazptrOffset, std::memory_order_release
-        );
-        return nullptr;
-      }
+    if (is_closed_past<std::memory_order_acquire>(StartIdx)) [[unlikely]] {
+      // Nothing will be written; release the hazard pointer so that this
+      // token doesn't block reclamation while it is idle.
+      Haz->active_offset.store(
+        EndIdx + InactiveHazptrOffset, std::memory_order_release
+      );
+      return nullptr;
     }
 
     // Ensure all blocks for the operation are allocated and available.
@@ -1120,32 +1133,22 @@ private:
     assert(circular_less_than(actOff, 1 + Idx));
     assert(circular_less_than(boff, 1 + Idx));
 
-    // close() will set `closed` before incrementing read_offset.
-    // Thus if we observe our read_offset increment after close() snapshots
-    // read_offset, the seq_cst load below is guaranteed to observe closed.
-    auto closedState = closed.load(std::memory_order_seq_cst);
-    if (0 != closedState) [[unlikely]] {
-      // Wait for the write_closed_at index to become available.
-      while (0 == (closedState & WRITE_CLOSED_BIT)) {
-        TMC_CPU_PAUSE();
-        closedState = closed.load(std::memory_order_acquire);
-      }
+    // Lost-wakeup avoidance is a Dekker-style store-load on two locations:
+    // - close():  store `closed` (seq_cst), then load read_offset (seq_cst)
+    // - consumer: RMW read_offset (seq_cst), then load `closed` (seq_cst)
+    if (is_closed_past<std::memory_order_seq_cst>(Idx)) [[unlikely]] {
       // If closed, continue draining until the channel is empty.
-      if (circular_less_than(
-            write_closed_at.load(std::memory_order_relaxed), 1 + Idx
-          )) {
-        // After channel is empty, we still need to mark each element as
-        // finished. This is a side effect of using fetch_add - we are still
-        // consuming indexes even if they aren't used.
-        block = find_block(block, Idx);
-        element* elem = &block->values[Idx & BlockSizeMask];
-        elem->set_not_waiting();
-        // Also release the hazard pointer now (nothing else to read)
-        Haz->active_offset.store(
-          Idx + InactiveHazptrOffset, std::memory_order_release
-        );
-        return nullptr;
-      }
+      // After channel is empty, we still need to mark each element as
+      // finished. This is a side effect of using fetch_add - we are still
+      // consuming indexes even if they aren't used.
+      block = find_block(block, Idx);
+      element* elem = &block->values[Idx & BlockSizeMask];
+      elem->set_not_waiting();
+      // Also release the hazard pointer now (nothing else to read)
+      Haz->active_offset.store(
+        Idx + InactiveHazptrOffset, std::memory_order_release
+      );
+      return nullptr;
     }
     block = find_block(block, Idx);
     // Update last known block.
@@ -1492,24 +1495,14 @@ public:
       auto woff = write_offset.load(std::memory_order_relaxed);
       // If woff <= roff, the queue appears empty.
       if (circular_less_than(woff, Idx + 1)) {
-        auto closedState = closed.load(std::memory_order_acquire);
-        if (0 != closedState) [[unlikely]] {
-          // Wait for the write_closed_at index to become available.
-          while (0 == (closedState & WRITE_CLOSED_BIT)) {
-            TMC_CPU_PAUSE();
-            closedState = closed.load(std::memory_order_acquire);
-          }
-          // If closed, continue draining until the channel is empty.
-          if (circular_less_than(
-                write_closed_at.load(std::memory_order_relaxed), 1 + Idx
-              )) {
-            Haz->active_offset.store(
-              Idx + InactiveHazptrOffset, std::memory_order_release
-            );
-            return std::variant<T, std::monostate, std::monostate>(
-              std::in_place_index<chan_err::CLOSED>
-            );
-          }
+        // If closed, continue draining until the channel is empty.
+        if (is_closed_past<std::memory_order_acquire>(Idx)) [[unlikely]] {
+          Haz->active_offset.store(
+            Idx + InactiveHazptrOffset, std::memory_order_release
+          );
+          return std::variant<T, std::monostate, std::monostate>(
+            std::in_place_index<chan_err::CLOSED>
+          );
         }
         // Release the hazard pointer so that this token doesn't block
         // reclamation while it is idle.
@@ -1576,27 +1569,17 @@ public:
         // write_offset; those slots will never contain data. Check for that
         // here, or a polling consumer would see EMPTY forever on a closed and
         // fully-drained channel.
-        auto closedState = closed.load(std::memory_order_acquire);
-        if (0 != closedState) [[unlikely]] {
-          // Wait for the write_closed_at index to become available.
-          while (0 == (closedState & WRITE_CLOSED_BIT)) {
-            TMC_CPU_PAUSE();
-            closedState = closed.load(std::memory_order_acquire);
-          }
-          // If Idx < write_closed_at, a producer claimed this slot before
-          // close() and its data is still in flight; report EMPTY below so
-          // the consumer retries. Otherwise no data can ever arrive at or
-          // after Idx, and everything before Idx has been consumed.
-          if (circular_less_than(
-                write_closed_at.load(std::memory_order_relaxed), 1 + Idx
-              )) {
-            Haz->active_offset.store(
-              Idx + InactiveHazptrOffset, std::memory_order_release
-            );
-            return std::variant<T, std::monostate, std::monostate>(
-              std::in_place_index<chan_err::CLOSED>
-            );
-          }
+        // If Idx < write_closed_at, a producer claimed this slot before
+        // close() and its data is still in flight; report EMPTY below so
+        // the consumer retries. Otherwise no data can ever arrive at or
+        // after Idx, and everything before Idx has been consumed.
+        if (is_closed_past<std::memory_order_acquire>(Idx)) [[unlikely]] {
+          Haz->active_offset.store(
+            Idx + InactiveHazptrOffset, std::memory_order_release
+          );
+          return std::variant<T, std::monostate, std::monostate>(
+            std::in_place_index<chan_err::CLOSED>
+          );
         }
         // Release the hazard pointer so that this token doesn't block
         // reclamation while it is idle.

--- a/include/tmc/channel.hpp
+++ b/include/tmc/channel.hpp
@@ -1565,16 +1565,47 @@ public:
       } else {
         auto oldIdx = Idx;
         Idx = read_offset.load(std::memory_order_seq_cst);
-        if (Idx == oldIdx) {
-          // Release the hazard pointer so that this token doesn't block
-          // reclamation while it is idle.
-          Haz->active_offset.store(
-            Idx + InactiveHazptrOffset, std::memory_order_release
-          );
-          return std::variant<T, std::monostate, std::monostate>(
-            std::in_place_index<chan_err::EMPTY>
-          );
+        if (Idx != oldIdx) {
+          // Another consumer claimed the slot at oldIdx before we could, so
+          // retry with the new Idx.
+          continue;
         }
+        // No data is ready at Idx and no other consumer has claimed it.
+        // The queue may appear non-empty based on indexes alone because close()
+        // and failed post() calls after close continue to increment
+        // write_offset; those slots will never contain data. Check for that
+        // here, or a polling consumer would see EMPTY forever on a closed and
+        // fully-drained channel.
+        auto closedState = closed.load(std::memory_order_acquire);
+        if (0 != closedState) [[unlikely]] {
+          // Wait for the write_closed_at index to become available.
+          while (0 == (closedState & WRITE_CLOSED_BIT)) {
+            TMC_CPU_PAUSE();
+            closedState = closed.load(std::memory_order_acquire);
+          }
+          // If Idx < write_closed_at, a producer claimed this slot before
+          // close() and its data is still in flight; report EMPTY below so
+          // the consumer retries. Otherwise no data can ever arrive at or
+          // after Idx, and everything before Idx has been consumed.
+          if (circular_less_than(
+                write_closed_at.load(std::memory_order_relaxed), 1 + Idx
+              )) {
+            Haz->active_offset.store(
+              Idx + InactiveHazptrOffset, std::memory_order_release
+            );
+            return std::variant<T, std::monostate, std::monostate>(
+              std::in_place_index<chan_err::CLOSED>
+            );
+          }
+        }
+        // Release the hazard pointer so that this token doesn't block
+        // reclamation while it is idle.
+        Haz->active_offset.store(
+          Idx + InactiveHazptrOffset, std::memory_order_release
+        );
+        return std::variant<T, std::monostate, std::monostate>(
+          std::in_place_index<chan_err::EMPTY>
+        );
       }
     }
   }


### PR DESCRIPTION
Fixed 4 issues:
1. major: After the channel was closed, a producer that calls post() could still consume an offset that would never have data pushed to it. pull() handles this correctly, but try_pull() did not and would always report EMPTY. This has been fixed so that try_pull() reports CLOSED in this situation. A new test was added for this scenario.
2. major: get_hazard_pointer races to read head_block->offset with a concurrent reclaim. With set_reuse_blocks(true), this is not a problem, as head_block would be guaranteed to point to some block (although an older protection index may be read, this is correct). However, when set_reuse_blocks(false) was called, this could result in a use-after-free read. The solution is to store head_offset separately (updated only by reclaim), and have new hazard pointers read this as their default protection index.
3. minor: Failed producers after the queue is closed don't reset their hazard pointer protection. This could prevent reclamation of completed blocks in the case of a channel whose lifetime persists long after it is closed.
4. minor: Hazard-pointer publication is technically weaker than the C++ memory model requires. On x86 / ARM (the only officially supported / tested platforms) in practice, the current implementation works correctly - the seq_cst RMW that follows is sufficient to provide the expected guarantee. This is now documented, and on non-x86, non-ARM platforms, a fallback to seq_cst hazard pointer publication was added.