### PR TITLE
fix `post_bulk()` index comparison wraparound

### DIFF
--- a/include/tmc/channel.hpp
+++ b/include/tmc/channel.hpp
@@ -1274,7 +1274,7 @@ public:
     }
 
     size_t idx = startIdx;
-    while (idx < endIdx) {
+    while (idx != endIdx) {
       element* elem = &block->values[idx & BlockSizeMask];
       // Store the data / wake any waiting consumers
       TMC_DISABLE_WARNING_PESSIMIZING_MOVE_BEGIN
@@ -1285,7 +1285,7 @@ public:
       if ((idx & BlockSizeMask) == 0) {
         block = block->next.load(std::memory_order_acquire);
         // all blocks should have been preallocated for [startIdx, endIdx)
-        assert(block != nullptr || idx >= endIdx);
+        assert(block != nullptr || !circular_less_than(idx, endIdx));
       }
     }
 

--- a/include/tmc/qu_mpsc_unbounded.hpp
+++ b/include/tmc/qu_mpsc_unbounded.hpp
@@ -793,7 +793,7 @@ public:
     }
 
     size_t idx = startIdx;
-    while (idx < endIdx) {
+    while (idx != endIdx) {
       element* elem = &block->values[idx & BlockSizeMask];
 
       TMC_DISABLE_WARNING_PESSIMIZING_MOVE_BEGIN
@@ -806,7 +806,7 @@ public:
       if ((idx & BlockSizeMask) == 0) {
         block = block->next.load(std::memory_order_acquire);
         // all blocks should have been preallocated for [startIdx, endIdx)
-        assert(block != nullptr || idx >= endIdx);
+        assert(block != nullptr || !circular_less_than(idx, endIdx));
       }
     }
     return true;

--- a/include/tmc/qu_spsc_unbounded.hpp
+++ b/include/tmc/qu_spsc_unbounded.hpp
@@ -665,7 +665,7 @@ public:
 
     size_t idx = startIdx;
     consumer_base* cons = nullptr;
-    while (idx < endIdx) {
+    while (idx != endIdx) {
       element* elem = &block->values[idx & BlockSizeMask];
 
       TMC_DISABLE_WARNING_PESSIMIZING_MOVE_BEGIN
@@ -681,8 +681,8 @@ public:
       if ((idx & BlockSizeMask) == 0) {
         block = block->next.load(std::memory_order_acquire);
         // all blocks should have been preallocated for [startIdx, endIdx)
-        assert(block != nullptr || idx >= endIdx);
-        if (idx < endIdx) {
+        assert(block != nullptr || !circular_less_than(idx, endIdx));
+        if (circular_less_than(idx, endIdx)) {
           write_block.store(block, std::memory_order_relaxed);
         }
       }


### PR DESCRIPTION
Affects:
- `tmc::channel::post_bulk()`
- `tmc::qu_mpsc_unbounded::post_bulk()`
- `tmc::qu_spsc_unbounded::post_bulk()`

When comparing the beginning index and end index of the post_bulk range, using `idx < endIdx` would loop forever when endIdx wraps around the top of the unsigned integer range. Instead we must use equality checking or `circular_less_than` for the comparison.