### PR TITLE
empty() returns false on a closed-and-drained queue

### DIFF
--- a/include/tmc/qu_mpsc_bounded.hpp
+++ b/include/tmc/qu_mpsc_bounded.hpp
@@ -711,11 +711,30 @@ public:
   }
 
   /// Returns true if the queue appears to be empty.
+  /// A closed-and-drained queue is considered non-empty, and this will return
+  /// false so that the consumer will call `try_pull()` / `pull()` and observe
+  /// the CLOSED status.
   /// This is an unsynchronized read (like `try_pull()`), so it is only a hint.
   /// Only safe to call from the single consumer.
   bool empty() {
-    element* elem = &values[read_offset % capacity];
-    return (elem->flags.load(std::memory_order_acquire) & DATA_BIT) == 0;
+    size_t idx = read_offset;
+    element* elem = &values[idx % capacity];
+    if ((elem->flags.load(std::memory_order_acquire) & DATA_BIT) != 0) {
+      return false;
+    }
+    // Mirror try_pull()'s CLOSED detection: once the consumer has reached the
+    // close cutoff, the queue is closed and drained (which for the purposes of
+    // this function is considered non-empty).
+    if (closed.load(std::memory_order_acquire)) {
+      while (!closed_ready.load(std::memory_order_acquire)) {
+        TMC_CPU_PAUSE();
+      }
+      size_t cutoff = write_closed_at.load(std::memory_order_acquire);
+      if (!circular_less_than(idx, cutoff)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   /// Await to dequeue. Returns a `pull_zc_scope` which provides a scoped

--- a/include/tmc/qu_mpsc_unbounded.hpp
+++ b/include/tmc/qu_mpsc_unbounded.hpp
@@ -944,6 +944,9 @@ public:
   }
 
   /// Returns true if the queue appears to be empty.
+  /// A closed-and-drained queue is considered non-empty, and this will return
+  /// false so that the consumer will call `try_pull()` / `pull()` and observe
+  /// the CLOSED status.
   /// This is an unsynchronized read (like `try_pull()`), so it is only a hint.
   /// Only safe to call from the single consumer.
   bool empty() {
@@ -951,8 +954,8 @@ public:
     data_block* block = find_block(read_block, Idx);
     element* elem = &block->values[Idx & BlockSizeMask];
 
-    bool isEmpty = !elem->is_data_waiting();
-    return isEmpty;
+    uintptr_t f = elem->poll();
+    return f != DATA_BIT && f != CLOSED_BIT;
   }
 
   /// Returns a `pull_zc_scope` when awaited.

--- a/include/tmc/qu_spsc_bounded.hpp
+++ b/include/tmc/qu_spsc_bounded.hpp
@@ -711,14 +711,21 @@ public:
   }
 
   /// Returns true if the queue appears to be empty.
+  /// A closed-and-drained queue is considered non-empty, and this will return
+  /// false so that the consumer will call `try_pull()` / `pull()` and observe
+  /// the CLOSED status.
   /// This is an unsynchronized read (like `try_pull()`), so it is only a hint.
   /// Only safe to call from the single consumer.
   bool empty() {
     size_t Idx = read_offset;
     element* elem = &values[Idx % capacity];
 
-    bool isEmpty = !elem->is_data_waiting();
-    return isEmpty;
+    // The only empty state is an unset slot (f == 0). Every non-zero state is
+    // non-empty: DATA_BIT (data present, possibly together with CLOSED_BIT),
+    // CLOSED_BIT (closed sentinel), or a producer_base* (>= 4, queue was full
+    // and the previous round's data is still present). A consumer_base* cannot
+    // appear here because empty() is called by the running consumer.
+    return elem->poll() == 0;
   }
 
   /// Returns `void` when awaited.

--- a/include/tmc/qu_spsc_unbounded.hpp
+++ b/include/tmc/qu_spsc_unbounded.hpp
@@ -812,6 +812,9 @@ public:
   }
 
   /// Returns true if the queue appears to be empty.
+  /// A closed-and-drained queue is considered non-empty, and this will return
+  /// false so that the consumer will call `try_pull()` / `pull()` and observe
+  /// the CLOSED status.
   /// This is an unsynchronized read (like `try_pull()`), so it is only a hint.
   /// Only safe to call from the single consumer.
   bool empty() {
@@ -819,8 +822,8 @@ public:
     data_block* block = find_block(head_block, Idx);
     element* elem = &block->values[Idx & BlockSizeMask];
 
-    bool isEmpty = !elem->is_data_waiting();
-    return isEmpty;
+    uintptr_t f = elem->poll();
+    return f != DATA_BIT && f != CLOSED_BIT;
   }
 
   /// Returns a `pull_zc_scope` when awaited.


### PR DESCRIPTION
Affects all 4 of the new queues:
- `qu_mpsc_unbounded`
- `qu_mpsc_bounded`
- `qu_spsc_unbounded`
- `qu_spsc_bounded`

`empty()` was underspecified on these queues. It was not clear what it would return if the queue was closed and drained.

I decided to make `empty()` return false when the queue is closed and drained. This means that consumers can use it as a lightweight polling mechanism without doing a full `try_pull()`. Once `empty()` returns false, that means that either data is ready, or the close signal is ready - and the polling consumer should try to consume it. I believe this is the most likely use case for the `empty()` function, so I've decided to support it.

Another way to think about this is that a closed queue contains a CLOSED sentinel element which is always available to consume, thus it can never be empty.

The alternative (`empty()` returns true when the queue is closed and drained) would mean that it can't ever be used to detect a closed signal, and a polling consumer could get stuck for a long time unless it periodically checks for the closed signal via `try_pull()`.