### PR TITLE
queue optimizations

### DIFF
--- a/include/tmc/qu_spsc_bounded.hpp
+++ b/include/tmc/qu_spsc_bounded.hpp
@@ -200,8 +200,8 @@ class qu_spsc_bounded {
   };
 
   char pad0[TMC_CACHE_LINE_SIZE - sizeof(size_t)];
-  // Producer's hot field, written on every push
-  std::atomic<size_t> write_offset;
+  // Read and written only by producer
+  size_t write_offset;
   char pad1[TMC_CACHE_LINE_SIZE - sizeof(size_t)];
   // Read and written only by consumer
   size_t read_offset;
@@ -386,7 +386,7 @@ public:
       "Capacity must be smaller than half the max value that can be "
       "represented by a platform word"
     );
-    write_offset.store(0, std::memory_order_relaxed);
+    write_offset = 0;
     closed.store(false, std::memory_order_relaxed);
     write_closed_at.store(0, std::memory_order_relaxed);
     read_offset = 0;
@@ -404,7 +404,7 @@ private:
   // Idx will be initialized by this function
   element* get_write_ticket(size_t& Idx) noexcept {
     // For SPSC, the element is written before writing updated write_offset
-    Idx = write_offset.load(std::memory_order_relaxed);
+    Idx = write_offset;
     return &values[Idx % capacity];
   }
 
@@ -539,7 +539,7 @@ public:
     }
     consumer_base* cons =
       write_element(elem, static_cast<Args&&>(ConstructArgs)...);
-    write_offset.store(idx + 1, std::memory_order_release);
+    write_offset = idx + 1;
     if (cons != nullptr) {
       tmc::detail::post_checked(
         cons->continuation_executor, std::move(cons->continuation), cons->prio
@@ -662,7 +662,7 @@ private:
     // The next slot the producer would have used is write_offset (writes are
     // published by storing write_offset *after* the data); this is the only
     // slot the consumer could still be waiting on.
-    size_t woff = write_offset.load(std::memory_order_relaxed);
+    size_t woff = write_offset;
     write_closed_at.store(woff, std::memory_order_release);
 
     // Set CLOSED_BIT into the cutoff slot's flags. This races with the
@@ -809,7 +809,7 @@ public:
           },
           std::move(args)
         );
-        queue.write_offset.store(idx + 1, std::memory_order_release);
+        queue.write_offset = idx + 1;
         if (cons != nullptr) {
           tmc::detail::post_checked(
             cons->continuation_executor, std::move(cons->continuation),
@@ -853,7 +853,7 @@ public:
         if (count == 0) [[unlikely]] {
           return true;
         }
-        startIdx = queue.write_offset.load(std::memory_order_relaxed);
+        startIdx = queue.write_offset;
         // The last slot we need free in order to write all `count` elements.
         // When single consumer frees this slot, all prior slots are also free.
         lastElem = &queue.values[(startIdx + count - 1) % queue.capacity];
@@ -926,7 +926,7 @@ public:
           cons = nullptr;
         }
 
-        queue.write_offset.store(startIdx + count, std::memory_order_release);
+        queue.write_offset = startIdx + count;
         if (cons != nullptr) {
           tmc::detail::post_checked(
             cons->continuation_executor, std::move(cons->continuation),

--- a/include/tmc/qu_spsc_bounded.hpp
+++ b/include/tmc/qu_spsc_bounded.hpp
@@ -382,8 +382,8 @@ public:
     // Ensure that the subtraction of unsigned offsets always results in a
     // value that can be represented as a signed integer.
     assert(
-      Capacity <= (TMC_ONE_BIT << (TMC_PLATFORM_BITS - 1)) &&
-      "Capacity must not be larger than half the max value that can be "
+      Capacity < (TMC_ONE_BIT << (TMC_PLATFORM_BITS - 1)) &&
+      "Capacity must be smaller than half the max value that can be "
       "represented by a platform word"
     );
     write_offset.store(0, std::memory_order_relaxed);
@@ -964,8 +964,14 @@ public:
         element* myElem = queue.get_read_ticket(idx);
         base.elem = myElem;
         // Data is ready when DATA_BIT is set, possibly together with
-        // CLOSED_BIT if close() ran while data was still in the slot.
-        return (myElem->poll() & DATA_BIT) != 0;
+        // CLOSED_BIT if close() ran while data was still in the slot, OR if the
+        // value is >= 4. This is a producer_base* - it cannot be our own
+        // consumer_base*, since we are running, not suspended. A producer
+        // pointer is only ever installed by CAS(DATA_BIT -> producer_base*),
+        // so it implies the previous round's data is still present in this
+        // slot.
+        uintptr_t f = myElem->poll();
+        return (f & DATA_BIT) != 0 || f >= 4;
       }
 
       bool await_suspend(std::coroutine_handle<> Outer) noexcept {

--- a/include/tmc/qu_spsc_unbounded.hpp
+++ b/include/tmc/qu_spsc_unbounded.hpp
@@ -189,7 +189,7 @@ class qu_spsc_unbounded {
 
   char pad0[TMC_CACHE_LINE_SIZE];
   // Producer hot fields
-  std::atomic<size_t> write_offset;
+  size_t write_offset; // accessed only by producer
   std::atomic<data_block*> write_block;
   // Cold close-related fields: only written once by close() itself. No
   // `closed_ready` handshake is required (unlike qu_mpsc) because the closer
@@ -198,7 +198,7 @@ class qu_spsc_unbounded {
   std::atomic<bool> closed;
   std::atomic<size_t> write_closed_at;
   char pad1[TMC_CACHE_LINE_SIZE - sizeof(size_t)];
-  // Read and written only by consumer
+  // Consumer hot fields - all accessed only by consumer
   size_t read_offset;
   data_block* head_block; // aka read_block
   data_block* tail_block;
@@ -386,7 +386,7 @@ public:
     head_block = block;
     write_block.store(block, std::memory_order_relaxed);
     tail_block = block;
-    write_offset.store(0, std::memory_order_relaxed);
+    write_offset = 0;
     closed.store(false, std::memory_order_relaxed);
     write_closed_at.store(0, std::memory_order_relaxed);
     read_offset = 0;
@@ -549,7 +549,7 @@ private:
     // In SPSC mode, write_offset is the committed write offset. The producer
     // takes the next index from it, advances its block cursor before making a
     // block-start element visible, and publishes write_offset after writing.
-    Idx = write_offset.load(std::memory_order_relaxed);
+    Idx = write_offset;
     data_block* block = find_write_block(Idx);
     element* elem = &block->values[Idx & BlockSizeMask];
     return elem;
@@ -598,7 +598,7 @@ private:
   ) noexcept {
     // In SPSC mode, write_offset is published after all elements in the bulk
     // operation have been written.
-    StartIdx = write_offset.load(std::memory_order_relaxed);
+    StartIdx = write_offset;
     EndIdx = StartIdx + Count;
     data_block* block = write_block.load(std::memory_order_relaxed);
 
@@ -634,7 +634,7 @@ public:
 
     consumer_base* cons =
       write_element(elem, static_cast<Args&&>(ConstructArgs)...);
-    write_offset.store(idx + 1, std::memory_order_release);
+    write_offset = idx + 1;
     if (cons != nullptr) {
       tmc::detail::post_checked(
         cons->continuation_executor, std::move(cons->continuation), cons->prio
@@ -691,7 +691,7 @@ public:
         }
       }
     }
-    write_offset.store(endIdx, std::memory_order_release);
+    write_offset = endIdx;
     if (cons != nullptr) {
       tmc::detail::post_checked(
         cons->continuation_executor, std::move(cons->continuation), cons->prio
@@ -757,7 +757,7 @@ private:
     //
     // No `closed_ready` handshake is required (unlike qu_mpsc), because no
     // other producer is racing with the closer to learn the cutoff.
-    size_t woff = write_offset.load(std::memory_order_relaxed);
+    size_t woff = write_offset;
     write_closed_at.store(woff, std::memory_order_release);
 
     // Publish the CLOSED sentinel at slot woff. This races with the consumer's


### PR DESCRIPTION
- qu_spsc_unbounded's write_offset becomes non-atomic since it's only accessed by the producer.
- qu_spsc_bounded's write_offset becomes non-atomic since it's only accessed by the producer.
- qu_spsc_bounded's pull::await_ready can now return true if there is a parked producer because the queue is full. This avoids a round-trip through await_suspend.
- fixed an off-by-one assert problem when qu_spsc_bounded's capacity is exactly at the max capacity (half a machine word)