### PR TITLE
fix incorrect wake/wait counts on Linux in `ex_cpu_st`

### DIFF
--- a/include/tmc/detail/ex_cpu_st.ipp
+++ b/include/tmc/detail/ex_cpu_st.ipp
@@ -285,12 +285,13 @@ auto ex_cpu_st::make_worker(
         break;
       }
 #ifdef __linux__
-      long waitResult =
-        syscall(SYS_futex_waitv, waiters, PRIORITY_COUNT + 1, 0, nullptr, 0);
-      if (waitResult >= 0 && static_cast<size_t>(waitResult) < PRIORITY_COUNT) {
-        didWait[waitResult] = false;
-        // Don't increment failed_wait_count since this was a successful wait.
-      }
+      syscall(SYS_futex_waitv, waiters, PRIORITY_COUNT + 1, 0, nullptr, 0);
+      // didWait stays set even on a successful wait; producers count every
+      // wake attempt that observed WAITING, and the matching consume counts
+      // the wait (the same convention as the non-Linux path below). Clearing
+      // the woken index here would lose the pairing when two producers wake
+      // different words of the same futex_waitv concurrently: both wakes
+      // report success, but the waiter returns only one index.
 #else
       // Non-Linux platforms don't provide a futex_waitv equivalent. Use a
       // shared wake word for all queues. Producers conservatively count every
@@ -468,13 +469,30 @@ void ex_cpu_st::teardown() {
     worker_thread.join();
   }
 
-  // For each failed wait, there must also be a failed wake - where the producer
-  // released the data to the queue, but didn't wake us, since we already took
-  // the data. In those scenarios, it's possible for the queue destruction to
-  // race with the futex wake of the producer. Wait for all of the failed wakes
-  // to finish before destroying.
-  // On non-Linux, we can't distinguish failed from successful wakes, so we just
-  // wait for all wakes.
+  // To prevent the following race condition:
+  // 1. Producer A (caller of post() / post_bulk() on ex_cpu_st) submits work
+  //    to the queue and the consumer appears to be sleeping.
+  // 2. Producer B also submits some work and then wakes the consumer by waking
+  //    the futex.
+  // 3. Consumer wakes up, consumes the work from both A and B. These work items
+  //    are final jobs, and when joined, the executor is then destroyed.
+  // 4. Producer A tries to wake the futex; this is a use-after-free.
+  //
+  // On the consumer side, each time we consume an item from a slot we had
+  // previously armed with WAITING (tracked by `didWait`), we increment
+  // wait_count. This matches the set of posts for which a producer observed
+  // WAITING and therefore touched the futex; hot-path posts that never saw
+  // WAITING are counted by neither side.
+  //
+  // Setting WAITING is idempotent and the consumer never clears it except by
+  // consuming; if it re-checks or spins on the same slot, the status stays
+  // WAITING until a producer posts.
+  //
+  // When a producer writes that slot and sees WAITING, it fires the wake
+  // syscall and only then increments the wake count. Because that increment
+  // lands after the syscall, wait_count >= wakeCount until every producer's
+  // syscall has completed, so waiting for wakeCount == wait_count guarantees no
+  // producer is still touching the futex before we destroy the queues.
   while (true) {
     size_t wakeCount = 0;
     for (size_t i = 0; i < PRIORITY_COUNT; ++i) {

--- a/include/tmc/detail/ex_cpu_st.ipp
+++ b/include/tmc/detail/ex_cpu_st.ipp
@@ -284,19 +284,13 @@ auto ex_cpu_st::make_worker(
       if (ThreadStopToken.stop_requested()) [[unlikely]] {
         break;
       }
+      // Producers count every wake attempt that observed WAITING, so keep
+      // didWait set here and account it when the item is consumed.
 #ifdef __linux__
       syscall(SYS_futex_waitv, waiters, PRIORITY_COUNT + 1, 0, nullptr, 0);
-      // didWait stays set even on a successful wait; producers count every
-      // wake attempt that observed WAITING, and the matching consume counts
-      // the wait (the same convention as the non-Linux path below). Clearing
-      // the woken index here would lose the pairing when two producers wake
-      // different words of the same futex_waitv concurrently: both wakes
-      // report success, but the waiter returns only one index.
 #else
       // Non-Linux platforms don't provide a futex_waitv equivalent. Use a
-      // shared wake word for all queues. Producers conservatively count every
-      // wake attempt that observed WAITING, so keep didWait set here and
-      // account it when the item is consumed.
+      // shared wake word for all queues.
       if (ThreadStopToken.stop_requested()) [[unlikely]] {
         break;
       }

--- a/include/tmc/detail/qu_mpsc_blocking.hpp
+++ b/include/tmc/detail/qu_mpsc_blocking.hpp
@@ -529,11 +529,12 @@ private:
       FUTEX_WAKE_PRIVATE, 1, nullptr, nullptr, 0
     );
     assert(wokenCount >= 0);
-    bool didWake = wokenCount != 0;
-    if (!didWake) {
-      wake_ref_count.fetch_add(1, std::memory_order_release);
-    }
-    return didWake;
+    // If the waiter is using futex_waitv, this can return non-zero even if the
+    // wake came from another waker or cancellation. So the wake syscall return
+    // value isn't a reliable signal of "we were the unique waker". Therefore we
+    // need to always increment the ref-count.
+    wake_ref_count.fetch_add(1, std::memory_order_release);
+    return wokenCount != 0;
 #else
     wake_wait->fetch_add(1, std::memory_order_release);
     wake_wait->notify_one();

--- a/include/tmc/detail/qu_mpsc_blocking.hpp
+++ b/include/tmc/detail/qu_mpsc_blocking.hpp
@@ -12,11 +12,14 @@
 // - single consumer's offset is non-atomic
 
 // Instead of hazard pointers, uses a quiescent-state based reclamation scheme:
-// 1. Producers reserve tickets with write_offset, then load write_block.
-// 2. The consumer enters a new block and publishes it as the new write_block.
-// 3. The consumer snapshots write_offset as the reclaim cutoff.
-// 4. Once read_offset reaches that cutoff, producers that may have observed the
-//    old write_block are done, so old blocks can be recycled.
+// 1. Producers reserve tickets with write_offset, then load write_block_hint.
+//    If the hint is past their reservation, they fall back to write_block.
+// 2. Producers may advance write_block_hint forward after finding their block.
+// 3. The consumer enters a new block and publishes it as the new write_block.
+// 4. The consumer snapshots write_offset as the reclaim cutoff.
+// 5. Once read_offset reaches that cutoff, producers that may have observed the
+//    old write_block or write_block_hint are done, so old blocks can be
+//    recycled.
 // This scheme works only with single-consumer queues since we can be sure that
 // after the consumer reached the cutoff, there are guaranteed to be no other
 // users of the old blocks.
@@ -201,14 +204,13 @@ private:
     data_block() noexcept : data_block(0) {}
   };
 
-  char pad0[TMC_CACHE_LINE_SIZE - sizeof(size_t)];
+  char pad0[TMC_CACHE_LINE_SIZE];
   std::atomic<size_t> write_offset;
+  std::atomic<data_block*> write_block_hint;
+  std::atomic<data_block*> write_block;
   char pad1[TMC_CACHE_LINE_SIZE - sizeof(size_t)];
   size_t read_offset;
   data_block* read_block;
-  char pad2[TMC_CACHE_LINE_SIZE - sizeof(size_t) - sizeof(data_block*)];
-
-  std::atomic<data_block*> write_block;
   data_block* head_block;
   data_block* tail_block;
 
@@ -249,6 +251,7 @@ public:
     }
     head_block = block;
     write_block.store(block, std::memory_order_relaxed);
+    write_block_hint.store(block, std::memory_order_relaxed);
     tail_block = block;
     write_offset.store(0, std::memory_order_relaxed);
     read_offset = 0;
@@ -361,6 +364,48 @@ private:
     return Block;
   }
 
+  static inline bool block_before(data_block* A, data_block* B) noexcept {
+    return circular_less_than(
+      A->offset.load(std::memory_order_relaxed),
+      B->offset.load(std::memory_order_relaxed)
+    );
+  }
+
+  void advance_write_block_hint_at_least(
+    data_block* Current, data_block* Target
+  ) noexcept {
+    while (block_before(Current, Target)) {
+      if (write_block_hint.compare_exchange_weak(
+            Current, Target, std::memory_order_seq_cst,
+            std::memory_order_seq_cst
+          )) {
+        return;
+      }
+    }
+  }
+
+  void advance_write_block_hint_at_least(data_block* Target) noexcept {
+    advance_write_block_hint_at_least(
+      write_block_hint.load(std::memory_order_seq_cst), Target
+    );
+  }
+
+  data_block* get_mpsc_write_start_block(size_t Idx) noexcept {
+    data_block* block = write_block_hint.load(std::memory_order_seq_cst);
+    if (!circular_less_than(
+          block->offset.load(std::memory_order_relaxed), 1 + Idx
+        )) {
+      // A later producer may have advanced the hint past this producer's
+      // earlier reservation. Fall back to the consumer-managed reclaim
+      // frontier, which cannot advance past an unproduced reservation.
+      block = write_block.load(std::memory_order_seq_cst);
+      assert(circular_less_than(
+        block->offset.load(std::memory_order_relaxed), 1 + Idx
+      ));
+    }
+    return block;
+  }
+
   bool try_finish_pending_reclaim() noexcept {
     if (pending_reclaim_old_head == nullptr) {
       return false;
@@ -398,11 +443,14 @@ private:
       return;
     }
 
-    // This seq_cst store and the following seq_cst write_offset load form the
-    // cutoff protocol with producers, which do a seq_cst fetch_add before a
-    // seq_cst load of write_block. A producer that observes the old write_block
-    // must have a reservation included in the cutoff.
+    // This seq_cst write_block store, seq_cst write_block_hint advancement, and
+    // the following seq_cst write_offset load form the cutoff protocol with
+    // producers, which do a seq_cst fetch_add before a seq_cst load of either
+    // write_block_hint or write_block. A producer that observes the old
+    // write_block or write_block_hint must have a reservation included in the
+    // cutoff.
     write_block.store(NewHead, std::memory_order_seq_cst);
+    advance_write_block_hint_at_least(NewHead);
     pending_reclaim_cutoff = write_offset.load(std::memory_order_seq_cst);
     pending_reclaim_old_head = oldHead;
     pending_reclaim_new_head = NewHead;
@@ -418,15 +466,17 @@ private:
   element* get_write_ticket(size_t& Idx) noexcept {
     // seq_cst is needed here so the reader can order its write_block update and
     // subsequent write_offset load against the producer's reservation and
-    // write_block load.
+    // write_block_hint / write_block load.
     Idx = write_offset.fetch_add(1, std::memory_order_seq_cst);
-    data_block* block = write_block.load(std::memory_order_seq_cst);
 
-    assert(
-      circular_less_than(block->offset.load(std::memory_order_relaxed), 1 + Idx)
-    );
+    data_block* observed = get_mpsc_write_start_block(Idx);
 
-    block = find_block(block, Idx);
+    assert(circular_less_than(
+      observed->offset.load(std::memory_order_relaxed), 1 + Idx
+    ));
+
+    data_block* block = find_block(observed, Idx);
+    advance_write_block_hint_at_least(observed, block);
     element* elem = &block->values[Idx & BlockSizeMask];
     return elem;
   }
@@ -499,18 +549,20 @@ private:
   ) noexcept {
     // seq_cst is needed here so the reader can order its write_block update and
     // subsequent write_offset load against the producer's reservation and
-    // write_block load.
+    // write_block_hint / write_block load.
     StartIdx = write_offset.fetch_add(Count, std::memory_order_seq_cst);
     EndIdx = StartIdx + Count;
-    data_block* block = write_block.load(std::memory_order_seq_cst);
+
+    data_block* observed = get_mpsc_write_start_block(StartIdx);
 
     assert(circular_less_than(
-      block->offset.load(std::memory_order_relaxed), 1 + StartIdx
+      observed->offset.load(std::memory_order_relaxed), 1 + StartIdx
     ));
 
     // Ensure all blocks for the operation are allocated and available.
-    data_block* startBlock = find_block(block, StartIdx);
-    find_block(startBlock, EndIdx - 1);
+    data_block* startBlock = find_block(observed, StartIdx);
+    data_block* endBlock = find_block(startBlock, EndIdx - 1);
+    advance_write_block_hint_at_least(observed, endBlock);
     return startBlock;
   }
 

--- a/include/tmc/ex_cpu_st.hpp
+++ b/include/tmc/ex_cpu_st.hpp
@@ -55,14 +55,8 @@ class ex_cpu_st {
   std::atomic<bool> initialized;
   std::atomic<tmc::detail::atomic_wait_t> stop_wait;
 
-  // On Linux, counts only "failed waits" - queue items consumed after the
-  // worker had published a wait state, but before it was actually woken by a
-  // producer wake operation. This is possible since futex signals whether wake
-  // actually woke anything, and whether wait actually waited.
-  // On other OSes, counts all waits, since the OS APIs don't provide the
-  // necessary information, AND the OS APIs don't support user-space multi-wait,
-  // instead requiring the use of kernel objects. So we just use C++20 standard
-  // std::atomic::wait on a single value shared across all queues.
+  // Count the total number of consumer-published waits. Destructor waits for
+  // the number of producer-published wakes to match this before finalizing.
   std::atomic<size_t> wait_count;
 #ifndef __linux__
   std::atomic<tmc::detail::atomic_wait_t> wake_wait;


### PR DESCRIPTION
In https://github.com/tzcnt/TooManyCooks/pull/224 a more efficient reference-counting mechanism to resolve the producer-vs-destructor race. That PR also contains this text: "On Linux, this can be optimized further and we only need to increment the counter when waking/waiting fails (the race condition only occurs when the consumer sees the data is ready flag before actually going to sleep, causing the futex wait to return EAGAIN)"

That implementation also relied on the assumption that the producer/waker could accurately detect whether it was the single unique waker of the waiter. So, if multiple callers of FUTEX_WAKE_PRIVATE raced, only a single one would return 1 (indicating that it woke the waiter), and the others would return 0. This allowed for a Linux-specific optimization that only needed to count *failed* wakes / waits instead of *all* wakes / waits.

It turns out that assumption was false. When calling FUTEX_WAKE_PRIVATE where the waiter is using futex_waitv, multiple racing wakers may return 1. This throws off the wake/wait count and does not properly solve for the race condition.

The solution is to always count *all* wakes / waits on Linux, just like we do on the other operating systems. The only remaining Linux-specific optimization is the use of futex_waitv instead of a standalone waiter word.

This still preserves the majority of the reference-counting optimization: producers only need to increment the refcount when they do a syscall, in which case the syscall duration still dominates the atomic refcount overhead. When the consumer is working / not waiting, the refcount and syscall can be skipped.

---

This MR also ports the `write_block_hint` optimization from `qu_mpsc_unbounded` to `qu_mpsc_blocking`, which reduces producer latency when producers run far ahead of consumers.