### PR TITLE
optimize done_count completion check in awaitable_customizer

### DIFF
--- a/include/tmc/detail/awaitable_customizer.hpp
+++ b/include/tmc/detail/awaitable_customizer.hpp
@@ -112,7 +112,7 @@ struct awaitable_customizer_base {
         // If DoneCount was 0 then resume.
         // DoneCount cannot be < 0, but by using <= 0 check we get better
         // codegen on x86: `lock dec; jl` whereas == 0 check generates `mov -1;
-        // lock xadd; test; jnz`
+        // lock xadd; test; jnz`. It is also 1 instruction cheaper on AArch64.
         shouldResume =
           static_cast<std::atomic<ptrdiff_t>*>(DoneCount)->fetch_sub(
             1, std::memory_order_acq_rel

--- a/include/tmc/detail/awaitable_customizer.hpp
+++ b/include/tmc/detail/awaitable_customizer.hpp
@@ -34,6 +34,19 @@ static inline constexpr size_t PRIORITY_MASK =
 
 } // namespace task_flags
 
+// Atomically decrements DoneCount and returns true if this was the decrement
+// that completed the group - i.e. the value immediately before the decrement
+// was <= 0.
+//
+// Precondition: DoneCount cannot be < 0 before the decrement, so this is
+// equivalent to testing (oldValue == 0). Using (oldValue <= 0) lets
+// x86 lower it to `lock dec; jl` instead of the less efficient
+// `mov -1; lock xadd; test; jnz`. It is also 1 instruction cheaper on AArch64.
+[[nodiscard]] TMC_FORCE_INLINE inline bool
+done_count_arrived(std::atomic<ptrdiff_t>& DoneCount) noexcept {
+  return DoneCount.fetch_sub(1, std::memory_order_acq_rel) <= 0;
+}
+
 /// Multipurpose awaitable type. Exposes fields that can be customized by most
 /// TMC utility functions. Exposing this type allows various awaitables to be
 /// compatible with the library and with each other.
@@ -107,16 +120,8 @@ struct awaitable_customizer_base {
         // task is part of a spawn_many group, or fork
         // continuation is a std::coroutine_handle<>*
         // continuation_executor is a tmc::ex_any**
-
-        // If DoneCount was > 0 then don't resume.
-        // If DoneCount was 0 then resume.
-        // DoneCount cannot be < 0, but by using <= 0 check we get better
-        // codegen on x86: `lock dec; jl` whereas == 0 check generates `mov -1;
-        // lock xadd; test; jnz`. It is also 1 instruction cheaper on AArch64.
         shouldResume =
-          static_cast<std::atomic<ptrdiff_t>*>(DoneCount)->fetch_sub(
-            1, std::memory_order_acq_rel
-          ) <= 0;
+          done_count_arrived(*static_cast<std::atomic<ptrdiff_t>*>(DoneCount));
       }
       if (shouldResume) {
         ContinuationExecutor =

--- a/include/tmc/detail/awaitable_customizer.hpp
+++ b/include/tmc/detail/awaitable_customizer.hpp
@@ -107,10 +107,16 @@ struct awaitable_customizer_base {
         // task is part of a spawn_many group, or fork
         // continuation is a std::coroutine_handle<>*
         // continuation_executor is a tmc::ex_any**
+
+        // If DoneCount was > 0 then don't resume.
+        // If DoneCount was 0 then resume.
+        // DoneCount cannot be < 0, but by using <= 0 check we get better
+        // codegen on x86: `lock dec; jl` whereas == 0 check generates `mov -1;
+        // lock xadd; test; jnz`
         shouldResume =
           static_cast<std::atomic<ptrdiff_t>*>(DoneCount)->fetch_sub(
             1, std::memory_order_acq_rel
-          ) == 0;
+          ) <= 0;
       }
       if (shouldResume) {
         ContinuationExecutor =

--- a/include/tmc/sync.hpp
+++ b/include/tmc/sync.hpp
@@ -14,6 +14,7 @@
 // expected behavior of std::future / std::promise, although it does come at a
 // small performance penalty.
 
+#include "tmc/detail/awaitable_customizer.hpp"
 #include "tmc/detail/compat.hpp"
 #include "tmc/detail/concepts_awaitable.hpp"
 #include "tmc/detail/concepts_work_item.hpp"
@@ -367,8 +368,7 @@ template <
                  Functor t, std::shared_ptr<BulkSyncState> SharedState
                ) -> task<void> {
           t();
-          if (SharedState->done_count.fetch_sub(1, std::memory_order_acq_rel) ==
-              0) {
+          if (tmc::detail::done_count_arrived(SharedState->done_count)) {
             SharedState->promise.set_value();
           }
           co_return;
@@ -386,8 +386,7 @@ template <
       [sharedState](FuncIter iter) mutable -> auto {
         return [f = std::move(*iter), sharedState]() mutable {
           f();
-          if (sharedState->done_count.fetch_sub(1, std::memory_order_acq_rel) ==
-              0) {
+          if (tmc::detail::done_count_arrived(sharedState->done_count)) {
             sharedState->promise.set_value();
           }
         };


### PR DESCRIPTION
On x86, `fetch_sub(1) == 0` generates:
```
mov   rax, 0xffffffffffffffff
lock xadd QWORD PTR [r12], rax
test  rax, rax
je    ...
```

`fetch_sub(1) <= 0` generates:
```
lock dec QWORD PTR [r12]
jl    ...
```

Given that the precondition that the value is not already < 0 is already enforced, this is strictly more efficient. This is a micro-optimization, but this code runs at the end of every single task that's part of an awaitable group, so it's worth it.