### PR TITLE
add `tmc::rw_lock`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,4 @@
-ColumnLimit: 80
+ColumnLimit: 90
 DerivePointerAlignment: false
 PointerAlignment: Left
 ReferenceAlignment: Pointer

--- a/include/tmc/all_headers.hpp
+++ b/include/tmc/all_headers.hpp
@@ -31,6 +31,7 @@
 #include "tmc/qu_mpsc_unbounded.hpp"  // IWYU pragma: export
 #include "tmc/qu_spsc_bounded.hpp"    // IWYU pragma: export
 #include "tmc/qu_spsc_unbounded.hpp"  // IWYU pragma: export
+#include "tmc/rw_lock.hpp"            // IWYU pragma: export
 #include "tmc/semaphore.hpp"          // IWYU pragma: export
 #include "tmc/spawn.hpp"              // IWYU pragma: export
 #include "tmc/spawn_func.hpp"         // IWYU pragma: export

--- a/include/tmc/detail/barrier.ipp
+++ b/include/tmc/detail/barrier.ipp
@@ -16,13 +16,8 @@
 
 namespace tmc {
 bool aw_barrier::await_suspend(std::coroutine_handle<> Outer) noexcept {
-  // Configure this awaiter
-  me.waiter.continuation = Outer;
-  me.waiter.continuation_executor = tmc::detail::this_thread::executor();
-  me.waiter.continuation_priority = tmc::detail::this_thread::this_task().prio;
-
-  // Add this awaiter to the waiter list
-  parent.waiters.add_waiter(me);
+  // Configure this awaiter and add it to the waiter list
+  parent.waiters.configure_and_add_waiter(me, Outer);
 
   // Note: We don't run the risk of use-after-resume-and-destroy, because of the
   // invariant that the number of waiters equals the initial count.

--- a/include/tmc/detail/rw_lock.ipp
+++ b/include/tmc/detail/rw_lock.ipp
@@ -1,0 +1,231 @@
+// Copyright (c) 2023-2026 Logan McDougall
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include "tmc/detail/impl.hpp" // IWYU pragma: keep
+
+#include "tmc/detail/waiter_list.hpp"
+#include "tmc/rw_lock.hpp"
+
+#include <atomic>
+#include <cassert>
+#include <coroutine>
+
+namespace tmc {
+rw_lock_read_scope::~rw_lock_read_scope() {
+  if (parent != nullptr) {
+    parent->unlock_read();
+  }
+}
+
+rw_lock_write_scope::~rw_lock_write_scope() {
+  if (parent != nullptr) {
+    parent->unlock_write();
+  }
+}
+
+bool rw_lock::try_lock_read() noexcept {
+  state_t v = value.load(std::memory_order_relaxed);
+  do {
+    // Readers cannot enter while a writer holds the lock, or while writers
+    // are waiting (so that a steady stream of readers cannot starve writers).
+    if ((v & WRITER) != 0 || unpack_write_waiters(v) != 0) {
+      return false;
+    }
+  } while (!value.compare_exchange_weak(
+    v, v + READERS_ONE, std::memory_order_acquire, std::memory_order_relaxed
+  ));
+  return true;
+}
+
+bool rw_lock::try_lock_write() noexcept {
+  state_t v = value.load(std::memory_order_relaxed);
+  do {
+    // Writers can only enter when the lock is idle and uncontended.
+    if (v != 0) {
+      return false;
+    }
+  } while (!value.compare_exchange_weak(
+    v, WRITER, std::memory_order_acquire, std::memory_order_relaxed
+  ));
+  return true;
+}
+
+void rw_lock::suspend_read(
+  tmc::detail::waiter_list_node& Node, std::coroutine_handle<> Outer
+) noexcept {
+  read_waiters.configure_and_add_waiter(Node, Outer);
+
+  // Release the operation by increasing the waiter count.
+  state_t old = value.fetch_add(READ_WAITERS_ONE, std::memory_order_acq_rel);
+
+  // Using the fetched value, double-check if we can wake ourselves.
+  try_wake<false>(old + READ_WAITERS_ONE);
+}
+
+void rw_lock::suspend_write(
+  tmc::detail::waiter_list_node& Node, std::coroutine_handle<> Outer
+) noexcept {
+  write_waiters.configure_and_add_waiter(Node, Outer);
+
+  // Release the operation by increasing the waiter count.
+  state_t old = value.fetch_add(WRITE_WAITERS_ONE, std::memory_order_acq_rel);
+
+  // Using the fetched value, double-check if we can wake ourselves.
+  try_wake<true>(old + WRITE_WAITERS_ONE);
+}
+
+template <bool PreferWriters> void rw_lock::try_wake(state_t V) noexcept {
+  // Try to claim the WAKING bit. Only one thread may hold it at a time; it
+  // guards the consumer side of both waiter lists.
+  while (true) {
+    if (!can_wake(V)) {
+      return;
+    }
+    if (value.compare_exchange_weak(
+          V, V | WAKING, std::memory_order_acq_rel, std::memory_order_relaxed
+        )) {
+      V |= WAKING;
+      break;
+    }
+  }
+
+  // While the WAKING bit is held:
+  // - No writer can hold the lock. The writer fast path requires the entire
+  //   value to be 0, and the handoff to a waiting writer releases the WAKING
+  //   bit in the same operation that sets the WRITER bit.
+  // - Other threads may register new waiters and acquire/release the read
+  //   lock concurrently, but only this thread may decrease the waiting reader
+  //   / waiting writer counts (or take nodes from the waiter lists).
+  //
+  // The WAKING bit must be released via CAS. On CAS failure, re-check for
+  // new writers or readers in order to prevent lost wakeups.
+  while (true) {
+    assert((V & WRITER) == 0);
+    state_t readers = unpack_readers(V);
+    state_t readWaiterCount = unpack_read_waiters(V);
+    state_t writeWaiterCount = unpack_write_waiters(V);
+
+    // Decide who to wake. When both readers and writers are waiting,
+    // PreferWriters breaks the tie; it is set by the caller to alternate
+    // between reader and writer phases (writers wake readers / readers wake
+    // writers).
+    bool wakeWriter, wakeReaders;
+    if constexpr (PreferWriters) {
+      wakeWriter = readers == 0 && writeWaiterCount > 0;
+      wakeReaders = !wakeWriter && writeWaiterCount == 0 && readWaiterCount > 0;
+    } else {
+      wakeReaders = readWaiterCount > 0;
+      wakeWriter = !wakeReaders && readers == 0 && writeWaiterCount > 0;
+    }
+
+    if (!wakeWriter && !wakeReaders) {
+      // Nothing left to wake.
+      if (value.compare_exchange_strong(
+            V, V & ~WAKING, std::memory_order_acq_rel, std::memory_order_acquire
+          )) {
+        return;
+      }
+      // CAS failure means another thread submitted a new writer or reader.
+      continue;
+    }
+
+    if (wakeWriter) {
+      // Extract a single writer from the waiter list and transfer the lock to it.
+      auto toWake = write_waiters.must_take_1();
+      state_t newV;
+      do {
+        assert(unpack_readers(V) == 0);
+        assert(unpack_write_waiters(V) > 0);
+        // Atomically transfer 1 write waiter -> active writer, and release WAKING.
+        newV = V - WAKING - WRITE_WAITERS_ONE + WRITER;
+      } while (!value.compare_exchange_weak(
+        V, newV, std::memory_order_acq_rel, std::memory_order_relaxed
+      ));
+      toWake->waiter.resume();
+      return;
+    } else {
+      // Wake the waiting readers. We can't take more than the observed count,
+      // because a waiter may add itself to the list before incrementing the
+      // count; over-taking would corrupt the state.
+      tmc::detail::waiter_list_node wakeHead;
+      tmc::detail::waiter_list_node* wakeTail = &wakeHead;
+      state_t taken = 0;
+
+      while (true) {
+        // `readWaiterCount` starts with the initial value from the top of the function,
+        // but may increase after a subsequent CAS failure in this loop.
+        for (; taken < readWaiterCount; ++taken) {
+          auto node = read_waiters.must_take_1();
+          wakeTail->next = node;
+          wakeTail = node;
+        }
+
+        // Atomically transfer `taken` read waiters -> active readers, and release WAKING.
+        state_t newV = V - WAKING - taken * READ_WAITERS_ONE + taken * READERS_ONE;
+        if (value.compare_exchange_weak(
+              V, newV, std::memory_order_acq_rel, std::memory_order_relaxed
+            )) {
+          break;
+        }
+
+        // CAS failed - accept new readers into the batch if there is no writer waiting.
+        if (unpack_write_waiters(V) == 0) {
+          readWaiterCount = unpack_read_waiters(V);
+          assert(readWaiterCount >= taken);
+        }
+      }
+      wakeTail->next = nullptr;
+
+      auto toWake = wakeHead.next;
+      while (toWake != nullptr) {
+        auto next = toWake->next;
+        toWake->waiter.resume();
+        toWake = next;
+      }
+      return;
+    }
+  }
+}
+
+void rw_lock::unlock_read() noexcept {
+  state_t old = value.fetch_sub(READERS_ONE, std::memory_order_acq_rel);
+  assert(unpack_readers(old) > 0);
+  try_wake<true>(old - READERS_ONE);
+}
+
+void rw_lock::unlock_write() noexcept {
+  assert(is_write_locked());
+  state_t old = value.fetch_sub(WRITER, std::memory_order_acq_rel);
+  assert((old & WRITER) != 0);
+  assert(unpack_readers(old) == 0);
+  try_wake<false>(old - WRITER);
+}
+
+rw_lock::~rw_lock() {
+  read_waiters.wake_all();
+  write_waiters.wake_all();
+}
+
+// parent is atomic to prevent use-after-resume. See waiter_list.ipp's
+// aw_acquire::await_suspend for more info.
+
+bool aw_rw_lock_read_base::await_ready() noexcept {
+  return parent.load(std::memory_order_relaxed)->try_lock_read();
+}
+
+void aw_rw_lock_read_base::await_suspend(std::coroutine_handle<> Outer) noexcept {
+  parent.load(std::memory_order_acquire)->suspend_read(me, Outer);
+}
+
+bool aw_rw_lock_write_base::await_ready() noexcept {
+  return parent.load(std::memory_order_relaxed)->try_lock_write();
+}
+
+void aw_rw_lock_write_base::await_suspend(std::coroutine_handle<> Outer) noexcept {
+  parent.load(std::memory_order_acquire)->suspend_write(me, Outer);
+}
+} // namespace tmc

--- a/include/tmc/detail/waiter_list.hpp
+++ b/include/tmc/detail/waiter_list.hpp
@@ -63,8 +63,8 @@ struct waiter_list_node {
 /// Two-stack waiter queue with FIFO wake order.
 ///
 /// `input` is a lock-free Treiber stack that producers push to via
-/// `add_waiter` (LIFO). `output` is a private, single-consumer list of
-/// waiters in FIFO order, only ever touched by the thread that currently
+/// `configure_and_add_waiter` (LIFO). `output` is a private, single-consumer
+/// list of waiters in FIFO order, only ever touched by the thread that currently
 /// holds the `maybe_wake` critical section (or callers that the user has
 /// otherwise serialized, such as the barrier's terminal arriver and
 /// destructors). When `output` is empty and a consumer needs a waiter, the
@@ -77,15 +77,18 @@ class waiter_list {
 public:
   inline waiter_list() noexcept : input{nullptr}, output{nullptr} {}
 
-  /// Adds w to the input stack. Lock-free.
+  /// Configures Node's continuation from Outer and the current thread's
+  /// executor and priority, then adds it to the input stack. Lock-free.
   /// Thread-safe.
-  TMC_DECL void add_waiter(waiter_list_node& w) noexcept;
+  TMC_DECL void configure_and_add_waiter(
+    waiter_list_node& Node, std::coroutine_handle<> Outer
+  ) noexcept;
 
   /// Wakes all waiters. Not guaranteed to wake in FIFO order (which doesn't
   /// matter since waking all waiters doesn't guarantee they get *processed* in
   /// FIFO order either after going through their executor queues). Both lists
-  /// become empty. Thread-safe with concurrent `add_waiter`, but not with
-  /// concurrent consumers (`maybe_wake`, `must_take_1`, `take_all`).
+  /// become empty. Thread-safe with concurrent `configure_and_add_waiter`, but
+  /// not with concurrent consumers (`maybe_wake`, `must_take_1`, `take_all`).
   TMC_DECL void wake_all() noexcept;
 
   /// Returns the number of waiters currently in the list (both `output` and
@@ -96,8 +99,8 @@ public:
 
   /// Returns a singly-linked chain of all waiters. Not guaranteed to take in
   /// FIFO order. Both lists become empty. Thread-safe with concurrent
-  /// `add_waiter`, but not with concurrent consumers (`maybe_wake`,
-  /// `must_take_1`, `take_all`).
+  /// `configure_and_add_waiter`, but not with concurrent consumers
+  /// (`maybe_wake`, `must_take_1`, `take_all`).
   [[nodiscard]] TMC_DECL waiter_list_node* take_all() noexcept;
 
   /// Assumes at least 1 waiter is in the list.

--- a/include/tmc/detail/waiter_list.ipp
+++ b/include/tmc/detail/waiter_list.ipp
@@ -13,6 +13,7 @@
 
 #include <atomic>
 #include <cassert>
+#include <coroutine>
 #include <cstddef>
 
 namespace tmc {
@@ -24,13 +25,8 @@ void waiter_list_node::suspend(
   auto& parentList = Parent->waiters;
   auto& parentValue = Parent->value;
 
-  // Configure this awaiter
-  waiter.continuation = Outer;
-  waiter.continuation_executor = tmc::detail::this_thread::executor();
-  waiter.continuation_priority = tmc::detail::this_thread::this_task().prio;
-
-  // Add this awaiter to the waiter list
-  Parent->waiters.add_waiter(*this);
+  // Configure this awaiter and add it to the waiter list
+  parentList.configure_and_add_waiter(*this, Outer);
 
   // Release the operation by increasing the waiter count
   size_t add = TMC_ONE_BIT << tmc::detail::WAITERS_OFFSET;
@@ -118,12 +114,19 @@ std::coroutine_handle<> try_symmetric_transfer2_waiter(
   return std::noop_coroutine();
 }
 
-void waiter_list::add_waiter(tmc::detail::waiter_list_node& w) noexcept {
+void waiter_list::configure_and_add_waiter(
+  tmc::detail::waiter_list_node& Node, std::coroutine_handle<> Outer
+) noexcept {
+  Node.waiter.continuation = Outer;
+  Node.waiter.continuation_executor = tmc::detail::this_thread::executor();
+  Node.waiter.continuation_priority =
+    tmc::detail::this_thread::this_task().prio;
+
   auto h = input.load(std::memory_order_acquire);
   do {
-    w.next = h;
+    Node.next = h;
   } while (!input.compare_exchange_strong(
-    h, &w, std::memory_order_acq_rel, std::memory_order_acquire
+    h, &Node, std::memory_order_acq_rel, std::memory_order_acquire
   ));
 }
 

--- a/include/tmc/mutex.hpp
+++ b/include/tmc/mutex.hpp
@@ -240,8 +240,8 @@ public:
     return aw_mutex_co_unlock_return<void>(*this);
   }
 
-  /// Tries to acquire the mutex without suspending. Returns true if acquired,
-  /// or false if the mutex was already locked. Not re-entrant.
+  /// Tries to acquire the mutex without suspending. Returns true on success,
+  /// or false if the mutex is already locked. Not re-entrant.
   inline bool try_lock() noexcept { return tmc::detail::try_acquire(value); }
 
   /// Tries to acquire the mutex. If it is locked by another task, will

--- a/include/tmc/rw_lock.hpp
+++ b/include/tmc/rw_lock.hpp
@@ -1,0 +1,335 @@
+// Copyright (c) 2023-2026 Logan McDougall
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+#include "tmc/detail/impl.hpp" // IWYU pragma: keep
+
+#include "tmc/detail/concepts_awaitable.hpp"
+#include "tmc/detail/waiter_list.hpp"
+
+#include <atomic>
+#include <coroutine>
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+namespace tmc::tests {
+class waiter_count_accessor;
+}
+
+namespace tmc {
+class rw_lock;
+
+/// The read lock will be released when this goes out of scope.
+class [[nodiscard("The read lock will be released when this goes out of scope.")]]
+rw_lock_read_scope {
+  rw_lock* parent;
+
+  friend class aw_rw_lock_read_scope;
+
+  inline rw_lock_read_scope(rw_lock* Parent) noexcept : parent(Parent) {}
+
+public:
+  // Movable but not copyable
+  rw_lock_read_scope(rw_lock_read_scope const&) = delete;
+  rw_lock_read_scope& operator=(rw_lock_read_scope const&) = delete;
+  inline rw_lock_read_scope(rw_lock_read_scope&& Other) noexcept {
+    parent = Other.parent;
+    Other.parent = nullptr;
+  }
+  rw_lock_read_scope& operator=(rw_lock_read_scope&& Other) = delete;
+
+  /// Releases the read lock on destruction. Does not symmetric transfer.
+  TMC_DECL ~rw_lock_read_scope();
+};
+
+/// The write lock will be released when this goes out of scope.
+class [[nodiscard("The write lock will be released when this goes out of scope.")]]
+rw_lock_write_scope {
+  rw_lock* parent;
+
+  friend class aw_rw_lock_write_scope;
+
+  inline rw_lock_write_scope(rw_lock* Parent) noexcept : parent(Parent) {}
+
+public:
+  // Movable but not copyable
+  rw_lock_write_scope(rw_lock_write_scope const&) = delete;
+  rw_lock_write_scope& operator=(rw_lock_write_scope const&) = delete;
+  inline rw_lock_write_scope(rw_lock_write_scope&& Other) noexcept {
+    parent = Other.parent;
+    Other.parent = nullptr;
+  }
+  rw_lock_write_scope& operator=(rw_lock_write_scope&& Other) = delete;
+
+  /// Releases the write lock on destruction. Does not symmetric transfer.
+  TMC_DECL ~rw_lock_write_scope();
+};
+
+// Common state shared by all four rw_lock awaiters. Same structure as
+// aw_acquire but `value` has different semantics.
+class aw_rw_lock_base : tmc::detail::AwaitTagNoGroupAsIs {
+protected:
+  tmc::detail::waiter_list_node me;
+  // parent is atomic to prevent use-after-resume. See waiter_list.ipp's
+  // aw_acquire::await_suspend for more info.
+  std::atomic<rw_lock*> parent;
+
+  inline aw_rw_lock_base(rw_lock& Parent) noexcept : parent(&Parent) {}
+
+public:
+  // Cannot be moved or copied due to holding intrusive list pointer
+  aw_rw_lock_base(aw_rw_lock_base const&) = delete;
+  aw_rw_lock_base& operator=(aw_rw_lock_base const&) = delete;
+  aw_rw_lock_base(aw_rw_lock_base&&) = delete;
+  aw_rw_lock_base& operator=(aw_rw_lock_base&&) = delete;
+};
+
+// Shared await_ready()/await_suspend() for read awaiters.
+class aw_rw_lock_read_base : public aw_rw_lock_base {
+protected:
+  inline aw_rw_lock_read_base(rw_lock& Parent) noexcept : aw_rw_lock_base(Parent) {}
+
+public:
+  TMC_DECL bool await_ready() noexcept;
+
+  TMC_DECL void await_suspend(std::coroutine_handle<> Outer) noexcept;
+};
+
+// Shared await_ready()/await_suspend() for write awaiters.
+class aw_rw_lock_write_base : public aw_rw_lock_base {
+protected:
+  inline aw_rw_lock_write_base(rw_lock& Parent) noexcept : aw_rw_lock_base(Parent) {}
+
+public:
+  TMC_DECL bool await_ready() noexcept;
+
+  TMC_DECL void await_suspend(std::coroutine_handle<> Outer) noexcept;
+};
+
+class [[nodiscard("You must co_await aw_rw_lock_read for it to have any effect.")]]
+aw_rw_lock_read : public aw_rw_lock_read_base {
+  friend class rw_lock;
+
+  inline aw_rw_lock_read(rw_lock& Parent) noexcept : aw_rw_lock_read_base(Parent) {}
+
+public:
+  inline void await_resume() noexcept {}
+};
+
+class [[nodiscard("You must co_await aw_rw_lock_write for it to have any effect.")]]
+aw_rw_lock_write : public aw_rw_lock_write_base {
+  friend class rw_lock;
+
+  inline aw_rw_lock_write(rw_lock& Parent) noexcept : aw_rw_lock_write_base(Parent) {}
+
+public:
+  inline void await_resume() noexcept {}
+};
+
+/// Same as aw_rw_lock_read but returns a nodiscard rw_lock_read_scope that
+/// releases the read lock on destruction.
+class [[nodiscard("You must co_await aw_rw_lock_read_scope for it to have any effect.")]]
+aw_rw_lock_read_scope : public aw_rw_lock_read_base {
+  friend class rw_lock;
+
+  inline aw_rw_lock_read_scope(rw_lock& Parent) noexcept : aw_rw_lock_read_base(Parent) {}
+
+public:
+  [[nodiscard]] inline rw_lock_read_scope await_resume() noexcept {
+    return rw_lock_read_scope(parent.load(std::memory_order_relaxed));
+  }
+};
+
+/// Same as aw_rw_lock_write but returns a nodiscard rw_lock_write_scope that
+/// releases the write lock on destruction.
+class [[nodiscard("You must co_await aw_rw_lock_write_scope for it to have any effect.")]]
+aw_rw_lock_write_scope : public aw_rw_lock_write_base {
+  friend class rw_lock;
+
+  inline aw_rw_lock_write_scope(rw_lock& Parent) noexcept
+      : aw_rw_lock_write_base(Parent) {}
+
+public:
+  [[nodiscard]] inline rw_lock_write_scope await_resume() noexcept {
+    return rw_lock_write_scope(parent.load(std::memory_order_relaxed));
+  }
+};
+
+/// An async reader-writer lock (a.k.a. std::shared_mutex). Any number of
+/// readers may hold the lock simultaneously, or one writer may hold it
+/// exclusively. Tasks that cannot acquire the lock immediately will suspend,
+/// and be resumed when the lock is transferred to them. All operations are
+/// implemented with lock-free atomics; no operation ever blocks or spins.
+///
+/// Phase-fair policy (neither readers nor writers can starve):
+/// - New readers can acquire the lock immediately only if no writer holds it
+///   and no writers are waiting. If a writer is waiting, new readers queue
+///   behind it.
+/// - When the last reader releases the lock, the longest-waiting writer is
+///   woken and the lock is transferred to it.
+/// - When a writer releases the lock, all currently-waiting readers are woken
+///   as a batch. If no readers are waiting, the next writer is woken instead.
+///
+/// The reader count, waiting reader count, and waiting writer count are each
+/// packed into (STATE_BITS - 2) / 3 bits of a single atomic word. When 64-bit atomics are
+/// available, a 64-bit word is used, so none of these may exceed 1048575. Otherwise,
+/// falls back to a size_t word; on a 32-bit platform that reduces each field to 10 bits
+/// (max 1023).
+class rw_lock {
+  friend class aw_rw_lock_read;
+  friend class aw_rw_lock_write;
+  friend class aw_rw_lock_read_scope;
+  friend class aw_rw_lock_write_scope;
+  friend class aw_rw_lock_read_base;
+  friend class aw_rw_lock_write_base;
+  friend class ::tmc::tests::waiter_count_accessor;
+
+  // Prefer a 64-bit state when possible. This includes on 32-bit x86 (which has
+  // cmpxchg8b). Otherwise, fallback to a 32-bit state, which limits each count
+  // to 10 bits.
+  using state_t =
+    std::conditional_t<std::atomic<uint64_t>::is_always_lock_free, uint64_t, size_t>;
+  static inline constexpr state_t STATE_ONE = static_cast<state_t>(1);
+  static inline constexpr size_t STATE_BITS = 8 * sizeof(state_t);
+
+  // Bit 0: WAKING - a lock bit for waiter consumption.
+  // Bit 1: WRITER - set if a writer holds the lock.
+  // The remaining bits are divided into 3 equal fields:
+  // active readers, waiting readers, and waiting writers.
+  //
+  // Logically there are 2x2 counts: (reader, writer) x (waiting, active),
+  // with the active writer count limited to a max of 1 / single bit.
+  static inline constexpr state_t WRITER = STATE_ONE << 1;
+  static inline constexpr state_t WAKING = STATE_ONE;
+  static inline constexpr size_t FIELD_BITS = (STATE_BITS - 2) / 3;
+  static inline constexpr state_t FIELD_MASK = (STATE_ONE << FIELD_BITS) - STATE_ONE;
+  static inline constexpr size_t READERS_OFFSET = 2;
+  static inline constexpr size_t READ_WAITERS_OFFSET = READERS_OFFSET + FIELD_BITS;
+  static inline constexpr size_t WRITE_WAITERS_OFFSET = READ_WAITERS_OFFSET + FIELD_BITS;
+  static inline constexpr state_t READERS_ONE = STATE_ONE << READERS_OFFSET;
+  static inline constexpr state_t READ_WAITERS_ONE = STATE_ONE << READ_WAITERS_OFFSET;
+  static inline constexpr state_t WRITE_WAITERS_ONE = STATE_ONE << WRITE_WAITERS_OFFSET;
+
+  static inline state_t unpack_readers(state_t V) noexcept {
+    return (V >> READERS_OFFSET) & FIELD_MASK;
+  }
+  static inline state_t unpack_read_waiters(state_t V) noexcept {
+    return (V >> READ_WAITERS_OFFSET) & FIELD_MASK;
+  }
+  static inline state_t unpack_write_waiters(state_t V) noexcept {
+    return (V >> WRITE_WAITERS_OFFSET) & FIELD_MASK;
+  }
+
+  // Returns true if a wake handoff is possible and no other thread is already performing
+  // one. A writer can be woken if the lock is fully released. Waiting readers can be
+  // woken if no writer holds or is waiting for the lock. If readers are active, and both
+  // writers and readers are waiting, we intentionally do not wake additional readers;
+  // instead drain all active readers so the writer can be woken.
+  static inline bool can_wake(state_t V) noexcept {
+    if ((V & (WRITER | WAKING)) != 0) {
+      return false;
+    }
+    return (unpack_readers(V) == 0 && unpack_write_waiters(V) > 0) ||
+           (unpack_write_waiters(V) == 0 && unpack_read_waiters(V) > 0);
+  }
+
+  tmc::detail::waiter_list read_waiters;
+  tmc::detail::waiter_list write_waiters;
+  std::atomic<state_t> value{0};
+
+  // Registers Outer as a waiting reader and wakes waiters if a release
+  // happened concurrently.
+  TMC_DECL void suspend_read(
+    tmc::detail::waiter_list_node& Node, std::coroutine_handle<> Outer
+  ) noexcept;
+
+  // Registers Outer as a waiting writer and wakes waiters if a release
+  // happened concurrently.
+  TMC_DECL void suspend_write(
+    tmc::detail::waiter_list_node& Node, std::coroutine_handle<> Outer
+  ) noexcept;
+
+  // If V represents a wakeable state, tries to claim the WAKING bit and
+  // transfer the lock to one or more waiters. PreferWriters controls which
+  // kind of waiter is woken when both readers amd writers are waiting.
+  template <bool PreferWriters> void try_wake(state_t V) noexcept;
+
+  // Returns the number of awaiters currently registered (suspended and
+  // waiting to acquire, in either mode) on this lock. For testing purposes.
+  // Thread-safe.
+  inline size_t waiter_count() noexcept {
+    state_t v = value.load(std::memory_order_acquire);
+    return static_cast<size_t>(unpack_read_waiters(v) + unpack_write_waiters(v));
+  }
+
+public:
+  /// The lock begins in the fully unlocked state.
+  rw_lock() noexcept = default;
+
+  /// Returns true if some task is holding the write lock.
+  /// This value is not guaranteed to be consistent with any other operation.
+  inline bool is_write_locked() noexcept {
+    return 0 != (WRITER & value.load(std::memory_order_relaxed));
+  }
+
+  /// Returns the number of tasks currently holding the read lock.
+  /// This value is not guaranteed to be consistent with any other operation.
+  inline size_t reader_count() noexcept {
+    return static_cast<size_t>(unpack_readers(value.load(std::memory_order_relaxed)));
+  }
+
+  /// Tries to acquire the read lock without suspending. Returns true on
+  /// success. Returns false if a writer holds the lock or any writers are
+  /// waiting. Not re-entrant.
+  TMC_DECL bool try_lock_read() noexcept;
+
+  /// Tries to acquire the write lock without suspending. Returns true on
+  /// success. Returns false if the lock is held in any mode. Not re-entrant.
+  TMC_DECL bool try_lock_write() noexcept;
+
+  /// Tries to acquire the read lock. If a writer is holding or waiting for
+  /// the lock, will suspend until the read lock can be acquired by this task.
+  /// Multiple tasks may hold the read lock simultaneously. Not re-entrant.
+  inline aw_rw_lock_read lock_read() noexcept { return aw_rw_lock_read(*this); }
+
+  /// Tries to acquire the write lock. If the lock is held by any other task,
+  /// will suspend until the write lock can be acquired exclusively by this
+  /// task. Not re-entrant.
+  inline aw_rw_lock_write lock_write() noexcept { return aw_rw_lock_write(*this); }
+
+  /// Same as lock_read(), but returns an object that will release the read
+  /// lock (and resume awaiters) when it goes out of scope. Not re-entrant.
+  inline aw_rw_lock_read_scope lock_read_scope() noexcept {
+    return aw_rw_lock_read_scope(*this);
+  }
+
+  /// Same as lock_write(), but returns an object that will release the write
+  /// lock (and resume awaiters) when it goes out of scope. Not re-entrant.
+  inline aw_rw_lock_write_scope lock_write_scope() noexcept {
+    return aw_rw_lock_write_scope(*this);
+  }
+
+  /// Releases the read lock. If this was the last reader and writers are
+  /// waiting, a writer will be resumed and the write lock will be transferred
+  /// to it. Does not symmetric transfer; the awaiter will be posted to its
+  /// executor.
+  TMC_DECL void unlock_read() noexcept;
+
+  /// Releases the write lock. If readers are waiting, all of them will be
+  /// resumed and the read lock will be transferred to them. Otherwise, if
+  /// writers are waiting, one writer will be resumed and the write lock will
+  /// be transferred to it. Does not symmetric transfer; awaiters will be
+  /// posted to their executors.
+  TMC_DECL void unlock_write() noexcept;
+
+  /// On destruction, any awaiters will be resumed.
+  TMC_DECL ~rw_lock();
+};
+} // namespace tmc
+
+#if !defined(TMC_STANDALONE_COMPILATION) || defined(TMC_IMPL)
+#include "tmc/detail/rw_lock.ipp"
+#endif

--- a/include/tmc/semaphore.hpp
+++ b/include/tmc/semaphore.hpp
@@ -254,7 +254,7 @@ public:
   }
 
   /// Tries to acquire 1 resource from the semaphore without suspending.
-  /// Returns true if acquired, or false if no resources are ready. Not
+  /// Returns true on success, or false if no resources are ready. Not
   /// re-entrant.
   inline bool try_acquire() noexcept { return tmc::detail::try_acquire(value); }
 


### PR DESCRIPTION
Uses a phase-fair algorithm which prevents readers or writers from being starved:
- If no writers are waiting, readers can continue to acquire and release the lock freely.
- Once a writer starts waiting, no new readers can acquire the lock. New readers are instead queued. After all existing readers release the lock, 1 writer will be woken.
- After the single writer finishes, if there are readers waiting, they will all be woken in a single batch. Otherwise, if there are more writers waiting, another writer will be woken.

Methods:
- `try_lock_read()`
- `co_await lock_read()`
- `co_await lock_read_scope()`
- `unlock_read()`
- `try_lock_write()`
- `co_await lock_write()`
- `co_await lock_write_scope()`
- `unlock_write()`
- `is_write_locked()`
- `reader_count()`