### PR TITLE
remove dead code

### DIFF
--- a/.github/workflows/arm64-macos-clang-ubsan.yml
+++ b/.github/workflows/arm64-macos-clang-ubsan.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: macos-15
     strategy:
       matrix:
-        PRESET: [clang-macos-debug, clang-macos-release]
+        PRESET: [clang-macos-debug]
         WORK_ITEM: [CORO, FUNCORO]
     steps:
     - name: install-hwloc

--- a/include/tmc/detail/waiter_list.ipp
+++ b/include/tmc/detail/waiter_list.ipp
@@ -7,7 +7,6 @@
 
 #include "tmc/detail/impl.hpp" // IWYU pragma: keep
 
-#include "tmc/current.hpp"
 #include "tmc/detail/thread_locals.hpp"
 #include "tmc/detail/waiter_list.hpp"
 
@@ -44,9 +43,8 @@ void waiter_list_waiter::resume() noexcept {
   );
 }
 
-std::coroutine_handle<> waiter_list_waiter::try_symmetric_transfer(
-  std::coroutine_handle<> Outer
-) noexcept {
+std::coroutine_handle<>
+waiter_list_waiter::try_symmetric_transfer(std::coroutine_handle<> Outer) noexcept {
   if (tmc::detail::this_thread::exec_prio_is(
         continuation_executor, continuation_priority
       )) {
@@ -81,8 +79,8 @@ reverse_chain(tmc::detail::waiter_list_node* curr) noexcept {
 } // namespace
 
 std::coroutine_handle<> try_symmetric_transfer2_waiter(
-  waiter_list_waiter* ToWake, std::coroutine_handle<> Continuation,
-  tmc::ex_any* Executor, size_t Priority
+  waiter_list_waiter* ToWake, std::coroutine_handle<> Continuation, tmc::ex_any* Executor,
+  size_t Priority
 ) noexcept {
   if (ToWake != nullptr) {
     std::coroutine_handle<> toContinuation = ToWake->continuation;
@@ -97,9 +95,7 @@ std::coroutine_handle<> try_symmetric_transfer2_waiter(
     }
 
     // Transfer to primary disallowed
-    tmc::detail::post_checked(
-      toExecutor, std::move(toContinuation), toPriority
-    );
+    tmc::detail::post_checked(toExecutor, std::move(toContinuation), toPriority);
   }
 
   if (Continuation != nullptr) {
@@ -119,8 +115,7 @@ void waiter_list::configure_and_add_waiter(
 ) noexcept {
   Node.waiter.continuation = Outer;
   Node.waiter.continuation_executor = tmc::detail::this_thread::executor();
-  Node.waiter.continuation_priority =
-    tmc::detail::this_thread::this_task().prio;
+  Node.waiter.continuation_priority = tmc::detail::this_thread::this_task().prio;
 
   auto h = input.load(std::memory_order_acquire);
   do {
@@ -298,9 +293,7 @@ bool try_acquire(std::atomic<size_t>& Value) noexcept {
 } // namespace detail
 
 bool aw_acquire::await_ready() noexcept {
-  return tmc::detail::try_acquire(
-    parent.load(std::memory_order_relaxed)->value
-  );
+  return tmc::detail::try_acquire(parent.load(std::memory_order_relaxed)->value);
 }
 
 void aw_acquire::await_suspend(std::coroutine_handle<> Outer) noexcept {

--- a/include/tmc/qu_mpsc_unbounded.hpp
+++ b/include/tmc/qu_mpsc_unbounded.hpp
@@ -67,8 +67,7 @@ class qu_mpsc_unbounded {
   static inline constexpr size_t BlockSizeMask = BlockSize - 1;
   static inline constexpr bool ConsumerCanSuspend = Config::ConsumerCanSuspend;
   static_assert(
-    BlockSize && ((BlockSize & (BlockSize - 1)) == 0),
-    "BlockSize must be a power of 2"
+    BlockSize && ((BlockSize & (BlockSize - 1)) == 0), "BlockSize must be a power of 2"
   );
 
   // Ensure that the subtraction of unsigned offsets always results in a value
@@ -102,16 +101,14 @@ class qu_mpsc_unbounded {
 
     static constexpr size_t UNPADLEN =
       sizeof(std::atomic<void*>) + sizeof(tmc::detail::qu_storage<T>);
-    static constexpr size_t WANTLEN = (UNPADLEN + TMC_CACHE_LINE_SIZE - 1) &
-                                      static_cast<size_t>(
-                                        0 - TMC_CACHE_LINE_SIZE
-                                      ); // round up to TMC_CACHE_LINE_SIZE
-    static constexpr size_t PADLEN =
-      UNPADLEN < WANTLEN ? (WANTLEN - UNPADLEN) : 999;
+    static constexpr size_t WANTLEN =
+      (UNPADLEN + TMC_CACHE_LINE_SIZE - 1) &
+      static_cast<size_t>(0 - TMC_CACHE_LINE_SIZE); // round up to TMC_CACHE_LINE_SIZE
+    static constexpr size_t PADLEN = UNPADLEN < WANTLEN ? (WANTLEN - UNPADLEN) : 999;
 
     struct empty {};
-    using Padding = std::conditional_t<
-      Config::PackingLevel == 0 && PADLEN != 999, char[PADLEN], empty>;
+    using Padding =
+      std::conditional_t<Config::PackingLevel == 0 && PADLEN != 999, char[PADLEN], empty>;
     TMC_NO_UNIQUE_ADDRESS Padding pad;
 
     // Attempts to install Cons as a waiting consumer.
@@ -130,9 +127,8 @@ class qu_mpsc_unbounded {
     consumer_base* set_data_ready_or_get_waiting_consumer() noexcept
       requires(ConsumerCanSuspend)
     {
-      void* prev = flags.exchange(
-        reinterpret_cast<void*>(DATA_BIT), std::memory_order_acq_rel
-      );
+      void* prev =
+        flags.exchange(reinterpret_cast<void*>(DATA_BIT), std::memory_order_acq_rel);
       return static_cast<consumer_base*>(prev);
     }
 
@@ -146,9 +142,8 @@ class qu_mpsc_unbounded {
     // waiting, its consumer_base pointer is returned so the caller can wake it.
     // Used only by close() to mark the cutoff slot.
     consumer_base* set_closed_or_get_waiting_consumer() noexcept {
-      void* prev = flags.exchange(
-        reinterpret_cast<void*>(CLOSED_BIT), std::memory_order_acq_rel
-      );
+      void* prev =
+        flags.exchange(reinterpret_cast<void*>(CLOSED_BIT), std::memory_order_acq_rel);
       if (reinterpret_cast<uintptr_t>(prev) < 4) {
         return nullptr;
       }
@@ -158,11 +153,6 @@ class qu_mpsc_unbounded {
     bool is_data_waiting() noexcept {
       void* f = flags.load(std::memory_order_acquire);
       return DATA_BIT == reinterpret_cast<uintptr_t>(f);
-    }
-
-    bool is_closed_sentinel() noexcept {
-      void* f = flags.load(std::memory_order_acquire);
-      return CLOSED_BIT == reinterpret_cast<uintptr_t>(f);
     }
 
     // Returns the raw flags value: DATA_BIT, CLOSED_BIT, or 0 (meaning empty).
@@ -218,8 +208,7 @@ class qu_mpsc_unbounded {
   char pad2[TMC_CACHE_LINE_SIZE - sizeof(void*)];
 
   struct empty {};
-  using EmbeddedBlock =
-    std::conditional_t<Config::EmbedFirstBlock, data_block, empty>;
+  using EmbeddedBlock = std::conditional_t<Config::EmbedFirstBlock, data_block, empty>;
   TMC_NO_UNIQUE_ADDRESS EmbeddedBlock embedded_block;
 
 public:
@@ -261,8 +250,8 @@ public:
     try_pull_zc_scope& operator=(const try_pull_zc_scope&) = delete;
 
     try_pull_zc_scope(try_pull_zc_scope&& Other) noexcept
-        : queue{Other.queue}, elem{Other.elem}, block{Other.block},
-          idx{Other.idx}, err{Other.err} {
+        : queue{Other.queue}, elem{Other.elem}, block{Other.block}, idx{Other.idx},
+          err{Other.err} {
       Other.elem = nullptr;
       Other.err = tmc::qu_mpsc_unbounded_err::EMPTY;
     }
@@ -335,15 +324,13 @@ public:
 
   public:
     /// Constructs an empty scope. Evaluates to false when converted to bool.
-    pull_zc_scope() noexcept
-        : queue{nullptr}, elem{nullptr}, block{nullptr}, idx{0} {}
+    pull_zc_scope() noexcept : queue{nullptr}, elem{nullptr}, block{nullptr}, idx{0} {}
 
     pull_zc_scope(const pull_zc_scope&) = delete;
     pull_zc_scope& operator=(const pull_zc_scope&) = delete;
 
     pull_zc_scope(pull_zc_scope&& Other) noexcept
-        : queue{Other.queue}, elem{Other.elem}, block{Other.block},
-          idx{Other.idx} {
+        : queue{Other.queue}, elem{Other.elem}, block{Other.block}, idx{Other.idx} {
       Other.elem = nullptr;
     }
 
@@ -447,14 +434,11 @@ private:
       }
       // Actually unlink the blocks from the head of the queue.
       // They stay linked to each other.
-      unlinked[unlinkedCount - 1]->next.store(
-        nullptr, std::memory_order_release
-      );
+      unlinked[unlinkedCount - 1]->next.store(nullptr, std::memory_order_release);
 
       while (true) {
         // Update their offsets to the end of the queue.
-        size_t boff =
-          tailBlock->offset.load(std::memory_order_relaxed) + BlockSize;
+        size_t boff = tailBlock->offset.load(std::memory_order_relaxed) + BlockSize;
         for (size_t i = 0; i < unlinkedCount; ++i) {
           unlinked[i]->offset.store(boff, std::memory_order_relaxed);
           boff += BlockSize;
@@ -462,8 +446,7 @@ private:
 
         // Re-link the tail of the queue to the head of the unlinked blocks.
         if (tailBlock->next.compare_exchange_strong(
-              next, unlinked[0], std::memory_order_acq_rel,
-              std::memory_order_acquire
+              next, unlinked[0], std::memory_order_acq_rel, std::memory_order_acquire
             )) {
           break;
         }
@@ -490,8 +473,7 @@ private:
       if (next == nullptr) {
         data_block* newBlock = new data_block(offset + BlockSize);
         if (Block->next.compare_exchange_strong(
-              next, newBlock, std::memory_order_acq_rel,
-              std::memory_order_acquire
+              next, newBlock, std::memory_order_acq_rel, std::memory_order_acquire
             )) {
           next = newBlock;
         } else {
@@ -512,18 +494,15 @@ private:
 
   static inline bool block_before(data_block* A, data_block* B) noexcept {
     return circular_less_than(
-      A->offset.load(std::memory_order_relaxed),
-      B->offset.load(std::memory_order_relaxed)
+      A->offset.load(std::memory_order_relaxed), B->offset.load(std::memory_order_relaxed)
     );
   }
 
-  void advance_write_block_hint_at_least(
-    data_block* Current, data_block* Target
-  ) noexcept {
+  void
+  advance_write_block_hint_at_least(data_block* Current, data_block* Target) noexcept {
     while (block_before(Current, Target)) {
       if (write_block_hint.compare_exchange_weak(
-            Current, Target, std::memory_order_seq_cst,
-            std::memory_order_seq_cst
+            Current, Target, std::memory_order_seq_cst, std::memory_order_seq_cst
           )) {
         return;
       }
@@ -538,16 +517,12 @@ private:
 
   data_block* get_mpsc_write_start_block(size_t Idx) noexcept {
     data_block* block = write_block_hint.load(std::memory_order_seq_cst);
-    if (!circular_less_than(
-          block->offset.load(std::memory_order_relaxed), 1 + Idx
-        )) {
+    if (!circular_less_than(block->offset.load(std::memory_order_relaxed), 1 + Idx)) {
       // A later producer may have advanced the hint past this producer's
       // earlier reservation. Fall back to the consumer-managed reclaim
       // frontier, which cannot advance past an unproduced reservation.
       block = write_block.load(std::memory_order_seq_cst);
-      assert(circular_less_than(
-        block->offset.load(std::memory_order_relaxed), 1 + Idx
-      ));
+      assert(circular_less_than(block->offset.load(std::memory_order_relaxed), 1 + Idx));
     }
     return block;
   }
@@ -626,18 +601,14 @@ private:
       while (!closed_ready.load(std::memory_order_acquire)) {
         TMC_CPU_PAUSE();
       }
-      if (circular_less_than(
-            write_closed_at.load(std::memory_order_acquire), 1 + Idx
-          )) {
+      if (circular_less_than(write_closed_at.load(std::memory_order_acquire), 1 + Idx)) {
         return nullptr;
       }
     }
 
     data_block* observed = get_mpsc_write_start_block(Idx);
 
-    assert(circular_less_than(
-      observed->offset.load(std::memory_order_relaxed), 1 + Idx
-    ));
+    assert(circular_less_than(observed->offset.load(std::memory_order_relaxed), 1 + Idx));
 
     data_block* block = find_block(observed, Idx);
     advance_write_block_hint_at_least(observed, block);
@@ -649,9 +620,7 @@ private:
     Idx = read_offset;
     Block = read_block;
 
-    assert(
-      circular_less_than(Block->offset.load(std::memory_order_relaxed), 1 + Idx)
-    );
+    assert(circular_less_than(Block->offset.load(std::memory_order_relaxed), 1 + Idx));
 
     Block = find_block(Block, Idx);
     return &Block->values[Idx & BlockSizeMask];
@@ -671,8 +640,7 @@ private:
   }
 
   template <typename... Args>
-  consumer_base*
-  write_element(element* Elem, Args&&... ConstructArgs) noexcept {
+  consumer_base* write_element(element* Elem, Args&&... ConstructArgs) noexcept {
     Elem->data.emplace(static_cast<Args&&>(ConstructArgs)...);
     if constexpr (ConsumerCanSuspend) {
       return Elem->set_data_ready_or_get_waiting_consumer();
@@ -697,9 +665,8 @@ private:
   // that case. Because close() takes a single fetch_add cutoff, a bulk
   // reservation cannot straddle the cutoff: it is either all pre-close or
   // all post-close in the seq_cst total order on write_offset.
-  data_block* get_write_ticket_bulk(
-    size_t Count, size_t& StartIdx, size_t& EndIdx
-  ) noexcept {
+  data_block*
+  get_write_ticket_bulk(size_t Count, size_t& StartIdx, size_t& EndIdx) noexcept {
     // seq_cst here serves the same purpose as in get_write_ticket: it orders
     // the reader's reclaim cutoff AND forms the producer side of the close
     // protocol (RMW-chain from close()'s release store to `closed`).
@@ -719,9 +686,9 @@ private:
 
     data_block* observed = get_mpsc_write_start_block(StartIdx);
 
-    assert(circular_less_than(
-      observed->offset.load(std::memory_order_relaxed), 1 + StartIdx
-    ));
+    assert(
+      circular_less_than(observed->offset.load(std::memory_order_relaxed), 1 + StartIdx)
+    );
 
     // Ensure all blocks for the operation are allocated and available.
     data_block* startBlock = find_block(observed, StartIdx);
@@ -753,8 +720,7 @@ public:
       return false;
     }
 
-    consumer_base* cons =
-      write_element(elem, static_cast<Args&&>(ConstructArgs)...);
+    consumer_base* cons = write_element(elem, static_cast<Args&&>(ConstructArgs)...);
     notify_consumer(cons);
     return true;
   }
@@ -777,9 +743,7 @@ public:
     // Implementing handling for throwing construction is not possible with the
     // current design. This assert will also fire if no matching constructor can
     // be found for the iterator's dereferenced value.
-    static_assert(
-      std::is_nothrow_constructible_v<T, decltype(std::move(*Items))>
-    );
+    static_assert(std::is_nothrow_constructible_v<T, decltype(std::move(*Items))>);
 
     if (Count == 0) [[unlikely]] {
       return true;
@@ -832,12 +796,8 @@ public:
     // Implementing handling for throwing construction is not possible with the
     // current design. This assert will also fire if no matching constructor can
     // be found for the iterator's dereferenced value.
-    static_assert(
-      std::is_nothrow_constructible_v<T, decltype(std::move(*Begin))>
-    );
-    return post_bulk(
-      static_cast<It&&>(Begin), static_cast<size_t>(End - Begin)
-    );
+    static_assert(std::is_nothrow_constructible_v<T, decltype(std::move(*Begin))>);
+    return post_bulk(static_cast<It&&>(Begin), static_cast<size_t>(End - Begin));
   }
 
   /// Calculates the number of elements via

--- a/include/tmc/qu_spsc_bounded.hpp
+++ b/include/tmc/qu_spsc_bounded.hpp
@@ -84,16 +84,14 @@ class qu_spsc_bounded {
 
     static constexpr size_t UNPADLEN =
       sizeof(std::atomic<void*>) + sizeof(tmc::detail::qu_storage<T>);
-    static constexpr size_t WANTLEN = (UNPADLEN + TMC_CACHE_LINE_SIZE - 1) &
-                                      static_cast<size_t>(
-                                        0 - TMC_CACHE_LINE_SIZE
-                                      ); // round up to TMC_CACHE_LINE_SIZE
-    static constexpr size_t PADLEN =
-      UNPADLEN < WANTLEN ? (WANTLEN - UNPADLEN) : 999;
+    static constexpr size_t WANTLEN =
+      (UNPADLEN + TMC_CACHE_LINE_SIZE - 1) &
+      static_cast<size_t>(0 - TMC_CACHE_LINE_SIZE); // round up to TMC_CACHE_LINE_SIZE
+    static constexpr size_t PADLEN = UNPADLEN < WANTLEN ? (WANTLEN - UNPADLEN) : 999;
 
     struct empty {};
-    using Padding = std::conditional_t<
-      Config::PackingLevel == 0 && PADLEN != 999, char[PADLEN], empty>;
+    using Padding =
+      std::conditional_t<Config::PackingLevel == 0 && PADLEN != 999, char[PADLEN], empty>;
     TMC_NO_UNIQUE_ADDRESS Padding pad;
 
     // Attempts to install Cons as a waiting consumer via CAS(nullptr → Cons).
@@ -121,9 +119,8 @@ class qu_spsc_bounded {
     consumer_base* set_data_ready_or_get_waiting_consumer() noexcept
       requires(ConsumerCanSuspend)
     {
-      void* prev = flags.exchange(
-        reinterpret_cast<void*>(DATA_BIT), std::memory_order_acq_rel
-      );
+      void* prev =
+        flags.exchange(reinterpret_cast<void*>(DATA_BIT), std::memory_order_acq_rel);
       return static_cast<consumer_base*>(prev);
     }
 
@@ -157,11 +154,10 @@ class qu_spsc_bounded {
       void* expected = flags.load(std::memory_order_relaxed);
       while (true) {
         uintptr_t cur = reinterpret_cast<uintptr_t>(expected);
-        uintptr_t desired =
-          (cur == DATA_BIT) ? (DATA_BIT | CLOSED_BIT) : CLOSED_BIT;
+        uintptr_t desired = (cur == DATA_BIT) ? (DATA_BIT | CLOSED_BIT) : CLOSED_BIT;
         if (flags.compare_exchange_weak(
-              expected, reinterpret_cast<void*>(desired),
-              std::memory_order_acq_rel, std::memory_order_relaxed
+              expected, reinterpret_cast<void*>(desired), std::memory_order_acq_rel,
+              std::memory_order_relaxed
             )) {
           if (cur >= 4) {
             return static_cast<consumer_base*>(expected);
@@ -172,8 +168,7 @@ class qu_spsc_bounded {
     }
 
     bool is_data_waiting() noexcept {
-      uintptr_t v =
-        reinterpret_cast<uintptr_t>(flags.load(std::memory_order_acquire));
+      uintptr_t v = reinterpret_cast<uintptr_t>(flags.load(std::memory_order_acquire));
       // Data is present when DATA_BIT is set (possibly together with
       // CLOSED_BIT if close() ran while the slot still held data), or when
       // flags is a producer_base* (>= 4) meaning a producer is suspended
@@ -184,11 +179,6 @@ class qu_spsc_bounded {
       // cannot be waiting, and the destructor doesn't wake producers (it would
       // be unsafe for the destructor to race with a producer).
       return (v & DATA_BIT) != 0 || v >= 4;
-    }
-
-    bool is_closed_sentinel() noexcept {
-      void* f = flags.load(std::memory_order_acquire);
-      return CLOSED_BIT == reinterpret_cast<uintptr_t>(f);
     }
 
     // Returns the raw flags value: DATA_BIT, CLOSED_BIT, or 0 (meaning empty).
@@ -235,11 +225,8 @@ public:
     size_t idx;
     tmc::qu_spsc_bounded_err err;
 
-    try_pull_zc_scope(
-      qu_spsc_bounded* Queue, element* Elem, size_t Idx
-    ) noexcept
-        : queue{Queue}, elem{Elem}, idx{Idx},
-          err{tmc::qu_spsc_bounded_err::OK} {}
+    try_pull_zc_scope(qu_spsc_bounded* Queue, element* Elem, size_t Idx) noexcept
+        : queue{Queue}, elem{Elem}, idx{Idx}, err{tmc::qu_spsc_bounded_err::OK} {}
 
     explicit try_pull_zc_scope(tmc::qu_spsc_bounded_err Err) noexcept
         : queue{nullptr}, elem{nullptr}, idx{0}, err{Err} {}
@@ -248,8 +235,7 @@ public:
     /// Constructs an empty scope (status EMPTY). Evaluates to false when
     /// converted to bool.
     try_pull_zc_scope() noexcept
-        : queue{nullptr}, elem{nullptr}, idx{0},
-          err{tmc::qu_spsc_bounded_err::EMPTY} {}
+        : queue{nullptr}, elem{nullptr}, idx{0}, err{tmc::qu_spsc_bounded_err::EMPTY} {}
 
     try_pull_zc_scope(const try_pull_zc_scope&) = delete;
     try_pull_zc_scope& operator=(const try_pull_zc_scope&) = delete;
@@ -436,15 +422,12 @@ private:
       // same physical slot, its next pull/try_pull observes the closed
       // sentinel directly instead of suspending forever. No producer can be
       // waiting or race us here because close() forbids any further pushes.
-      Elem->flags.store(
-        reinterpret_cast<void*>(CLOSED_BIT), std::memory_order_release
-      );
+      Elem->flags.store(reinterpret_cast<void*>(CLOSED_BIT), std::memory_order_release);
     }
   }
 
   template <typename... Args>
-  consumer_base*
-  write_element(element* Elem, Args&&... ConstructArgs) noexcept {
+  consumer_base* write_element(element* Elem, Args&&... ConstructArgs) noexcept {
     Elem->data.emplace(static_cast<Args&&>(ConstructArgs)...);
     if constexpr (ConsumerCanSuspend) {
       return Elem->set_data_ready_or_get_waiting_consumer();
@@ -537,8 +520,7 @@ public:
     if (f == DATA_BIT) {
       return false;
     }
-    consumer_base* cons =
-      write_element(elem, static_cast<Args&&>(ConstructArgs)...);
+    consumer_base* cons = write_element(elem, static_cast<Args&&>(ConstructArgs)...);
     write_offset = idx + 1;
     if (cons != nullptr) {
       tmc::detail::post_checked(
@@ -567,8 +549,7 @@ public:
     "You must co_await push_bulk(). The values will not be enqueued "
     "until co_await."
   )]]
-  aw_push_bulk<std::remove_cvref_t<It>>
-  push_bulk(It&& Items, size_t Count) noexcept {
+  aw_push_bulk<std::remove_cvref_t<It>> push_bulk(It&& Items, size_t Count) noexcept {
     static_assert(
       std::is_nothrow_move_constructible_v<T>,
       "push_bulk moves values from the iterator into the queue; T must be "
@@ -579,9 +560,7 @@ public:
     // close() is a programming error.
     assert(!closed.load(std::memory_order_relaxed));
     assert(Count <= capacity);
-    return aw_push_bulk<std::remove_cvref_t<It>>(
-      *this, static_cast<It&&>(Items), Count
-    );
+    return aw_push_bulk<std::remove_cvref_t<It>>(*this, static_cast<It&&>(Items), Count);
   }
 
   /// Calculates the number of elements via `size_t Count = End - Begin;`
@@ -602,16 +581,13 @@ public:
     "You must co_await push_bulk(). The values will not be enqueued "
     "until co_await."
   )]]
-  aw_push_bulk<std::remove_cvref_t<It>>
-  push_bulk(It&& Begin, It&& End) noexcept {
+  aw_push_bulk<std::remove_cvref_t<It>> push_bulk(It&& Begin, It&& End) noexcept {
     static_assert(
       std::is_nothrow_move_constructible_v<T>,
       "push_bulk moves values from the iterator into the queue; T must be "
       "nothrow move constructible"
     );
-    return push_bulk(
-      static_cast<It&&>(Begin), static_cast<size_t>(End - Begin)
-    );
+    return push_bulk(static_cast<It&&>(Begin), static_cast<size_t>(End - Begin));
   }
 
   /// Calculates the number of elements via
@@ -812,8 +788,7 @@ public:
         queue.write_offset = idx + 1;
         if (cons != nullptr) {
           tmc::detail::post_checked(
-            cons->continuation_executor, std::move(cons->continuation),
-            cons->prio
+            cons->continuation_executor, std::move(cons->continuation), cons->prio
           );
         }
       }
@@ -911,9 +886,7 @@ public:
         for (size_t i = 1; i < count; ++i) {
           element* elem = &queue.values[(startIdx + i) % queue.capacity];
           elem->data.emplace(std::move(*items));
-          elem->flags.store(
-            reinterpret_cast<void*>(DATA_BIT), std::memory_order_relaxed
-          );
+          elem->flags.store(reinterpret_cast<void*>(DATA_BIT), std::memory_order_relaxed);
           ++items;
         }
 
@@ -929,17 +902,14 @@ public:
         queue.write_offset = startIdx + count;
         if (cons != nullptr) {
           tmc::detail::post_checked(
-            cons->continuation_executor, std::move(cons->continuation),
-            cons->prio
+            cons->continuation_executor, std::move(cons->continuation), cons->prio
           );
         }
       }
     };
 
   public:
-    aw_push_bulk_impl operator co_await() && noexcept {
-      return aw_push_bulk_impl(*this);
-    }
+    aw_push_bulk_impl operator co_await() && noexcept { return aw_push_bulk_impl(*this); }
   };
 
   /// Returns a `pull_zc_scope` when awaited.

--- a/include/tmc/qu_spsc_unbounded.hpp
+++ b/include/tmc/qu_spsc_unbounded.hpp
@@ -61,8 +61,7 @@ class qu_spsc_unbounded {
   static inline constexpr size_t BlockSizeMask = BlockSize - 1;
   static inline constexpr bool ConsumerCanSuspend = Config::ConsumerCanSuspend;
   static_assert(
-    BlockSize && ((BlockSize & (BlockSize - 1)) == 0),
-    "BlockSize must be a power of 2"
+    BlockSize && ((BlockSize & (BlockSize - 1)) == 0), "BlockSize must be a power of 2"
   );
 
   // Ensure that the subtraction of unsigned offsets always results in a value
@@ -96,16 +95,14 @@ class qu_spsc_unbounded {
 
     static constexpr size_t UNPADLEN =
       sizeof(std::atomic<void*>) + sizeof(tmc::detail::qu_storage<T>);
-    static constexpr size_t WANTLEN = (UNPADLEN + TMC_CACHE_LINE_SIZE - 1) &
-                                      static_cast<size_t>(
-                                        0 - TMC_CACHE_LINE_SIZE
-                                      ); // round up to TMC_CACHE_LINE_SIZE
-    static constexpr size_t PADLEN =
-      UNPADLEN < WANTLEN ? (WANTLEN - UNPADLEN) : 999;
+    static constexpr size_t WANTLEN =
+      (UNPADLEN + TMC_CACHE_LINE_SIZE - 1) &
+      static_cast<size_t>(0 - TMC_CACHE_LINE_SIZE); // round up to TMC_CACHE_LINE_SIZE
+    static constexpr size_t PADLEN = UNPADLEN < WANTLEN ? (WANTLEN - UNPADLEN) : 999;
 
     struct empty {};
-    using Padding = std::conditional_t<
-      Config::PackingLevel == 0 && PADLEN != 999, char[PADLEN], empty>;
+    using Padding =
+      std::conditional_t<Config::PackingLevel == 0 && PADLEN != 999, char[PADLEN], empty>;
     TMC_NO_UNIQUE_ADDRESS Padding pad;
 
     // Attempts to install Cons as a waiting consumer.
@@ -124,9 +121,8 @@ class qu_spsc_unbounded {
     consumer_base* set_data_ready_or_get_waiting_consumer() noexcept
       requires(ConsumerCanSuspend)
     {
-      void* prev = flags.exchange(
-        reinterpret_cast<void*>(DATA_BIT), std::memory_order_acq_rel
-      );
+      void* prev =
+        flags.exchange(reinterpret_cast<void*>(DATA_BIT), std::memory_order_acq_rel);
       return static_cast<consumer_base*>(prev);
     }
 
@@ -140,9 +136,8 @@ class qu_spsc_unbounded {
     // waiting, its consumer_base pointer is returned so the caller can wake it.
     // Used only by close() to mark the cutoff slot.
     consumer_base* set_closed_or_get_waiting_consumer() noexcept {
-      void* prev = flags.exchange(
-        reinterpret_cast<void*>(CLOSED_BIT), std::memory_order_acq_rel
-      );
+      void* prev =
+        flags.exchange(reinterpret_cast<void*>(CLOSED_BIT), std::memory_order_acq_rel);
       if (reinterpret_cast<uintptr_t>(prev) < 4) {
         return nullptr;
       }
@@ -152,11 +147,6 @@ class qu_spsc_unbounded {
     bool is_data_waiting() noexcept {
       void* f = flags.load(std::memory_order_acquire);
       return DATA_BIT == reinterpret_cast<uintptr_t>(f);
-    }
-
-    bool is_closed_sentinel() noexcept {
-      void* f = flags.load(std::memory_order_acquire);
-      return CLOSED_BIT == reinterpret_cast<uintptr_t>(f);
     }
 
     // Returns the raw flags value: DATA_BIT, CLOSED_BIT, or 0 (meaning empty).
@@ -205,8 +195,7 @@ class qu_spsc_unbounded {
   char pad2[TMC_CACHE_LINE_SIZE - sizeof(void*)];
 
   struct empty {};
-  using EmbeddedBlock =
-    std::conditional_t<Config::EmbedFirstBlock, data_block, empty>;
+  using EmbeddedBlock = std::conditional_t<Config::EmbedFirstBlock, data_block, empty>;
   TMC_NO_UNIQUE_ADDRESS EmbeddedBlock embedded_block;
 
 public:
@@ -248,8 +237,8 @@ public:
     try_pull_zc_scope& operator=(const try_pull_zc_scope&) = delete;
 
     try_pull_zc_scope(try_pull_zc_scope&& Other) noexcept
-        : queue{Other.queue}, elem{Other.elem}, block{Other.block},
-          idx{Other.idx}, err{Other.err} {
+        : queue{Other.queue}, elem{Other.elem}, block{Other.block}, idx{Other.idx},
+          err{Other.err} {
       Other.elem = nullptr;
       Other.err = tmc::qu_spsc_unbounded_err::EMPTY;
     }
@@ -322,15 +311,13 @@ public:
 
   public:
     /// Constructs an empty scope. Evaluates to false when converted to bool.
-    pull_zc_scope() noexcept
-        : queue{nullptr}, elem{nullptr}, block{nullptr}, idx{0} {}
+    pull_zc_scope() noexcept : queue{nullptr}, elem{nullptr}, block{nullptr}, idx{0} {}
 
     pull_zc_scope(const pull_zc_scope&) = delete;
     pull_zc_scope& operator=(const pull_zc_scope&) = delete;
 
     pull_zc_scope(pull_zc_scope&& Other) noexcept
-        : queue{Other.queue}, elem{Other.elem}, block{Other.block},
-          idx{Other.idx} {
+        : queue{Other.queue}, elem{Other.elem}, block{Other.block}, idx{Other.idx} {
       Other.elem = nullptr;
     }
 
@@ -428,14 +415,11 @@ private:
       }
       // Actually unlink the blocks from the head of the queue.
       // They stay linked to each other.
-      unlinked[unlinkedCount - 1]->next.store(
-        nullptr, std::memory_order_release
-      );
+      unlinked[unlinkedCount - 1]->next.store(nullptr, std::memory_order_release);
 
       while (true) {
         // Update their offsets to the end of the queue.
-        size_t boff =
-          tailBlock->offset.load(std::memory_order_relaxed) + BlockSize;
+        size_t boff = tailBlock->offset.load(std::memory_order_relaxed) + BlockSize;
         for (size_t i = 0; i < unlinkedCount; ++i) {
           unlinked[i]->offset.store(boff, std::memory_order_relaxed);
           boff += BlockSize;
@@ -443,8 +427,7 @@ private:
 
         // Re-link the tail of the queue to the head of the unlinked blocks.
         if (tailBlock->next.compare_exchange_strong(
-              next, unlinked[0], std::memory_order_acq_rel,
-              std::memory_order_acquire
+              next, unlinked[0], std::memory_order_acq_rel, std::memory_order_acquire
             )) {
           break;
         }
@@ -471,8 +454,7 @@ private:
       if (next == nullptr) {
         data_block* newBlock = new data_block(offset + BlockSize);
         if (Block->next.compare_exchange_strong(
-              next, newBlock, std::memory_order_acq_rel,
-              std::memory_order_acquire
+              next, newBlock, std::memory_order_acq_rel, std::memory_order_acquire
             )) {
           next = newBlock;
         } else {
@@ -505,8 +487,7 @@ private:
         if (next == nullptr) {
           data_block* newBlock = new data_block(offset + BlockSize);
           if (block->next.compare_exchange_strong(
-                next, newBlock, std::memory_order_acq_rel,
-                std::memory_order_acquire
+                next, newBlock, std::memory_order_acq_rel, std::memory_order_acquire
               )) {
             next = newBlock;
           } else {
@@ -559,9 +540,7 @@ private:
     Idx = read_offset;
     Block = head_block;
 
-    assert(
-      circular_less_than(Block->offset.load(std::memory_order_relaxed), 1 + Idx)
-    );
+    assert(circular_less_than(Block->offset.load(std::memory_order_relaxed), 1 + Idx));
 
     Block = find_block(Block, Idx);
     return &Block->values[Idx & BlockSizeMask];
@@ -580,8 +559,7 @@ private:
   }
 
   template <typename... Args>
-  consumer_base*
-  write_element(element* Elem, Args&&... ConstructArgs) noexcept {
+  consumer_base* write_element(element* Elem, Args&&... ConstructArgs) noexcept {
     Elem->data.emplace(static_cast<Args&&>(ConstructArgs)...);
     if constexpr (ConsumerCanSuspend) {
       return Elem->set_data_ready_or_get_waiting_consumer();
@@ -593,18 +571,17 @@ private:
 
   // StartIdx and EndIdx will be initialized by this function.
   // Count must be non-zero (enforced by the caller).
-  data_block* get_write_ticket_bulk(
-    size_t Count, size_t& StartIdx, size_t& EndIdx
-  ) noexcept {
+  data_block*
+  get_write_ticket_bulk(size_t Count, size_t& StartIdx, size_t& EndIdx) noexcept {
     // In SPSC mode, write_offset is published after all elements in the bulk
     // operation have been written.
     StartIdx = write_offset;
     EndIdx = StartIdx + Count;
     data_block* block = write_block.load(std::memory_order_relaxed);
 
-    assert(circular_less_than(
-      block->offset.load(std::memory_order_relaxed), 1 + StartIdx
-    ));
+    assert(
+      circular_less_than(block->offset.load(std::memory_order_relaxed), 1 + StartIdx)
+    );
 
     // Ensure all blocks for the operation are allocated and available.
     data_block* startBlock = find_block(block, StartIdx);
@@ -632,8 +609,7 @@ public:
     size_t idx;
     element* elem = get_write_ticket(idx);
 
-    consumer_base* cons =
-      write_element(elem, static_cast<Args&&>(ConstructArgs)...);
+    consumer_base* cons = write_element(elem, static_cast<Args&&>(ConstructArgs)...);
     write_offset = idx + 1;
     if (cons != nullptr) {
       tmc::detail::post_checked(


### PR DESCRIPTION
Apple Clang UBSan has started crashing with an ICE on the Mac GitHub Actions runner so I'll have to disable it :(

On Release build only, perhaps? It's failing to perform tail call elimination which is an optimization pass.