### PR TITLE
add [[clang::lifetimebound]] annotations where possible

### DIFF
--- a/include/tmc/asio/aw_asio.hpp
+++ b/include/tmc/asio/aw_asio.hpp
@@ -77,7 +77,7 @@ template <IsAwAsio Awaitable> struct awaitable_traits<Awaitable> {
   using self_type = Awaitable;
 
   // Values controlling the behavior when awaited directly in a tmc::task
-  static decltype(auto) get_awaiter(self_type&& awaitable) {
+  static decltype(auto) get_awaiter(self_type&& awaitable TMC_LIFETIMEBOUND) {
     return std::forward<self_type>(awaitable).operator co_await();
   }
 
@@ -125,7 +125,7 @@ template <typename Awaitable> struct aw_asio_impl {
   tmc::detail::result_storage_t<typename Awaitable::result_type> result;
 
   friend Awaitable;
-  aw_asio_impl(Awaitable& Handle) : handle(Handle) {}
+  aw_asio_impl(Awaitable& Handle TMC_LIFETIMEBOUND) : handle(Handle) {}
 
   bool await_ready() { return false; }
 
@@ -229,7 +229,7 @@ struct async_result<tmc::aw_asio_t, void(ResultArgs...)> {
       );
     }
 
-    tmc::aw_asio_impl<aw_asio> operator co_await() && {
+    tmc::aw_asio_impl<aw_asio> operator co_await() && TMC_LIFETIMEBOUND {
       return tmc::aw_asio_impl<aw_asio>(*this);
     }
 
@@ -254,7 +254,7 @@ struct async_result<tmc::aw_asio_t, void(ResultArgs...)> {
     /// When co_awaited, the outer coroutine will resume on the provided
     /// executor.
     template <typename Exec>
-    [[nodiscard]] aw_asio&& resume_on(Exec&& Executor) && {
+      [[nodiscard]] aw_asio&& resume_on(Exec&& Executor) && TMC_LIFETIMEBOUND {
       this->customizer.continuation_executor =
         tmc::detail::get_executor_traits<Exec>::type_erased(Executor);
       return std::move(*this);

--- a/include/tmc/asio/ex_asio.hpp
+++ b/include/tmc/asio/ex_asio.hpp
@@ -80,7 +80,7 @@ public:
   /// Requires `TMC_USE_HWLOC`.
   /// Builder func to limit the executor to a subset of the available CPUs.
   /// This should only be called once, as this is a single-threaded executor.
-  inline ex_asio& add_partition(tmc::topology::topology_filter Filter) {
+  inline ex_asio& add_partition(tmc::topology::topology_filter Filter) TMC_LIFETIMEBOUND {
     set_init_params()->add_partition(Filter);
     return *this;
   }
@@ -89,7 +89,8 @@ public:
   /// Builder func to set a hook that will be invoked at the startup of the
   /// executor thread, and passed the ordinal index of the thread (which is
   /// always 0, since this is a single-threaded executor).
-  inline ex_asio& set_thread_init_hook(std::function<void(size_t)> Hook) {
+  inline ex_asio&
+  set_thread_init_hook(std::function<void(size_t)> Hook) TMC_LIFETIMEBOUND {
     set_init_params()->set_thread_init_hook(Hook);
     return *this;
   }
@@ -97,7 +98,8 @@ public:
   /// Builder func to set a hook that will be invoked before destruction of each
   /// thread owned by this executor, and passed the ordinal index of the thread
   /// (which is always 0, since this is a single-threaded executor).
-  inline ex_asio& set_thread_teardown_hook(std::function<void(size_t)> Hook) {
+  inline ex_asio&
+  set_thread_teardown_hook(std::function<void(size_t)> Hook) TMC_LIFETIMEBOUND {
     set_init_params()->set_thread_teardown_hook(Hook);
     return *this;
   }
@@ -230,7 +232,7 @@ public:
   /// This object shares a lifetime with this executor, and can be used for
   /// pointer-based equality comparison against
   /// the thread-local `tmc::current_executor()`.
-  inline tmc::ex_any* type_erased() { return &type_erased_this; }
+  inline tmc::ex_any* type_erased() TMC_LIFETIMEBOUND { return &type_erased_this; }
 
   inline void post(
     work_item&& Item, size_t Priority = 0,
@@ -325,7 +327,7 @@ template <> struct executor_traits<tmc::ex_asio> {
     ex.post_bulk(std::forward<It>(Items), Count, Priority, ThreadHint);
   }
 
-  static inline tmc::ex_any* type_erased(tmc::ex_asio& ex) {
+  static inline tmc::ex_any* type_erased(tmc::ex_asio& ex TMC_LIFETIMEBOUND) {
     return ex.type_erased();
   }
 

--- a/include/tmc/atomic_condvar.hpp
+++ b/include/tmc/atomic_condvar.hpp
@@ -38,7 +38,9 @@ class [[nodiscard(
   friend class atomic_condvar<T>;
   friend class aw_atomic_condvar_co_notify<T>;
 
-  inline aw_atomic_condvar(atomic_condvar<T>& Parent, T Expected) noexcept
+  inline aw_atomic_condvar(
+    atomic_condvar<T>& Parent TMC_LIFETIMEBOUND, T Expected
+  ) noexcept
       : expected(Expected), parent(Parent) {}
 
 public:
@@ -86,7 +88,7 @@ class [[nodiscard(
   friend class atomic_condvar<T>;
 
   inline aw_atomic_condvar_co_notify(
-    atomic_condvar<T>& Parent, size_t NotifyCount
+    atomic_condvar<T>& Parent TMC_LIFETIMEBOUND, size_t NotifyCount
   ) noexcept
       : parent(Parent), notify_count(NotifyCount) {}
 
@@ -186,7 +188,7 @@ public:
   inline atomic_condvar(T InitialValue) noexcept : value{InitialValue} {}
 
   /// Returns a reference to the contained atomic variable.
-  inline std::atomic<T>& ref() noexcept { return value; }
+  inline std::atomic<T>& ref() noexcept TMC_LIFETIMEBOUND { return value; }
 
   /// Returns a reference to the contained atomic variable.
   inline const std::atomic<T>& ref() const noexcept { return value; }
@@ -196,7 +198,7 @@ public:
   /// (it resumes on the same executor and priority as the caller).
   /// Awaiters are woken in LIFO order.
   inline aw_atomic_condvar_co_notify<T>
-  co_notify_one(size_t NotifyCount = 1) noexcept {
+  co_notify_one(size_t NotifyCount = 1) noexcept TMC_LIFETIMEBOUND {
     return aw_atomic_condvar_co_notify<T>(*this, NotifyCount);
   }
 
@@ -206,14 +208,14 @@ public:
   /// (it resumes on the same executor and priority as the caller).
   /// Awaiters are woken in LIFO order.
   inline aw_atomic_condvar_co_notify<T>
-  co_notify_n(size_t NotifyCount = 1) noexcept {
+  co_notify_n(size_t NotifyCount = 1) noexcept TMC_LIFETIMEBOUND {
     return aw_atomic_condvar_co_notify<T>(*this, NotifyCount);
   }
 
   /// Wakes all awaiters that meet the criteria (expected != current value).
   /// Up to one awaiter may be resumed by symmetric transfer if it is eligible
   /// (it resumes on the same executor and priority as the caller).
-  inline aw_atomic_condvar_co_notify<T> co_notify_all() noexcept {
+  inline aw_atomic_condvar_co_notify<T> co_notify_all() noexcept TMC_LIFETIMEBOUND {
     return aw_atomic_condvar_co_notify<T>(*this, TMC_ALL_ONES);
   }
 
@@ -252,7 +254,7 @@ public:
 
   /// Suspends until Expected != current value. If this condition is already
   /// true, resumes immediately.
-  inline aw_atomic_condvar<T> await(T Expected) noexcept {
+  inline aw_atomic_condvar<T> await(T Expected) noexcept TMC_LIFETIMEBOUND {
     return aw_atomic_condvar<T>(*this, Expected);
   }
 

--- a/include/tmc/auto_reset_event.hpp
+++ b/include/tmc/auto_reset_event.hpp
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "tmc/detail/compat.hpp"
 #include "tmc/detail/concepts_awaitable.hpp"
 #include "tmc/detail/impl.hpp" // IWYU pragma: keep
 #include "tmc/detail/waiter_list.hpp"
@@ -26,7 +27,7 @@ class [[nodiscard(
 
   friend class auto_reset_event;
 
-  inline aw_auto_reset_event_co_set(auto_reset_event& Parent) noexcept
+  inline aw_auto_reset_event_co_set(auto_reset_event& Parent TMC_LIFETIMEBOUND) noexcept
       : parent(Parent) {}
 
 public:
@@ -89,7 +90,7 @@ public:
   /// If the event state is already set, this will do nothing.
   /// The awaiter may be resumed by symmetric transfer if it is eligible
   /// (it resumes on the same executor and priority as the caller).
-  inline aw_auto_reset_event_co_set co_set() noexcept {
+  inline aw_auto_reset_event_co_set co_set() noexcept TMC_LIFETIMEBOUND {
     return aw_auto_reset_event_co_set(*this);
   }
 

--- a/include/tmc/aw_resume_on.hpp
+++ b/include/tmc/aw_resume_on.hpp
@@ -27,7 +27,7 @@ class [[nodiscard(
 public:
   /// It is recommended to call `resume_on()` instead of using this constructor
   /// directly.
-  aw_resume_on(tmc::ex_any* Executor)
+  aw_resume_on(tmc::ex_any* Executor TMC_LIFETIMEBOUND)
       : executor(Executor), prio(tmc::detail::this_thread::this_task().prio) {}
 
   /// Resume immediately if outer is already running on the requested executor,
@@ -52,7 +52,8 @@ public:
 /// Returns an awaitable that moves this task onto the requested executor. If
 /// this task is already running on the requested executor, the co_await will do
 /// nothing.
-template <typename Exec> inline aw_resume_on resume_on(Exec&& Executor) {
+template <typename Exec>
+inline aw_resume_on resume_on(Exec&& Executor TMC_LIFETIMEBOUND) {
   return aw_resume_on(
     tmc::detail::get_executor_traits<Exec>::type_erased(Executor)
   );
@@ -61,7 +62,7 @@ template <typename Exec> inline aw_resume_on resume_on(Exec&& Executor) {
 /// Returns an awaitable that moves this task onto the requested executor. If
 /// this task is already running on the requested executor, the co_await will do
 /// nothing.
-template <typename Exec> inline aw_resume_on resume_on(Exec* Executor) {
+template <typename Exec> inline aw_resume_on resume_on(Exec* Executor TMC_LIFETIMEBOUND) {
   return aw_resume_on(
     tmc::detail::get_executor_traits<Exec>::type_erased(*Executor)
   );
@@ -74,7 +75,7 @@ inline aw_resume_on change_priority(size_t Priority) {
 
 template <typename E> class aw_ex_scope_exit;
 template <typename E> class aw_ex_scope_enter;
-template <typename E> inline aw_ex_scope_enter<E> enter(E& Executor);
+template <typename E> inline aw_ex_scope_enter<E> enter(E& Executor TMC_LIFETIMEBOUND);
 template <typename E> inline aw_ex_scope_enter<E> enter(E* Executor);
 
 /// The awaitable type returned by `co_await tmc::enter()`.
@@ -90,7 +91,7 @@ class aw_ex_scope_exit
   tmc::ex_any* continuation_executor;
   size_t prio;
 
-  aw_ex_scope_exit(tmc::ex_any* Executor, size_t Priority)
+  aw_ex_scope_exit(tmc::ex_any* Executor TMC_LIFETIMEBOUND, size_t Priority)
       : continuation_executor(Executor), prio(Priority) {}
 
 public:
@@ -102,7 +103,7 @@ public:
     "You must co_await exit() for it to have any "
     "effect."
   )]] inline aw_ex_scope_exit&&
-  exit() {
+  exit() TMC_LIFETIMEBOUND {
     return std::move(*this);
   }
 
@@ -135,7 +136,7 @@ class [[nodiscard(
   tmc::ex_any* continuation_executor;
   size_t prio;
   size_t originalPrio;
-  aw_ex_scope_enter(E& Executor)
+  aw_ex_scope_enter(E& Executor TMC_LIFETIMEBOUND)
       : scope_executor(Executor),
         continuation_executor(tmc::detail::this_thread::executor()),
         prio(tmc::detail::this_thread::this_task().prio),
@@ -184,11 +185,11 @@ public:
 ///
 /// `exit()` also offers the `with_priority()` and `resume_on()`
 /// customizations that let you modify this behavior when exiting.
-template <typename E> inline aw_ex_scope_enter<E> enter(E& Executor) {
+template <typename E> inline aw_ex_scope_enter<E> enter(E& Executor TMC_LIFETIMEBOUND) {
   return aw_ex_scope_enter<E>(Executor);
 }
 /// A convenience function identical to tmc::enter(E& exec)
-template <typename E> inline aw_ex_scope_enter<E> enter(E* Executor) {
+template <typename E> inline aw_ex_scope_enter<E> enter(E* Executor TMC_LIFETIMEBOUND) {
   return aw_ex_scope_enter<E>(*Executor);
 }
 } // namespace tmc

--- a/include/tmc/aw_yield.hpp
+++ b/include/tmc/aw_yield.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include "tmc/current.hpp"
+#include "tmc/detail/compat.hpp"
 #include "tmc/detail/concepts_awaitable.hpp"
 #include "tmc/detail/thread_locals.hpp"
 
@@ -185,7 +186,7 @@ template <> struct awaitable_traits<aw_yield_counter_dynamic> {
   using self_type = aw_yield_counter_dynamic;
   using awaiter_type = self_type;
 
-  static awaiter_type& get_awaiter(self_type& Awaitable) noexcept {
+  static awaiter_type& get_awaiter(self_type& Awaitable TMC_LIFETIMEBOUND) noexcept {
     return Awaitable;
   }
 };
@@ -197,7 +198,7 @@ template <ptrdiff_t N> struct awaitable_traits<aw_yield_counter<N>> {
   using self_type = aw_yield_counter<N>;
   using awaiter_type = self_type;
 
-  static awaiter_type& get_awaiter(self_type& Awaitable) noexcept {
+  static awaiter_type& get_awaiter(self_type& Awaitable TMC_LIFETIMEBOUND) noexcept {
     return Awaitable;
   }
 };

--- a/include/tmc/barrier.hpp
+++ b/include/tmc/barrier.hpp
@@ -6,6 +6,7 @@
 #pragma once
 #include "tmc/detail/impl.hpp" // IWYU pragma: keep
 
+#include "tmc/detail/compat.hpp"
 #include "tmc/detail/concepts_awaitable.hpp"
 #include "tmc/detail/waiter_list.hpp"
 
@@ -26,7 +27,7 @@ class aw_barrier {
 
   friend class barrier;
 
-  inline aw_barrier(barrier& Parent) noexcept : parent(Parent) {}
+  inline aw_barrier(barrier& Parent TMC_LIFETIMEBOUND) noexcept : parent(Parent) {}
 
 public:
   inline bool await_ready() noexcept {
@@ -83,7 +84,9 @@ public:
   /// if the counter reaches 0, wakes all awaiters, and resets the counter to
   /// the original maximum as specified in the constructor. Otherwise, suspends
   /// until Count awaiters have reached this point.
-  inline aw_barrier operator co_await() noexcept { return aw_barrier(*this); }
+  inline aw_barrier operator co_await() noexcept TMC_LIFETIMEBOUND {
+    return aw_barrier(*this);
+  }
 
   /// On destruction, any awaiters will be resumed.
   TMC_DECL ~barrier();
@@ -97,7 +100,7 @@ template <> struct awaitable_traits<tmc::barrier> {
   using self_type = tmc::barrier;
   using awaiter_type = tmc::aw_barrier;
 
-  static awaiter_type get_awaiter(self_type& Awaitable) noexcept {
+  static awaiter_type get_awaiter(self_type& Awaitable TMC_LIFETIMEBOUND) noexcept {
     return Awaitable.operator co_await();
   }
 };

--- a/include/tmc/channel.hpp
+++ b/include/tmc/channel.hpp
@@ -231,7 +231,8 @@ template <typename T> class chan_zc_scope {
   template <typename U, typename Config> friend class tmc::chan_tok;
 
   chan_zc_scope(
-    hazard_ptr* Haz, tmc::detail::qu_storage<T>* Data, size_t ReleaseIdx
+    hazard_ptr* Haz TMC_LIFETIMEBOUND, tmc::detail::qu_storage<T>* Data TMC_LIFETIMEBOUND,
+    size_t ReleaseIdx
   ) noexcept
       : haz_ptr{Haz}, data{Data}, release_idx{ReleaseIdx} {}
 
@@ -786,7 +787,7 @@ private:
   // returned to become the NewHead. If OldHead is protected, then it will be
   // returned unchanged, and no blocks can be reclaimed.
   data_block* try_advance_head(
-    hazard_ptr* Haz, data_block* OldHead, size_t ProtectIdx
+    hazard_ptr* Haz, data_block* OldHead TMC_LIFETIMEBOUND, size_t ProtectIdx
   ) noexcept {
     // In the current implementation, this is called only from consumers.
     // Therefore, this token's hazptr will be active, and protecting read_block.
@@ -969,7 +970,8 @@ private:
 
   // Given idx and a starting block, advance it until the block containing idx
   // is found.
-  static inline data_block* find_block(data_block* Block, size_t Idx) noexcept {
+  static inline data_block*
+  find_block(data_block* Block TMC_LIFETIMEBOUND, size_t Idx) noexcept {
     size_t offset = Block->offset.load(std::memory_order_relaxed);
     size_t targetOffset = Idx & ~BlockSizeMask;
     // Find or allocate the associated block
@@ -1316,10 +1318,12 @@ public:
     element* elem;
     size_t release_idx;
 
-    aw_pull_base_impl(aw_pull_base& Parent) noexcept
-          : base{true, tmc::detail::this_thread::executor(), nullptr,
-                 tmc::detail::this_thread::this_task().prio},
-            parent{Parent}, thread_hint(tmc::current_thread_index()) {}
+    aw_pull_base_impl(aw_pull_base& Parent TMC_LIFETIMEBOUND) noexcept
+        : base{
+            true, tmc::detail::this_thread::executor(), nullptr,
+            tmc::detail::this_thread::this_task().prio
+          },
+          parent{Parent}, thread_hint(tmc::current_thread_index()) {}
 
     bool await_ready() noexcept {
       parent.haz_ptr->inc_read_count();
@@ -1428,7 +1432,9 @@ public:
 
     friend channel;
 
-    aw_pull_base(channel& Chan, hazard_ptr* Haz) noexcept
+    aw_pull_base(
+      channel& Chan TMC_LIFETIMEBOUND, hazard_ptr* Haz TMC_LIFETIMEBOUND
+    ) noexcept
         : chan(Chan), haz_ptr{Haz} {}
   };
 
@@ -1608,13 +1614,15 @@ public:
 
     friend chan_tok<T, Config>;
 
-    aw_push(channel& Chan, hazard_ptr* Haz, bool Result) noexcept
+    aw_push(
+      channel& Chan TMC_LIFETIMEBOUND, hazard_ptr* Haz TMC_LIFETIMEBOUND, bool Result
+    ) noexcept
         : chan{Chan}, haz_ptr{Haz}, result{Result} {}
 
     struct aw_push_impl {
       aw_push& parent;
 
-      aw_push_impl(aw_push& Parent) noexcept : parent{Parent} {}
+      aw_push_impl(aw_push& Parent TMC_LIFETIMEBOUND) noexcept : parent{Parent} {}
 
       bool await_ready() noexcept {
         if (parent.haz_ptr->write_count + parent.haz_ptr->read_count >=
@@ -1681,7 +1689,9 @@ public:
     };
 
   public:
-    aw_push_impl operator co_await() && noexcept { return aw_push_impl(*this); }
+    aw_push_impl operator co_await() && noexcept TMC_LIFETIMEBOUND {
+      return aw_push_impl(*this);
+    }
   };
 
   // called by close()
@@ -2164,7 +2174,7 @@ public:
   /// Default: true
   ///
   /// If Config::EmbedFirstBlock == true, this will be forced to true.
-  chan_tok& set_reuse_blocks(bool Reuse) noexcept {
+  chan_tok& set_reuse_blocks(bool Reuse) noexcept TMC_LIFETIMEBOUND {
     if constexpr (!Config::EmbedFirstBlock) {
       chan->ReuseBlocks.store(Reuse, std::memory_order_relaxed);
     }
@@ -2174,7 +2184,7 @@ public:
   /// If a consumer sees no data is ready at a ticket, it will spin wait this
   /// many times. Each spin wait is an asm("pause") and reload.
   /// Default: 0
-  chan_tok& set_consumer_spins(size_t SpinCount) noexcept {
+  chan_tok& set_consumer_spins(size_t SpinCount) noexcept TMC_LIFETIMEBOUND {
     chan->ConsumerSpins.store(SpinCount, std::memory_order_relaxed);
     return *this;
   }
@@ -2184,7 +2194,7 @@ public:
   /// consumers near each other to optimize sharing efficiency. The default
   /// value of 2,000,000 represents an item being pushed every 500ns. This
   /// behavior can be disabled entirely by setting this to 0.
-  chan_tok& set_heavy_load_threshold(size_t Threshold) noexcept {
+  chan_tok& set_heavy_load_threshold(size_t Threshold) noexcept TMC_LIFETIMEBOUND {
     size_t cycles =
       Threshold == 0 ? 0 : TMC_CPU_FREQ * chan_t::ClusterPeriod / Threshold;
     chan->MinClusterCycles.store(cycles, std::memory_order_relaxed);

--- a/include/tmc/detail/compat.hpp
+++ b/include/tmc/detail/compat.hpp
@@ -56,6 +56,18 @@
 #define TMC_CORO_AWAIT_ELIDABLE_ARGUMENT
 #endif
 
+#ifdef __has_cpp_attribute
+
+#if __has_cpp_attribute(clang::lifetimebound)
+#define TMC_LIFETIMEBOUND [[clang::lifetimebound]]
+#else
+#define TMC_LIFETIMEBOUND
+#endif
+
+#else // not __has_cpp_attribute
+#define TMC_LIFETIMEBOUND
+#endif
+
 #if defined(__cpp_sized_deallocation)
 #define TMC_SIZED_DEALLOCATION __cpp_sized_deallocation
 #else
@@ -161,6 +173,39 @@ _Pragma("clang diagnostic ignored \"-Wswitch-default\"")
 #else
 #define TMC_DISABLE_WARNING_SWITCH_DEFAULT_BEGIN
 #define TMC_DISABLE_WARNING_SWITCH_DEFAULT_END
+#endif
+
+// The lifetime-safety suggestion engine proposes [[clang::lifetimebound]]
+// per-instantiation. For generic forwarding functions (await_transform /
+// get_awaiter), some instantiations bind the returned awaiter to the parameter
+// (awaiters that reference the awaitable), while others do not (awaiters that
+// take ownership of the awaitable, e.g. aw_task). A single annotation cannot
+// satisfy both: applying it trips -Wlifetime-safety-lifetimebound-violation on
+// the owning instantiations. Suppress the suggestion at those sites instead.
+#if defined(__clang__)
+#if __has_warning("-Wlifetime-safety-suggestions")
+#define TMC_DISABLE_WARNING_LIFETIME_SUGGESTIONS_BEGIN \
+_Pragma("clang diagnostic push") \
+_Pragma("clang diagnostic ignored \"-Wlifetime-safety-suggestions\"")
+#define TMC_DISABLE_WARNING_LIFETIME_SUGGESTIONS_END _Pragma("clang diagnostic pop")
+#endif
+#endif
+#ifndef TMC_DISABLE_WARNING_LIFETIME_SUGGESTIONS_BEGIN
+#define TMC_DISABLE_WARNING_LIFETIME_SUGGESTIONS_BEGIN
+#define TMC_DISABLE_WARNING_LIFETIME_SUGGESTIONS_END
+#endif
+
+#if defined(__clang__)
+#if __has_warning("-Wlifetime-safety-invalidation")
+#define TMC_DISABLE_WARNING_LIFETIME_INVALIDATION_BEGIN \
+_Pragma("clang diagnostic push") \
+_Pragma("clang diagnostic ignored \"-Wlifetime-safety-invalidation\"")
+#define TMC_DISABLE_WARNING_LIFETIME_INVALIDATION_END _Pragma("clang diagnostic pop")
+#endif
+#endif
+#ifndef TMC_DISABLE_WARNING_LIFETIME_INVALIDATION_BEGIN
+#define TMC_DISABLE_WARNING_LIFETIME_INVALIDATION_BEGIN
+#define TMC_DISABLE_WARNING_LIFETIME_INVALIDATION_END
 #endif
 
 // We like to pack pointers and flags into single words for performance.

--- a/include/tmc/detail/concepts_awaitable.hpp
+++ b/include/tmc/detail/concepts_awaitable.hpp
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include "tmc/detail/compat.hpp"
+
 #include <optional>
 #include <type_traits>
 
@@ -35,6 +37,10 @@ template <typename Awaitable, typename = void> struct unknown_awaitable_traits {
 template <NonVoid Awaitable> struct unknown_awaitable_traits<Awaitable> {
   // Try to guess at the awaiter type based on the expected function signatures.
   // This function is normally unevaluated and only used to get the decltype.
+  // Whether the returned awaiter is lifetime-bound to the value parameter
+  // depends on the T type; see TMC_DISABLE_WARNING_LIFETIME_SUGGESTIONS in
+  // compat.hpp.
+  TMC_DISABLE_WARNING_LIFETIME_SUGGESTIONS_BEGIN
   template <typename T> static decltype(auto) guess_awaiter(T&& value) {
     if constexpr (requires { static_cast<T&&>(value).operator co_await(); }) {
       return static_cast<T&&>(value).operator co_await();
@@ -44,6 +50,7 @@ template <NonVoid Awaitable> struct unknown_awaitable_traits<Awaitable> {
       return static_cast<T&&>(value);
     }
   }
+  TMC_DISABLE_WARNING_LIFETIME_SUGGESTIONS_END
 
   using awaiter_type = decltype(guess_awaiter(std::declval<Awaitable>()));
 
@@ -171,7 +178,7 @@ concept HasAwaitTagNoGroupAsIs = std::is_base_of_v<AwaitTagNoGroupAsIs, T>;
 template <HasAwaitTagNoGroupAsIs Awaitable> struct awaitable_traits<Awaitable> {
   static constexpr configure_mode mode = WRAPPER;
 
-  static decltype(auto) get_awaiter(Awaitable&& awaitable) noexcept {
+  static decltype(auto) get_awaiter(Awaitable&& awaitable TMC_LIFETIMEBOUND) noexcept {
     return static_cast<Awaitable&&>(awaitable);
   }
 
@@ -192,9 +199,14 @@ concept HasAwaitTagNoGroupCoAwait = std::is_base_of_v<AwaitTagNoGroupCoAwait, T>
 template <HasAwaitTagNoGroupCoAwait Awaitable> struct awaitable_traits<Awaitable> {
   static constexpr configure_mode mode = WRAPPER;
 
+  // Whether the returned awaiter is lifetime-bound to the awaitable parameter
+  // depends on the Awaitable type; see TMC_DISABLE_WARNING_LIFETIME_SUGGESTIONS
+  // in compat.hpp.
+  TMC_DISABLE_WARNING_LIFETIME_SUGGESTIONS_BEGIN
   static decltype(auto) get_awaiter(Awaitable&& awaitable) noexcept {
     return static_cast<Awaitable&&>(awaitable).operator co_await();
   }
+  TMC_DISABLE_WARNING_LIFETIME_SUGGESTIONS_END
 
   using result_type = std::remove_reference_t<
     decltype(get_awaiter(std::declval<Awaitable>()).await_resume())>;
@@ -214,7 +226,7 @@ concept HasAwaitTagNoGroupCoAwaitLvalue =
 template <HasAwaitTagNoGroupCoAwaitLvalue Awaitable> struct awaitable_traits<Awaitable> {
   static constexpr configure_mode mode = WRAPPER;
 
-  static decltype(auto) get_awaiter(Awaitable& awaitable) noexcept {
+  static decltype(auto) get_awaiter(Awaitable& awaitable TMC_LIFETIMEBOUND) noexcept {
     return awaitable.operator co_await();
   }
 

--- a/include/tmc/detail/concepts_work_item.hpp
+++ b/include/tmc/detail/concepts_work_item.hpp
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "tmc/detail/compat.hpp"
 #include "tmc/detail/concepts_awaitable.hpp"
 #include "tmc/task.hpp"
 
@@ -142,6 +143,10 @@ task<void> into_task(Original FuncVoid) noexcept {
 
 // Ensures Item is of a known awaitable type,
 // that is, after calling this, the mode will not be WRAPPER.
+// Whether the returned value is lifetime-bound to Item depends on the
+// template parameters (the IsFunc path copies Item into a task's coroutine
+// frame); see TMC_DISABLE_WARNING_LIFETIME_SUGGESTIONS in compat.hpp.
+TMC_DISABLE_WARNING_LIFETIME_SUGGESTIONS_BEGIN
 template <bool IsFunc, typename Awaitable>
 inline decltype(auto) into_known(Awaitable&& Item) {
   if constexpr (IsFunc) {
@@ -160,6 +165,7 @@ inline decltype(auto) into_known(Awaitable&& Item) {
     }
   }
 }
+TMC_DISABLE_WARNING_LIFETIME_SUGGESTIONS_END
 
 // Converts k into a coroutine handle, then into a work_item.
 // This type erasure is necessary when TMC_WORK_ITEM=FUNC,

--- a/include/tmc/detail/coro_functor.hpp
+++ b/include/tmc/detail/coro_functor.hpp
@@ -77,7 +77,7 @@ public:
   }
 
   /// Free function void() constructor
-  inline coro_functor(void (*FreeFunction)()) noexcept {
+  inline coro_functor(void (*FreeFunction TMC_LIFETIMEBOUND)()) noexcept {
     func = reinterpret_cast<void*>(FreeFunction);
     obj = reinterpret_cast<void*>(IS_FREE_FUNC);
   }
@@ -99,7 +99,7 @@ public:
   /// lifetime of the parameter and ensure that the pointer remains valid until
   /// operator() is called.
   template <typename T>
-  coro_functor(T* Functor) noexcept
+  coro_functor(T* Functor TMC_LIFETIMEBOUND) noexcept
     requires(
       !std::is_same_v<std::remove_cvref_t<T>, coro_functor> &&
       !std::is_convertible_v<T, std::coroutine_handle<>>

--- a/include/tmc/detail/hwloc_unique_bitmap.hpp
+++ b/include/tmc/detail/hwloc_unique_bitmap.hpp
@@ -6,6 +6,8 @@
 #pragma once
 #include "tmc/detail/impl.hpp" // IWYU pragma: keep
 
+#include "tmc/detail/compat.hpp"
+
 #ifdef TMC_USE_HWLOC
 #include "tmc/detail/hwloc_forward_defs.hpp"
 #endif
@@ -19,7 +21,7 @@ struct hwloc_unique_bitmap {
   hwloc_bitmap_s* obj;
 
   TMC_DECL hwloc_unique_bitmap();
-  TMC_DECL hwloc_unique_bitmap(hwloc_bitmap_s*);
+  TMC_DECL hwloc_unique_bitmap(hwloc_bitmap_s* From TMC_LIFETIMEBOUND);
 
   // Releases the bitmap on destruction. If null, nothing happens.
   TMC_DECL ~hwloc_unique_bitmap();

--- a/include/tmc/detail/mixins.hpp
+++ b/include/tmc/detail/mixins.hpp
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include "tmc/detail/compat.hpp"
 #include "tmc/detail/concepts_awaitable.hpp"
 
 #include <cstddef>
@@ -105,7 +106,9 @@ private:
   using Base::await_suspend;
 
 public:
-  Base&& operator co_await() && noexcept { return static_cast<Base&&>(*this); }
+  Base&& operator co_await() && noexcept TMC_LIFETIMEBOUND {
+    return static_cast<Base&&>(*this);
+  }
 };
 
 template <typename Base>
@@ -124,7 +127,9 @@ private:
   using Base::await_suspend;
 
 public:
-  Base& operator co_await() & noexcept { return static_cast<Base&>(*this); }
+  Base& operator co_await() & noexcept TMC_LIFETIMEBOUND {
+    return static_cast<Base&>(*this);
+  }
 };
 
 } // namespace detail

--- a/include/tmc/detail/qu_mc.hpp
+++ b/include/tmc/detail/qu_mc.hpp
@@ -407,7 +407,8 @@ template <typename T> static inline bool circular_less_than(T a, T b) {
   // calling code and has no effect when done here.
 }
 
-template <typename U> static inline std::byte* align_for(std::byte* ptr) {
+template <typename U>
+static inline std::byte* align_for(std::byte* ptr TMC_LIFETIMEBOUND) {
   const std::size_t alignment = std::alignment_of<U>::value;
   return ptr +
          (alignment - (reinterpret_cast<std::uintptr_t>(ptr) % alignment)) %
@@ -939,7 +940,7 @@ private:
       elementsCompletelyDequeued.store(0, std::memory_order_relaxed);
     }
 
-    inline T* operator[](index_t idx) TMC_MOODYCAMEL_NOEXCEPT {
+    inline T* operator[](index_t idx) TMC_MOODYCAMEL_NOEXCEPT TMC_LIFETIMEBOUND {
       size_t raw_off =
         static_cast<size_t>(idx & static_cast<index_t>(BLOCK_MASK));
       if constexpr (ELEM_INTERLEAVING > 1) {
@@ -1002,7 +1003,7 @@ private:
   //////////////////////////////////
 
   struct alignas(TMC_CACHE_LINE_SIZE) ImplicitProducer {
-    ImplicitProducer(ConcurrentQueue* parent_)
+    ImplicitProducer(ConcurrentQueue* parent_ TMC_LIFETIMEBOUND)
         : next(nullptr), inactive(false), tailIndex(0), headIndex(0),
           dequeueOptimisticCount(0), dequeueOvercommit(0), tailBlock(nullptr),
           parent(parent_), nextBlockIndexCapacity(IMPLICIT_INITIAL_INDEX_SIZE),
@@ -1946,7 +1947,7 @@ private:
     return add_producer(new ImplicitProducer(this));
   }
 
-  ImplicitProducer* add_producer(ImplicitProducer* producer) {
+  ImplicitProducer* add_producer(ImplicitProducer* producer TMC_LIFETIMEBOUND) {
     producerCount.fetch_add(1, std::memory_order_relaxed);
 
     // Add it to the lock-free list

--- a/include/tmc/detail/qu_mpsc_blocking.hpp
+++ b/include/tmc/detail/qu_mpsc_blocking.hpp
@@ -166,7 +166,8 @@ private:
 
     static constexpr tmc::detail::atomic_wait_t WAIT_VALUE = WAITING;
 
-    tmc::detail::atomic_wait_t* set_waiting_or_get_wait_address() noexcept {
+    tmc::detail::atomic_wait_t*
+    set_waiting_or_get_wait_address() noexcept TMC_LIFETIMEBOUND {
       tmc::detail::atomic_wait_t prev =
         flags.exchange(WAITING, std::memory_order_seq_cst);
       if (prev != DATA) {
@@ -335,7 +336,8 @@ private:
 
   // Given idx and a starting block, advance it until the block containing idx
   // is found.
-  static inline data_block* find_block(data_block* Block, size_t Idx) noexcept {
+  static inline data_block*
+  find_block(data_block* Block TMC_LIFETIMEBOUND, size_t Idx) noexcept {
     size_t offset = Block->offset.load(std::memory_order_relaxed);
     size_t targetOffset = Idx & ~BlockSizeMask;
     // Find or allocate the associated block

--- a/include/tmc/detail/task_wrapper.hpp
+++ b/include/tmc/detail/task_wrapper.hpp
@@ -206,7 +206,7 @@ public:
   }
 
   /// Returns the value provided by the awaited task.
-  TMC_AWAIT_RESUME inline Result&& await_resume() {
+  TMC_AWAIT_RESUME inline Result&& await_resume() TMC_LIFETIMEBOUND {
 #if TMC_HAS_EXCEPTIONS
     if (exc != nullptr) {
       std::rethrow_exception(exc);

--- a/include/tmc/detail/thread_layout.hpp
+++ b/include/tmc/detail/thread_layout.hpp
@@ -7,6 +7,8 @@
 
 #include "tmc/detail/impl.hpp" // IWYU pragma: keep
 
+#include "tmc/detail/compat.hpp"
+
 #ifdef TMC_USE_HWLOC
 #include "tmc/detail/hwloc_forward_defs.hpp"
 #include "tmc/detail/hwloc_unique_bitmap.hpp"
@@ -114,7 +116,7 @@ TMC_DECL detail::Topology query_internal(
 TMC_DECL void
 query_internal_parse(hwloc_topology*& HwlocTopo, detail::Topology& Topo_out);
 
-TMC_DECL hwloc_obj* find_parent_cache(hwloc_obj* Start);
+TMC_DECL hwloc_obj* find_parent_cache(hwloc_obj* Start TMC_LIFETIMEBOUND);
 TMC_DECL void make_cache_parent_group(
   hwloc_obj* parent, std::vector<tmc::topology::detail::CacheGroup>& caches,
   std::vector<hwloc_obj*>& work, size_t shareStart, size_t shareEnd
@@ -133,8 +135,8 @@ struct ThreadCacheGroupIterator {
   std::vector<state> states_;
   std::function<void(tmc::topology::detail::CacheGroup&)> process_;
   TMC_DECL ThreadCacheGroupIterator(
-    std::vector<tmc::topology::detail::CacheGroup>&,
-    std::function<void(tmc::topology::detail::CacheGroup&)>
+    std::vector<tmc::topology::detail::CacheGroup>& GroupedCores,
+    std::function<void(tmc::topology::detail::CacheGroup&)> Process TMC_LIFETIMEBOUND
   );
   TMC_DECL bool next();
 };

--- a/include/tmc/detail/thread_layout.ipp
+++ b/include/tmc/detail/thread_layout.ipp
@@ -40,6 +40,10 @@ struct SubdivideNode {
 };
 
 // Cut the range in half repeatedly.
+// The invalidation warning is a false positive: no references into the vector
+// are held across emplace_back (node is a copy, and Results[idx] is
+// re-indexed fresh after each growth).
+TMC_DISABLE_WARNING_LIFETIME_INVALIDATION_BEGIN
 static void recursively_subdivide(std::vector<SubdivideNode>& Results) {
   size_t idx = Results.size() - 1;
   SubdivideNode node = Results[idx];
@@ -56,6 +60,7 @@ static void recursively_subdivide(std::vector<SubdivideNode>& Results) {
     recursively_subdivide(Results);
   }
 }
+TMC_DISABLE_WARNING_LIFETIME_INVALIDATION_END
 
 // Attempt to preserve the same path structure as the starting node, but branch
 // off earlier in the step. Each time we branch earlier, restore the original

--- a/include/tmc/detail/tiny_lock.hpp
+++ b/include/tmc/detail/tiny_lock.hpp
@@ -43,7 +43,8 @@ class [[nodiscard]] tiny_lock_guard {
   tiny_lock& lock;
 
 public:
-  [[nodiscard]] inline tiny_lock_guard(tiny_lock& Lock) noexcept : lock{Lock} {
+  [[nodiscard]] inline tiny_lock_guard(tiny_lock& Lock TMC_LIFETIMEBOUND) noexcept
+      : lock{Lock} {
     lock.spin_lock();
   }
   inline ~tiny_lock_guard() noexcept { lock.unlock(); }
@@ -59,7 +60,7 @@ class [[nodiscard]] concurrent_access_scope {
 
 public:
   // The lock is acquired in the ASSERT_NO_CONCURRENT_ACCESS macro
-  [[nodiscard]] inline concurrent_access_scope(tiny_lock& Lock) noexcept
+  [[nodiscard]] inline concurrent_access_scope(tiny_lock& Lock TMC_LIFETIMEBOUND) noexcept
       : lock{Lock} {}
   inline ~concurrent_access_scope() noexcept { lock.unlock(); }
 

--- a/include/tmc/detail/waiter_list.ipp
+++ b/include/tmc/detail/waiter_list.ipp
@@ -66,7 +66,7 @@ namespace {
 // Reverses a singly-linked chain of waiter_list_nodes in place.
 // The caller must have exclusive access to the chain.
 inline tmc::detail::waiter_list_node*
-reverse_chain(tmc::detail::waiter_list_node* curr) noexcept {
+reverse_chain(tmc::detail::waiter_list_node* curr TMC_LIFETIMEBOUND) noexcept {
   tmc::detail::waiter_list_node* prev = nullptr;
   while (curr != nullptr) {
     auto next = curr->next;

--- a/include/tmc/ex_any.hpp
+++ b/include/tmc/ex_any.hpp
@@ -50,7 +50,7 @@ public:
   ex_any() {}
 
   /// This constructor is used by TMC executors.
-  template <typename T> ex_any(T* Executor) {
+  template <typename T> ex_any(T* Executor TMC_LIFETIMEBOUND) {
     executor = Executor;
     s_post = [](
                void* Erased, work_item&& Item, size_t Priority,
@@ -99,7 +99,9 @@ template <> struct executor_traits<tmc::ex_any> {
     }
   }
 
-  static inline tmc::ex_any* type_erased(tmc::ex_any& ex) { return &ex; }
+  static inline tmc::ex_any* type_erased(tmc::ex_any& ex TMC_LIFETIMEBOUND) {
+    return &ex;
+  }
 
   static inline std::coroutine_handle<>
   dispatch(tmc::ex_any& ex, std::coroutine_handle<> Outer, size_t Priority) {
@@ -139,7 +141,7 @@ template <> struct executor_traits<tmc::ex_any*> {
     }
   }
 
-  static inline tmc::ex_any* type_erased(tmc::ex_any* ex) { return ex; }
+  static inline tmc::ex_any* type_erased(tmc::ex_any* ex TMC_LIFETIMEBOUND) { return ex; }
 
   static inline std::coroutine_handle<>
   dispatch(tmc::ex_any* ex, std::coroutine_handle<> Outer, size_t Priority) {

--- a/include/tmc/ex_braid.hpp
+++ b/include/tmc/ex_braid.hpp
@@ -103,7 +103,7 @@ public:
   /// This object shares a lifetime with this executor, and can be used for
   /// pointer-based equality comparison against
   /// the thread-local `tmc::current_executor()`.
-  inline tmc::ex_any* type_erased() { return &type_erased_this; }
+  inline tmc::ex_any* type_erased() TMC_LIFETIMEBOUND { return &type_erased_this; }
 
 private:
   TMC_DECL ex_braid(tmc::ex_any* Parent);
@@ -157,7 +157,7 @@ template <> struct executor_traits<tmc::ex_braid> {
     ex.post_bulk(std::forward<It>(Items), Count, Priority, ThreadHint);
   }
 
-  static TMC_DECL tmc::ex_any* type_erased(tmc::ex_braid& ex);
+  static TMC_DECL tmc::ex_any* type_erased(tmc::ex_braid& ex TMC_LIFETIMEBOUND);
 
   static TMC_DECL std::coroutine_handle<>
   dispatch(tmc::ex_braid& ex, std::coroutine_handle<> Outer, size_t Priority);

--- a/include/tmc/ex_cpu.hpp
+++ b/include/tmc/ex_cpu.hpp
@@ -129,13 +129,13 @@ private:
   // Returns a lambda closure that is executed on a worker thread
   TMC_DECL auto make_worker(
     tmc::topology::thread_info Info, size_t PriorityRangeBegin, size_t PriorityRangeEnd,
-    ex_cpu::cldq_t** StealOrder,
-    std::atomic<tmc::detail::atomic_wait_t>& InitThreadsBarrier,
+    ex_cpu::cldq_t** StealOrder TMC_LIFETIMEBOUND,
+    std::atomic<tmc::detail::atomic_wait_t>& InitThreadsBarrier TMC_LIFETIMEBOUND,
     // will be nullptr if hwloc is not enabled
     tmc::detail::hwloc_unique_bitmap& CpuSet,
     // will be nullptr if hwloc is not enabled
-    void* HwlocTopo
-  );
+    void* HwlocTopo TMC_LIFETIMEBOUND
+  ) TMC_LIFETIMEBOUND;
 
   // returns true if no tasks were found (caller should wait on cv)
   // returns false if thread stop requested (caller should exit)
@@ -181,14 +181,14 @@ public:
   TMC_DECL ex_cpu& set_thread_occupancy(
     float ThreadOccupancy,
     tmc::topology::cpu_kind::value CpuKinds = tmc::topology::cpu_kind::PERFORMANCE
-  );
+  ) TMC_LIFETIMEBOUND;
 
   /// Requires `TMC_USE_HWLOC`.
   /// Builder func to fill the SMT level of each core. On systems with multiple
   /// CPU kinds, the occupancy will be set separately for each CPU kind, based
   /// on its SMT level. (e.g. on Intel Hybrid, only P-cores have SMT, but on
   /// Apple M, neither P-cores nor E-cores have SMT)
-  TMC_DECL ex_cpu& fill_thread_occupancy();
+  TMC_DECL ex_cpu& fill_thread_occupancy() TMC_LIFETIMEBOUND;
 
   /// Requires `TMC_USE_HWLOC`.
   /// Builder func to limit threads to a subset of the available CPUs.
@@ -202,40 +202,45 @@ public:
   TMC_DECL ex_cpu& add_partition(
     tmc::topology::topology_filter Filter, size_t PriorityRangeBegin = 0,
     size_t PriorityRangeEnd = TMC_MAX_PRIORITY_COUNT
-  );
+  ) TMC_LIFETIMEBOUND;
 
   /// Requires `TMC_USE_HWLOC`.
   /// Builder func to specify whether threads should be pinned/bound to
   /// specific cores, groups, or NUMA nodes. The default is GROUP.
-  TMC_DECL ex_cpu& set_thread_pinning_level(tmc::topology::thread_pinning_level Level);
+  TMC_DECL ex_cpu&
+  set_thread_pinning_level(tmc::topology::thread_pinning_level Level) TMC_LIFETIMEBOUND;
 
   /// Requires `TMC_USE_HWLOC`.
   /// Builder func to configure how threads should be allocated when the thread
   /// occupancy is less than the full system. This will only have any effect
   /// if `set_thread_count()` is called with a number less than the count of
   /// physical cores in the system.
-  TMC_DECL ex_cpu&
-  set_thread_packing_strategy(tmc::topology::thread_packing_strategy Strategy);
+  TMC_DECL ex_cpu& set_thread_packing_strategy(
+    tmc::topology::thread_packing_strategy Strategy
+  ) TMC_LIFETIMEBOUND;
 
   /// Builder func to set a hook that will be invoked at the startup of each
   /// thread owned by this executor, and passed information about this thread.
   /// This overload requires `TMC_USE_HWLOC`.
-  TMC_DECL ex_cpu&
-  set_thread_init_hook(std::function<void(tmc::topology::thread_info)> Hook);
+  TMC_DECL ex_cpu& set_thread_init_hook(
+    std::function<void(tmc::topology::thread_info)> Hook
+  ) TMC_LIFETIMEBOUND;
 
   /// Builder func to set a hook that will be invoked before destruction of each
   /// thread owned by this executor, and passed information about this thread.
   /// This overload requires `TMC_USE_HWLOC`.
-  TMC_DECL ex_cpu&
-  set_thread_teardown_hook(std::function<void(tmc::topology::thread_info)> Hook);
+  TMC_DECL ex_cpu& set_thread_teardown_hook(
+    std::function<void(tmc::topology::thread_info)> Hook
+  ) TMC_LIFETIMEBOUND;
 
   /// Builder func to set a hook that will be invoked by each worker thread
   /// after it finishes running a batch of tasks, before entering the
   /// spinning/sleeping phase. If the hook returns true, the worker will
   /// immediately re-enter the run loop to check for more work.
   /// This overload requires `TMC_USE_HWLOC`.
-  TMC_DECL ex_cpu&
-  set_thread_post_run_hook(std::function<bool(tmc::topology::thread_info)> Hook);
+  TMC_DECL ex_cpu& set_thread_post_run_hook(
+    std::function<bool(tmc::topology::thread_info)> Hook
+  ) TMC_LIFETIMEBOUND;
 #endif
   /// Builder func to set the number of threads before calling `init()`.
   /// The maximum allowed value is equal to the number of bits on your
@@ -248,7 +253,7 @@ public:
   /// will be created.
   /// - Otherwise, `std::thread::hardware_concurrency()` threads will be
   /// created.
-  TMC_DECL ex_cpu& set_thread_count(size_t ThreadCount);
+  TMC_DECL ex_cpu& set_thread_count(size_t ThreadCount) TMC_LIFETIMEBOUND;
 
   /// Gets the number of worker threads. Only useful after `init()` has been
   /// called.
@@ -258,7 +263,7 @@ public:
   /// Builder func to set the number of priority levels before calling `init()`.
   /// The value must be in the range [1, 16].
   /// The default is 1.
-  TMC_DECL ex_cpu& set_priority_count(size_t PriorityCount);
+  TMC_DECL ex_cpu& set_priority_count(size_t PriorityCount) TMC_LIFETIMEBOUND;
 #endif
 
   /// Gets the number of priority levels. Only useful after `init()` has been
@@ -269,27 +274,31 @@ public:
   /// after it finishes running a batch of tasks, before entering the
   /// spinning/sleeping phase. If the hook returns true, the worker will
   /// immediately re-enter the run loop to check for more work.
-  TMC_DECL ex_cpu& set_thread_post_run_hook(std::function<bool(size_t)> Hook);
+  TMC_DECL ex_cpu&
+  set_thread_post_run_hook(std::function<bool(size_t)> Hook) TMC_LIFETIMEBOUND;
 
   /// Builder func to set a hook that will be invoked at the startup of each
   /// thread owned by this executor, and passed the ordinal index
   /// [0..thread_count()-1] of the thread.
-  TMC_DECL ex_cpu& set_thread_init_hook(std::function<void(size_t)> Hook);
+  TMC_DECL ex_cpu&
+  set_thread_init_hook(std::function<void(size_t)> Hook) TMC_LIFETIMEBOUND;
 
   /// Builder func to set a hook that will be invoked before destruction of each
   /// thread owned by this executor, and passed the ordinal index
   /// [0..thread_count()-1] of the thread.
-  TMC_DECL ex_cpu& set_thread_teardown_hook(std::function<void(size_t)> Hook);
+  TMC_DECL ex_cpu&
+  set_thread_teardown_hook(std::function<void(size_t)> Hook) TMC_LIFETIMEBOUND;
 
   /// Builder func to set the number of times that a thread worker will spin
   /// looking for new work when all queues appear to be empty before suspending
   /// the thread.  Each spin is an asm("pause") followed by re-checking all
   /// queues. The default is 0.
-  TMC_DECL ex_cpu& set_spins(size_t Spins);
+  TMC_DECL ex_cpu& set_spins(size_t Spins) TMC_LIFETIMEBOUND;
 
   /// Builder func to configure the work-stealing strategy used internally by
   /// this executor. The default is `HIERARCHY_MATRIX`.
-  TMC_DECL ex_cpu& set_work_stealing_strategy(tmc::work_stealing_strategy Strategy);
+  TMC_DECL ex_cpu&
+  set_work_stealing_strategy(tmc::work_stealing_strategy Strategy) TMC_LIFETIMEBOUND;
 
   /// Initializes the executor. If you want to customize the behavior, call the
   /// `set_X()` functions before calling `init()`. By default, uses hwloc to
@@ -328,7 +337,7 @@ public:
   /// This object shares a lifetime with this executor, and can be used for
   /// pointer-based equality comparison against
   /// the thread-local `tmc::current_executor()`.
-  TMC_DECL tmc::ex_any* type_erased();
+  TMC_DECL tmc::ex_any* type_erased() TMC_LIFETIMEBOUND;
 
   /// Submits `count` items to the executor. `It` is expected to be an iterator
   /// type that implements `operator*()` and `It& operator++()`. If Priority is
@@ -390,7 +399,7 @@ template <> struct executor_traits<tmc::ex_cpu> {
     ex.post_bulk(static_cast<It&&>(Items), Count, Priority, ThreadHint);
   }
 
-  static TMC_DECL tmc::ex_any* type_erased(tmc::ex_cpu& ex);
+  static TMC_DECL tmc::ex_any* type_erased(tmc::ex_cpu& ex TMC_LIFETIMEBOUND);
 
   static TMC_DECL std::coroutine_handle<>
   dispatch(tmc::ex_cpu& ex, std::coroutine_handle<> Outer, size_t Priority);

--- a/include/tmc/ex_cpu_st.hpp
+++ b/include/tmc/ex_cpu_st.hpp
@@ -87,13 +87,13 @@ class ex_cpu_st {
 
   // Returns a lambda closure that is executed on a worker thread
   TMC_DECL auto make_worker(
-    std::atomic<tmc::detail::atomic_wait_t>& InitThreadsBarrier,
+    std::atomic<tmc::detail::atomic_wait_t>& InitThreadsBarrier TMC_LIFETIMEBOUND,
     // actually a hwloc_topology_t
     // will be nullptr if hwloc is not enabled
-    void* Topology,
+    void* Topology TMC_LIFETIMEBOUND,
     // will be nullptr if hwloc is not enabled
     tmc::detail::hwloc_unique_bitmap& CpuSet, tmc::topology::cpu_kind::value Kind
-  );
+  ) TMC_LIFETIMEBOUND;
 
   // returns true if no tasks were found (caller should wait on cv)
   // returns false if thread stop requested (caller should exit)
@@ -122,14 +122,15 @@ public:
   /// Requires `TMC_USE_HWLOC`.
   /// Builder func to limit the executor to a subset of the available CPUs.
   /// This should only be called once, as this is a single-threaded executor.
-  TMC_DECL ex_cpu_st& add_partition(tmc::topology::topology_filter Filter);
+  TMC_DECL ex_cpu_st&
+  add_partition(tmc::topology::topology_filter Filter) TMC_LIFETIMEBOUND;
 #endif
 
 #ifndef TMC_PRIORITY_COUNT
   /// Builder func to set the number of priority levels before calling `init()`.
   /// The value must be in the range [1, 16].
   /// The default is 1.
-  TMC_DECL ex_cpu_st& set_priority_count(size_t PriorityCount);
+  TMC_DECL ex_cpu_st& set_priority_count(size_t PriorityCount) TMC_LIFETIMEBOUND;
 #endif
 
   /// Gets the number of priority levels. Only useful after `init()` has been
@@ -143,23 +144,26 @@ public:
   /// after it finishes running a batch of tasks, before entering the
   /// spinning/sleeping phase. If the hook returns true, the worker will
   /// immediately re-enter the run loop to check for more work.
-  TMC_DECL ex_cpu_st& set_thread_post_run_hook(std::function<bool(size_t)> Hook);
+  TMC_DECL ex_cpu_st&
+  set_thread_post_run_hook(std::function<bool(size_t)> Hook) TMC_LIFETIMEBOUND;
 
   /// Builder func to set a hook that will be invoked at the startup of the
   /// executor thread, and passed the ordinal index of the thread (which is
   /// always 0, since this is a single-threaded executor).
-  TMC_DECL ex_cpu_st& set_thread_init_hook(std::function<void(size_t)> Hook);
+  TMC_DECL ex_cpu_st&
+  set_thread_init_hook(std::function<void(size_t)> Hook) TMC_LIFETIMEBOUND;
 
   /// Builder func to set a hook that will be invoked before destruction of each
   /// thread owned by this executor, and passed the ordinal index of the thread
   /// (which is always 0, since this is a single-threaded executor).
-  TMC_DECL ex_cpu_st& set_thread_teardown_hook(std::function<void(size_t)> Hook);
+  TMC_DECL ex_cpu_st&
+  set_thread_teardown_hook(std::function<void(size_t)> Hook) TMC_LIFETIMEBOUND;
 
   /// Builder func to set the number of times that a thread worker will spin
   /// looking for new work when all queues appear to be empty before suspending
   /// the thread.  Each spin is an asm("pause") followed by re-checking all
   /// queues. The default is 0.
-  TMC_DECL ex_cpu_st& set_spins(size_t Spins);
+  TMC_DECL ex_cpu_st& set_spins(size_t Spins) TMC_LIFETIMEBOUND;
 
   /// Initializes the executor. If you want to customize the behavior, call the
   /// `set_X()` functions before calling `init()`.
@@ -195,7 +199,7 @@ public:
   /// This object shares a lifetime with this executor, and can be used for
   /// pointer-based equality comparison against
   /// the thread-local `tmc::current_executor()`.
-  TMC_DECL tmc::ex_any* type_erased();
+  TMC_DECL tmc::ex_any* type_erased() TMC_LIFETIMEBOUND;
 
   /// Submits `count` items to the executor. `It` is expected to be an iterator
   /// type that implements `operator*()` and `It& operator++()`. If Priority is
@@ -236,7 +240,7 @@ template <> struct executor_traits<tmc::ex_cpu_st> {
     ex.post_bulk(static_cast<It&&>(Items), Count, Priority, ThreadHint);
   }
 
-  static TMC_DECL tmc::ex_any* type_erased(tmc::ex_cpu_st& ex);
+  static TMC_DECL tmc::ex_any* type_erased(tmc::ex_cpu_st& ex TMC_LIFETIMEBOUND);
 
   static TMC_DECL std::coroutine_handle<>
   dispatch(tmc::ex_cpu_st& ex, std::coroutine_handle<> Outer, size_t Priority);

--- a/include/tmc/ex_manual_st.hpp
+++ b/include/tmc/ex_manual_st.hpp
@@ -120,7 +120,7 @@ public:
   /// Builder func to set the number of priority levels before calling `init()`.
   /// The value must be in the range [1, 16].
   /// The default is 1.
-  TMC_DECL ex_manual_st& set_priority_count(size_t PriorityCount);
+  TMC_DECL ex_manual_st& set_priority_count(size_t PriorityCount) TMC_LIFETIMEBOUND;
 #endif
 
   /// Gets the number of priority levels. Only useful after `init()` has been
@@ -163,7 +163,7 @@ public:
   /// This object shares a lifetime with this executor, and can be used for
   /// pointer-based equality comparison against
   /// the thread-local `tmc::current_executor()`.
-  TMC_DECL tmc::ex_any* type_erased();
+  TMC_DECL tmc::ex_any* type_erased() TMC_LIFETIMEBOUND;
 
   /// Submits `count` items to the executor. `It` is expected to be an iterator
   /// type that implements `operator*()` and `It& operator++()`. If Priority is
@@ -212,7 +212,7 @@ template <> struct executor_traits<tmc::ex_manual_st> {
     ex.post_bulk(static_cast<It&&>(Items), Count, Priority, ThreadHint);
   }
 
-  static TMC_DECL tmc::ex_any* type_erased(tmc::ex_manual_st& ex);
+  static TMC_DECL tmc::ex_any* type_erased(tmc::ex_manual_st& ex TMC_LIFETIMEBOUND);
 
   static TMC_DECL std::coroutine_handle<> dispatch(
     tmc::ex_manual_st& ex, std::coroutine_handle<> Outer, size_t Priority

--- a/include/tmc/fork_group.hpp
+++ b/include/tmc/fork_group.hpp
@@ -300,7 +300,7 @@ public:
 
   /// Returns the result array.
   TMC_AWAIT_RESUME std::add_rvalue_reference_t<ResultArray>
-  await_resume() noexcept
+  await_resume() noexcept TMC_LIFETIMEBOUND
     requires(!std::is_void_v<Result>)
   {
     return std::move(result_arr);
@@ -457,7 +457,7 @@ struct awaitable_traits<aw_fork_group<MaxCount, Result>> {
   using self_type = aw_fork_group<MaxCount, Result>;
   using awaiter_type = aw_fork_group<MaxCount, Result>&&;
 
-  static awaiter_type get_awaiter(self_type&& Aw) noexcept {
+  static awaiter_type get_awaiter(self_type&& Aw TMC_LIFETIMEBOUND) noexcept {
     return std::forward<self_type>(Aw);
   }
 };

--- a/include/tmc/latch.hpp
+++ b/include/tmc/latch.hpp
@@ -64,7 +64,7 @@ public:
   /// Waits until the counter becomes zero.
   /// Does not decrement the counter - you must call `count_down()` separately.
   /// Equivalent to `std::latch::wait()`.
-  inline tmc::aw_manual_reset_event operator co_await() noexcept {
+  inline tmc::aw_manual_reset_event operator co_await() noexcept TMC_LIFETIMEBOUND {
     return event.operator co_await();
   }
 
@@ -79,7 +79,7 @@ template <> struct awaitable_traits<tmc::latch> {
   using self_type = tmc::latch;
   using awaiter_type = tmc::aw_manual_reset_event;
 
-  static awaiter_type get_awaiter(self_type& Awaitable) noexcept {
+  static awaiter_type get_awaiter(self_type& Awaitable TMC_LIFETIMEBOUND) noexcept {
     return Awaitable.operator co_await();
   }
 };

--- a/include/tmc/manual_reset_event.hpp
+++ b/include/tmc/manual_reset_event.hpp
@@ -27,7 +27,8 @@ class aw_manual_reset_event {
 
   friend class manual_reset_event;
 
-  inline aw_manual_reset_event(manual_reset_event& Parent) noexcept : parent(Parent) {}
+  inline aw_manual_reset_event(manual_reset_event& Parent TMC_LIFETIMEBOUND) noexcept
+      : parent(Parent) {}
 
 public:
   inline bool await_ready() noexcept { return false; }
@@ -51,7 +52,9 @@ class [[nodiscard(
 
   friend class manual_reset_event;
 
-  inline aw_manual_reset_event_co_set(manual_reset_event& Parent) noexcept
+  inline aw_manual_reset_event_co_set(
+    manual_reset_event& Parent TMC_LIFETIMEBOUND
+  ) noexcept
       : parent(Parent), wakeCount(0) {}
 
 public:
@@ -124,13 +127,13 @@ public:
   /// If the event state is already set, this will do nothing.
   /// Up to one awaiter may be resumed by symmetric transfer if it is eligible
   /// (it resumes on the same executor and priority as the caller).
-  inline aw_manual_reset_event_co_set co_set() noexcept {
+  inline aw_manual_reset_event_co_set co_set() noexcept TMC_LIFETIMEBOUND {
     return aw_manual_reset_event_co_set(*this);
   }
 
   /// If the event state is set, resumes immediately.
   /// Otherwise, waits until set() is called.
-  inline aw_manual_reset_event operator co_await() noexcept {
+  inline aw_manual_reset_event operator co_await() noexcept TMC_LIFETIMEBOUND {
     return aw_manual_reset_event(*this);
   }
 
@@ -146,7 +149,7 @@ template <> struct awaitable_traits<tmc::manual_reset_event> {
   using self_type = tmc::manual_reset_event;
   using awaiter_type = tmc::aw_manual_reset_event;
 
-  static awaiter_type get_awaiter(self_type& Awaitable) noexcept {
+  static awaiter_type get_awaiter(self_type& Awaitable TMC_LIFETIMEBOUND) noexcept {
     return Awaitable.operator co_await();
   }
 };

--- a/include/tmc/mutex.hpp
+++ b/include/tmc/mutex.hpp
@@ -29,7 +29,7 @@ mutex_scope {
 
   friend class aw_mutex_lock_scope;
 
-  inline mutex_scope(mutex* Parent) noexcept : parent(Parent) {}
+  inline mutex_scope(mutex* Parent TMC_LIFETIMEBOUND) noexcept : parent(Parent) {}
 
 public:
   // Movable but not copyable
@@ -80,7 +80,7 @@ class [[nodiscard(
 
   friend class mutex;
 
-  inline aw_mutex_co_unlock(mutex& Parent) noexcept : parent(Parent) {}
+  inline aw_mutex_co_unlock(mutex& Parent TMC_LIFETIMEBOUND) noexcept : parent(Parent) {}
 
 public:
   inline bool await_ready() noexcept { return false; }
@@ -117,11 +117,14 @@ class [[nodiscard(
 
   // For result return
   template <typename ResultArg>
-  inline aw_mutex_co_unlock_return(mutex& Parent, ResultArg&& ResultIn) noexcept
+  inline aw_mutex_co_unlock_return(
+    mutex& Parent TMC_LIFETIMEBOUND, ResultArg&& ResultIn
+  ) noexcept
       : parent(Parent), result(static_cast<ResultArg&&>(ResultIn)) {}
 
   // For void return
-  inline aw_mutex_co_unlock_return(mutex& Parent) noexcept : parent(Parent) {}
+  inline aw_mutex_co_unlock_return(mutex& Parent TMC_LIFETIMEBOUND) noexcept
+      : parent(Parent) {}
 
 public:
   inline bool await_ready() noexcept { return false; }
@@ -179,7 +182,7 @@ public:
   /// and the lock will be re-locked and transferred to that awaiter.
   /// The awaiter may be resumed by symmetric transfer if it is eligible
   /// (it resumes on the same executor and priority as the caller).
-  inline aw_mutex_co_unlock co_unlock() noexcept {
+  inline aw_mutex_co_unlock co_unlock() noexcept TMC_LIFETIMEBOUND {
     return aw_mutex_co_unlock(*this);
   }
 
@@ -208,7 +211,7 @@ public:
   /// ```
   template <typename Result>
   inline aw_mutex_co_unlock_return<Result>
-  co_unlock_return(Result&& result) noexcept {
+  co_unlock_return(Result&& result) noexcept TMC_LIFETIMEBOUND {
     return aw_mutex_co_unlock_return<Result>(
       *this, static_cast<Result&&>(result)
     );
@@ -236,7 +239,7 @@ public:
   /// co_await mut.co_unlock_return();
   /// std::unreachable();
   /// ```
-  inline aw_mutex_co_unlock_return<void> co_unlock_return() noexcept {
+  inline aw_mutex_co_unlock_return<void> co_unlock_return() noexcept TMC_LIFETIMEBOUND {
     return aw_mutex_co_unlock_return<void>(*this);
   }
 

--- a/include/tmc/mux_many.hpp
+++ b/include/tmc/mux_many.hpp
@@ -329,7 +329,7 @@ public:
 
   /// This type must be awaited as an lvalue (it is awaited repeatedly and is not
   /// movable). The awaiter is the group itself.
-  mux_many& operator co_await() & noexcept { return *this; }
+  mux_many& operator co_await() & noexcept TMC_LIFETIMEBOUND { return *this; }
 
   /// Non-suspending check for a ready result. There are three outcomes:
   /// - a result is ready: it is consumed and its index returned (like `co_await`).
@@ -358,7 +358,7 @@ public:
 
   /// Gets the ready result at the given index.
   TMC_TSAN_NO_SPECULATE inline std::add_lvalue_reference_t<Result>
-  operator[](size_t Idx) noexcept
+  operator[](size_t Idx) noexcept TMC_LIFETIMEBOUND
     requires(!std::is_void_v<Result>)
   {
     assert(Idx < result_arr.size());

--- a/include/tmc/mux_tuple.hpp
+++ b/include/tmc/mux_tuple.hpp
@@ -220,7 +220,7 @@ public:
 
   /// This type must be awaited as an lvalue (it is awaited repeatedly and is not
   /// movable). The awaiter is the group itself.
-  mux_tuple& operator co_await() & noexcept { return *this; }
+  mux_tuple& operator co_await() & noexcept TMC_LIFETIMEBOUND { return *this; }
 
   /// Non-suspending check for a ready result. There are three outcomes:
   /// - a result is ready: it is consumed and its index returned (like `co_await`).

--- a/include/tmc/qu_mpsc_bounded.hpp
+++ b/include/tmc/qu_mpsc_bounded.hpp
@@ -182,10 +182,10 @@ public:
     tmc::qu_mpsc_bounded_err err;
 
     try_pull_zc_scope(
-      qu_mpsc_bounded* Queue, element* Elem, size_t Idx
+      qu_mpsc_bounded* Queue TMC_LIFETIMEBOUND, element* Elem TMC_LIFETIMEBOUND,
+      size_t Idx
     ) noexcept
-        : queue{Queue}, elem{Elem}, idx{Idx},
-          err{tmc::qu_mpsc_bounded_err::OK} {}
+        : queue{Queue}, elem{Elem}, idx{Idx}, err{tmc::qu_mpsc_bounded_err::OK} {}
 
     explicit try_pull_zc_scope(tmc::qu_mpsc_bounded_err Err) noexcept
         : queue{nullptr}, elem{nullptr}, idx{0}, err{Err} {}
@@ -265,7 +265,10 @@ public:
     element* elem;
     size_t idx;
 
-    pull_zc_scope(qu_mpsc_bounded* Queue, element* Elem, size_t Idx) noexcept
+    pull_zc_scope(
+      qu_mpsc_bounded* Queue TMC_LIFETIMEBOUND, element* Elem TMC_LIFETIMEBOUND,
+      size_t Idx
+    ) noexcept
         : queue{Queue}, elem{Elem}, idx{Idx} {}
 
   public:
@@ -359,7 +362,8 @@ private:
 
   // Reverses a singly-linked producer chain in place. The caller must have
   // exclusive access to the chain.
-  static inline producer_base* reverse_chain(producer_base* curr) noexcept {
+  static inline producer_base*
+  reverse_chain(producer_base* curr TMC_LIFETIMEBOUND) noexcept {
     producer_base* prev = nullptr;
     while (curr != nullptr) {
       producer_base* next = curr->next;
@@ -594,7 +598,7 @@ public:
   [[nodiscard(
     "You must co_await push(). The value will not be enqueued until co_await."
   )]]
-  aw_push<Args...> push(Args&&... ConstructArgs) noexcept {
+  aw_push<Args...> push(Args&&... ConstructArgs) noexcept TMC_LIFETIMEBOUND {
     return aw_push<Args...>(*this, static_cast<Args&&>(ConstructArgs)...);
   }
 
@@ -755,7 +759,7 @@ public:
     "You must co_await pull(). To poll from a non-coroutine function, use "
     "try_pull()."
   )]] aw_pull
-  pull() noexcept
+  pull() noexcept TMC_LIFETIMEBOUND
     requires(ConsumerCanSuspend)
   {
     return aw_pull(*this);
@@ -779,7 +783,7 @@ public:
   /// `pull()`. It must also be released before the queue is destroyed. The
   /// safest way to accomplish this is to tie its scope to the loop:
   /// `while (auto data = q.try_pull()) { process(data.value()); }`
-  try_pull_zc_scope try_pull() {
+  try_pull_zc_scope try_pull() TMC_LIFETIMEBOUND {
     while (true) {
       size_t idx = read_offset;
       element* elem = &values[idx % capacity];
@@ -858,7 +862,7 @@ public:
     // across both the suspension and the resumption.
     std::tuple<Args&&...> args;
 
-    aw_push(qu_mpsc_bounded& Queue, Args&&... ConstructArgs) noexcept
+    aw_push(qu_mpsc_bounded& Queue TMC_LIFETIMEBOUND, Args&&... ConstructArgs) noexcept
         : queue(Queue), args(static_cast<Args&&>(ConstructArgs)...) {}
 
     struct aw_push_impl final {
@@ -868,9 +872,11 @@ public:
       element* elem;
       bool closed_before_enqueue;
 
-      aw_push_impl(aw_push& Parent) noexcept
-          : base{nullptr, tmc::detail::this_thread::executor(), nullptr,
-                 tmc::detail::this_thread::this_task().prio},
+      aw_push_impl(aw_push& Parent TMC_LIFETIMEBOUND) noexcept
+          : base{
+              nullptr, tmc::detail::this_thread::executor(), nullptr,
+              tmc::detail::this_thread::this_task().prio
+            },
             queue(Parent.queue), args(Parent.args), elem(nullptr),
             closed_before_enqueue(false) {}
 
@@ -946,7 +952,9 @@ public:
     };
 
   public:
-    aw_push_impl operator co_await() && noexcept { return aw_push_impl(*this); }
+    aw_push_impl operator co_await() && noexcept TMC_LIFETIMEBOUND {
+      return aw_push_impl(*this);
+    }
   };
 
   /// Returns a `pull_zc_scope` when awaited.
@@ -955,7 +963,7 @@ public:
 
     qu_mpsc_bounded& queue;
 
-    aw_pull(qu_mpsc_bounded& Queue) noexcept : queue(Queue) {}
+    aw_pull(qu_mpsc_bounded& Queue TMC_LIFETIMEBOUND) noexcept : queue(Queue) {}
 
     struct aw_pull_impl final {
       consumer_base base;

--- a/include/tmc/qu_mpsc_unbounded.hpp
+++ b/include/tmc/qu_mpsc_unbounded.hpp
@@ -231,7 +231,8 @@ public:
     tmc::qu_mpsc_unbounded_err err;
 
     try_pull_zc_scope(
-      qu_mpsc_unbounded* Queue, element* Elem, data_block* Block, size_t Idx
+      qu_mpsc_unbounded* Queue TMC_LIFETIMEBOUND, element* Elem TMC_LIFETIMEBOUND,
+      data_block* Block TMC_LIFETIMEBOUND, size_t Idx
     ) noexcept
         : queue{Queue}, elem{Elem}, block{Block}, idx{Idx},
           err{tmc::qu_mpsc_unbounded_err::OK} {}
@@ -318,7 +319,8 @@ public:
     size_t idx;
 
     pull_zc_scope(
-      qu_mpsc_unbounded* Queue, element* Elem, data_block* Block, size_t Idx
+      qu_mpsc_unbounded* Queue TMC_LIFETIMEBOUND, element* Elem TMC_LIFETIMEBOUND,
+      data_block* Block TMC_LIFETIMEBOUND, size_t Idx
     ) noexcept
         : queue{Queue}, elem{Elem}, block{Block}, idx{Idx} {}
 
@@ -464,7 +466,8 @@ private:
 
   // Given idx and a starting block, advance it until the block containing idx
   // is found.
-  static inline data_block* find_block(data_block* Block, size_t Idx) noexcept {
+  static inline data_block*
+  find_block(data_block* Block TMC_LIFETIMEBOUND, size_t Idx) noexcept {
     size_t offset = Block->offset.load(std::memory_order_relaxed);
     size_t targetOffset = Idx & ~BlockSizeMask;
     // Find or allocate the associated block
@@ -924,7 +927,7 @@ public:
 
     qu_mpsc_unbounded& queue;
 
-    aw_pull(qu_mpsc_unbounded& Queue) noexcept : queue(Queue) {}
+    aw_pull(qu_mpsc_unbounded& Queue TMC_LIFETIMEBOUND) noexcept : queue(Queue) {}
 
     struct aw_pull_impl final {
       consumer_base base;
@@ -986,7 +989,7 @@ public:
     "You must co_await pull(). To poll from a non-coroutine function, use "
     "try_pull()."
   )]] aw_pull
-  pull() noexcept
+  pull() noexcept TMC_LIFETIMEBOUND
     requires(ConsumerCanSuspend)
   {
     return aw_pull(*this);
@@ -1010,7 +1013,7 @@ public:
   /// `pull()`. It must also be released before the queue is destroyed. The
   /// safest way to accomplish this is to tie its scope to the loop:
   /// `while (auto data = q.try_pull()) { process(data.value()); }`
-  try_pull_zc_scope try_pull() {
+  try_pull_zc_scope try_pull() TMC_LIFETIMEBOUND {
     size_t Idx;
     data_block* block;
     element* elem = get_read_ticket(Idx, block);

--- a/include/tmc/qu_spsc_bounded.hpp
+++ b/include/tmc/qu_spsc_bounded.hpp
@@ -225,7 +225,10 @@ public:
     size_t idx;
     tmc::qu_spsc_bounded_err err;
 
-    try_pull_zc_scope(qu_spsc_bounded* Queue, element* Elem, size_t Idx) noexcept
+    try_pull_zc_scope(
+      qu_spsc_bounded* Queue TMC_LIFETIMEBOUND, element* Elem TMC_LIFETIMEBOUND,
+      size_t Idx
+    ) noexcept
         : queue{Queue}, elem{Elem}, idx{Idx}, err{tmc::qu_spsc_bounded_err::OK} {}
 
     explicit try_pull_zc_scope(tmc::qu_spsc_bounded_err Err) noexcept
@@ -305,7 +308,10 @@ public:
     element* elem;
     size_t idx;
 
-    pull_zc_scope(qu_spsc_bounded* Queue, element* Elem, size_t Idx) noexcept
+    pull_zc_scope(
+      qu_spsc_bounded* Queue TMC_LIFETIMEBOUND, element* Elem TMC_LIFETIMEBOUND,
+      size_t Idx
+    ) noexcept
         : queue{Queue}, elem{Elem}, idx{Idx} {}
 
   public:
@@ -476,7 +482,7 @@ public:
   [[nodiscard(
     "You must co_await push(). The value will not be enqueued until co_await."
   )]]
-  aw_push<Args...> push(Args&&... ConstructArgs) noexcept {
+  aw_push<Args...> push(Args&&... ConstructArgs) noexcept TMC_LIFETIMEBOUND {
     // close() must only be called from the single producer, so push()
     // and close() are sequenced on the same task. Pushing after close() is
     // a programming error.
@@ -546,7 +552,8 @@ public:
     "You must co_await push_bulk(). The values will not be enqueued "
     "until co_await."
   )]]
-  aw_push_bulk<std::remove_cvref_t<It>> push_bulk(It&& Items, size_t Count) noexcept {
+  aw_push_bulk<std::remove_cvref_t<It>>
+  push_bulk(It&& Items, size_t Count) noexcept TMC_LIFETIMEBOUND {
     static_assert(
       std::is_nothrow_move_constructible_v<T>,
       "push_bulk moves values from the iterator into the queue; T must be "
@@ -578,7 +585,8 @@ public:
     "You must co_await push_bulk(). The values will not be enqueued "
     "until co_await."
   )]]
-  aw_push_bulk<std::remove_cvref_t<It>> push_bulk(It&& Begin, It&& End) noexcept {
+  aw_push_bulk<std::remove_cvref_t<It>>
+  push_bulk(It&& Begin, It&& End) noexcept TMC_LIFETIMEBOUND {
     static_assert(
       std::is_nothrow_move_constructible_v<T>,
       "push_bulk moves values from the iterator into the queue; T must be "
@@ -606,7 +614,7 @@ public:
     "You must co_await push_bulk(). The values will not be enqueued "
     "until co_await."
   )]]
-  auto push_bulk(Range&& R) noexcept {
+  auto push_bulk(Range&& R) noexcept TMC_LIFETIMEBOUND {
     static_assert(
       std::is_nothrow_move_constructible_v<T>,
       "push_bulk moves values from the iterator into the queue; T must be "
@@ -717,7 +725,7 @@ public:
     // extended across both the suspension and the resumption.
     std::tuple<Args&&...> args;
 
-    aw_push(qu_spsc_bounded& Queue, Args&&... ConstructArgs) noexcept
+    aw_push(qu_spsc_bounded& Queue TMC_LIFETIMEBOUND, Args&&... ConstructArgs) noexcept
         : queue(Queue), args(static_cast<Args&&>(ConstructArgs)...) {}
 
     struct aw_push_impl final {
@@ -727,9 +735,11 @@ public:
       element* elem;
       size_t idx;
 
-      aw_push_impl(aw_push& Parent) noexcept
-          : base{tmc::detail::this_thread::executor(), nullptr,
-                 tmc::detail::this_thread::this_task().prio},
+      aw_push_impl(aw_push& Parent TMC_LIFETIMEBOUND) noexcept
+          : base{
+              tmc::detail::this_thread::executor(), nullptr,
+              tmc::detail::this_thread::this_task().prio
+            },
             queue(Parent.queue), args(Parent.args), elem(nullptr), idx(0) {}
 
       bool await_ready() noexcept {
@@ -792,7 +802,9 @@ public:
     };
 
   public:
-    aw_push_impl operator co_await() && noexcept { return aw_push_impl(*this); }
+    aw_push_impl operator co_await() && noexcept TMC_LIFETIMEBOUND {
+      return aw_push_impl(*this);
+    }
   };
 
   /// Returns `void` when awaited.
@@ -804,8 +816,15 @@ public:
     It items;
     size_t count;
 
-    aw_push_bulk(qu_spsc_bounded& Queue, It Items, size_t Count) noexcept
+    // Whether the stored iterator copy aliases caller-owned storage depends
+    // on the It type; see TMC_DISABLE_WARNING_LIFETIME_SUGGESTIONS in
+    // compat.hpp.
+    TMC_DISABLE_WARNING_LIFETIME_SUGGESTIONS_BEGIN
+    aw_push_bulk(
+      qu_spsc_bounded& Queue TMC_LIFETIMEBOUND, It Items, size_t Count
+    ) noexcept
         : queue(Queue), items(std::move(Items)), count(Count) {}
+    TMC_DISABLE_WARNING_LIFETIME_SUGGESTIONS_END
 
     struct aw_push_bulk_impl final {
       producer_base base;
@@ -815,11 +834,13 @@ public:
       size_t startIdx;
       element* lastElem;
 
-      aw_push_bulk_impl(aw_push_bulk& Parent) noexcept
-          : base{tmc::detail::this_thread::executor(), nullptr,
-                 tmc::detail::this_thread::this_task().prio},
-            queue(Parent.queue), items(Parent.items), count(Parent.count),
-            startIdx(0), lastElem(nullptr) {}
+      aw_push_bulk_impl(aw_push_bulk& Parent TMC_LIFETIMEBOUND) noexcept
+          : base{
+              tmc::detail::this_thread::executor(), nullptr,
+              tmc::detail::this_thread::this_task().prio
+            },
+            queue(Parent.queue), items(Parent.items), count(Parent.count), startIdx(0),
+            lastElem(nullptr) {}
 
       bool await_ready() noexcept {
         if (count == 0) [[unlikely]] {
@@ -906,7 +927,9 @@ public:
     };
 
   public:
-    aw_push_bulk_impl operator co_await() && noexcept { return aw_push_bulk_impl(*this); }
+    aw_push_bulk_impl operator co_await() && noexcept TMC_LIFETIMEBOUND {
+      return aw_push_bulk_impl(*this);
+    }
   };
 
   /// Returns a `pull_zc_scope` when awaited.
@@ -915,7 +938,7 @@ public:
 
     qu_spsc_bounded& queue;
 
-    aw_pull(qu_spsc_bounded& Queue) noexcept : queue(Queue) {}
+    aw_pull(qu_spsc_bounded& Queue TMC_LIFETIMEBOUND) noexcept : queue(Queue) {}
 
     struct aw_pull_impl final {
       consumer_base base;
@@ -992,7 +1015,7 @@ public:
     "You must co_await pull(). To poll from a non-coroutine function, use "
     "try_pull()."
   )]] aw_pull
-  pull() noexcept
+  pull() noexcept TMC_LIFETIMEBOUND
     requires(ConsumerCanSuspend)
   {
     return aw_pull(*this);
@@ -1016,7 +1039,7 @@ public:
   /// `pull()`. It must also be released before the queue is destroyed. The
   /// safest way to accomplish this is to tie its scope to the loop:
   /// `while (auto data = q.try_pull()) { process(data.value()); }`
-  try_pull_zc_scope try_pull() {
+  try_pull_zc_scope try_pull() TMC_LIFETIMEBOUND {
     size_t Idx;
     element* elem = get_read_ticket(Idx);
 

--- a/include/tmc/qu_spsc_unbounded.hpp
+++ b/include/tmc/qu_spsc_unbounded.hpp
@@ -218,7 +218,8 @@ public:
     tmc::qu_spsc_unbounded_err err;
 
     try_pull_zc_scope(
-      qu_spsc_unbounded* Queue, element* Elem, data_block* Block, size_t Idx
+      qu_spsc_unbounded* Queue TMC_LIFETIMEBOUND, element* Elem TMC_LIFETIMEBOUND,
+      data_block* Block TMC_LIFETIMEBOUND, size_t Idx
     ) noexcept
         : queue{Queue}, elem{Elem}, block{Block}, idx{Idx},
           err{tmc::qu_spsc_unbounded_err::OK} {}
@@ -305,7 +306,8 @@ public:
     size_t idx;
 
     pull_zc_scope(
-      qu_spsc_unbounded* Queue, element* Elem, data_block* Block, size_t Idx
+      qu_spsc_unbounded* Queue TMC_LIFETIMEBOUND, element* Elem TMC_LIFETIMEBOUND,
+      data_block* Block TMC_LIFETIMEBOUND, size_t Idx
     ) noexcept
         : queue{Queue}, elem{Elem}, block{Block}, idx{Idx} {}
 
@@ -445,7 +447,8 @@ private:
 
   // Given idx and a starting block, advance it until the block containing idx
   // is found.
-  static inline data_block* find_block(data_block* Block, size_t Idx) noexcept {
+  static inline data_block*
+  find_block(data_block* Block TMC_LIFETIMEBOUND, size_t Idx) noexcept {
     size_t offset = Block->offset.load(std::memory_order_relaxed);
     size_t targetOffset = Idx & ~BlockSizeMask;
     // Find or allocate the associated block
@@ -808,7 +811,7 @@ public:
 
     qu_spsc_unbounded& queue;
 
-    aw_pull(qu_spsc_unbounded& Queue) noexcept : queue(Queue) {}
+    aw_pull(qu_spsc_unbounded& Queue TMC_LIFETIMEBOUND) noexcept : queue(Queue) {}
 
     struct aw_pull_impl final {
       consumer_base base;
@@ -879,7 +882,7 @@ public:
     "You must co_await pull(). To poll from a non-coroutine function, use "
     "try_pull()."
   )]] aw_pull
-  pull() noexcept
+  pull() noexcept TMC_LIFETIMEBOUND
     requires(ConsumerCanSuspend)
   {
     return aw_pull(*this);
@@ -903,7 +906,7 @@ public:
   /// `pull()`. It must also be released before the queue is destroyed. The
   /// safest way to accomplish this is to tie its scope to the loop:
   /// `while (auto data = q.try_pull()) { process(data.value()); }`
-  try_pull_zc_scope try_pull() {
+  try_pull_zc_scope try_pull() TMC_LIFETIMEBOUND {
     size_t Idx;
     data_block* block;
     element* elem = get_read_ticket(Idx, block);

--- a/include/tmc/rw_lock.hpp
+++ b/include/tmc/rw_lock.hpp
@@ -6,6 +6,7 @@
 #pragma once
 #include "tmc/detail/impl.hpp" // IWYU pragma: keep
 
+#include "tmc/detail/compat.hpp"
 #include "tmc/detail/concepts_awaitable.hpp"
 #include "tmc/detail/waiter_list.hpp"
 
@@ -29,7 +30,8 @@ rw_lock_read_scope {
 
   friend class aw_rw_lock_read_scope;
 
-  inline rw_lock_read_scope(rw_lock* Parent) noexcept : parent(Parent) {}
+  inline rw_lock_read_scope(rw_lock* Parent TMC_LIFETIMEBOUND) noexcept
+      : parent(Parent) {}
 
 public:
   // Movable but not copyable
@@ -52,7 +54,8 @@ rw_lock_write_scope {
 
   friend class aw_rw_lock_write_scope;
 
-  inline rw_lock_write_scope(rw_lock* Parent) noexcept : parent(Parent) {}
+  inline rw_lock_write_scope(rw_lock* Parent TMC_LIFETIMEBOUND) noexcept
+      : parent(Parent) {}
 
 public:
   // Movable but not copyable

--- a/include/tmc/select.hpp
+++ b/include/tmc/select.hpp
@@ -175,7 +175,8 @@ public:
     requires(tmc::detail::is_awaitable<std::remove_reference_t<A>> &&
              requires(A& Obj) { Obj.cancel(); } &&
              std::is_reference_v<tmc::detail::forward_awaitable<A>>)
-  explicit cancellable(A&& Obj) : awaitable(static_cast<A&&>(Obj)), canceller{} {}
+  explicit cancellable(A&& Obj TMC_LIFETIMEBOUND)
+      : awaitable(static_cast<A&&>(Obj)), canceller{} {}
 
   /// This overload is invalid; it exists only to provide a useful compilation
   /// error. It rejects passing an awaitable directly as the canceller (the second

--- a/include/tmc/semaphore.hpp
+++ b/include/tmc/semaphore.hpp
@@ -30,7 +30,7 @@ class [[nodiscard(
 
   friend class aw_semaphore_acquire_scope;
 
-  inline semaphore_scope(semaphore* Parent) noexcept : parent(Parent) {}
+  inline semaphore_scope(semaphore* Parent TMC_LIFETIMEBOUND) noexcept : parent(Parent) {}
 
 public:
   // Movable but not copyable
@@ -83,7 +83,8 @@ class [[nodiscard(
 
   friend class semaphore;
 
-  inline aw_semaphore_co_release(semaphore& Parent) noexcept : parent(Parent) {}
+  inline aw_semaphore_co_release(semaphore& Parent TMC_LIFETIMEBOUND) noexcept
+      : parent(Parent) {}
 
 public:
   inline bool await_ready() noexcept { return false; }
@@ -121,12 +122,12 @@ class [[nodiscard(
   // For result return
   template <typename ResultArg>
   inline aw_semaphore_co_release_return(
-    semaphore& Parent, ResultArg&& ResultIn
+    semaphore& Parent TMC_LIFETIMEBOUND, ResultArg&& ResultIn
   ) noexcept
       : parent(Parent), result(static_cast<ResultArg&&>(ResultIn)) {}
 
   // For void return
-  inline aw_semaphore_co_release_return(semaphore& Parent) noexcept
+  inline aw_semaphore_co_release_return(semaphore& Parent TMC_LIFETIMEBOUND) noexcept
       : parent(Parent) {}
 
 public:
@@ -192,7 +193,7 @@ public:
   /// 1 will be awoken and the resource will be transferred to it.
   /// The awaiter may be resumed by symmetric transfer if it is eligible
   /// (it resumes on the same executor and priority as the caller).
-  inline aw_semaphore_co_release co_release() noexcept {
+  inline aw_semaphore_co_release co_release() noexcept TMC_LIFETIMEBOUND {
     return aw_semaphore_co_release(*this);
   }
 
@@ -221,7 +222,7 @@ public:
   /// ```
   template <typename Result>
   inline aw_semaphore_co_release_return<Result>
-  co_release_return(Result&& result) noexcept {
+  co_release_return(Result&& result) noexcept TMC_LIFETIMEBOUND {
     return aw_semaphore_co_release_return<Result>(
       *this, static_cast<Result&&>(result)
     );
@@ -249,7 +250,8 @@ public:
   /// co_await sem.co_release_return();
   /// std::unreachable();
   /// ```
-  inline aw_semaphore_co_release_return<void> co_release_return() noexcept {
+  inline aw_semaphore_co_release_return<void>
+  co_release_return() noexcept TMC_LIFETIMEBOUND {
     return aw_semaphore_co_release_return<void>(*this);
   }
 

--- a/include/tmc/spawn.hpp
+++ b/include/tmc/spawn.hpp
@@ -97,8 +97,8 @@ template <typename Awaitable, typename Result> class aw_spawn_fork_impl {
   // Private constructor from aw_spawn. Takes ownership of parent's
   // task.
   aw_spawn_fork_impl(
-    Awaitable&& Task, tmc::ex_any* Executor, tmc::ex_any* ContinuationExecutor,
-    size_t Priority
+    Awaitable&& Task, tmc::ex_any* Executor,
+    tmc::ex_any* ContinuationExecutor TMC_LIFETIMEBOUND, size_t Priority
   )
       : continuation{nullptr}, continuation_executor(ContinuationExecutor),
         done_count(1) {
@@ -145,7 +145,7 @@ public:
 
   /// Returns the value provided by the wrapped function.
   TMC_AWAIT_RESUME inline std::add_rvalue_reference_t<Result>
-  await_resume() noexcept
+  await_resume() noexcept TMC_LIFETIMEBOUND
     requires(!std::is_void_v<Result>)
   {
     if constexpr (std::is_default_constructible_v<Result>) {
@@ -200,12 +200,17 @@ template <typename Awaitable, typename Result> class aw_spawn_impl {
 
   friend aw_spawn<Awaitable>;
 
+  // Whether the stored Awaitable aliases the Task parameter depends on
+  // whether Awaitable is a reference type; see
+  // TMC_DISABLE_WARNING_LIFETIME_SUGGESTIONS in compat.hpp.
+  TMC_DISABLE_WARNING_LIFETIME_SUGGESTIONS_BEGIN
   aw_spawn_impl(
-    Awaitable&& Task, tmc::ex_any* Executor, tmc::ex_any* ContinuationExecutor,
-    size_t Prio
+    Awaitable&& Task, tmc::ex_any* Executor TMC_LIFETIMEBOUND,
+    tmc::ex_any* ContinuationExecutor TMC_LIFETIMEBOUND, size_t Prio
   )
       : wrapped{static_cast<Awaitable&&>(Task)}, executor{Executor},
         continuation_executor{ContinuationExecutor}, prio{Prio} {}
+  TMC_DISABLE_WARNING_LIFETIME_SUGGESTIONS_END
 
   template <typename T>
   TMC_FORCE_INLINE inline void
@@ -236,7 +241,7 @@ public:
 
   /// Returns the value provided by the wrapped task.
   TMC_AWAIT_RESUME inline std::add_rvalue_reference_t<Result>
-  await_resume() noexcept
+  await_resume() noexcept TMC_LIFETIMEBOUND
     requires(!std::is_void_v<Result>)
   {
     if constexpr (std::is_default_constructible_v<Result>) {
@@ -274,6 +279,10 @@ class [[nodiscard(
 public:
   /// It is recommended to call `spawn()` instead of using this constructor
   /// directly.
+  // Whether the stored Awaitable aliases the Task parameter depends on
+  // whether Awaitable is a reference type; see
+  // TMC_DISABLE_WARNING_LIFETIME_SUGGESTIONS in compat.hpp.
+  TMC_DISABLE_WARNING_LIFETIME_SUGGESTIONS_BEGIN
   aw_spawn(Awaitable&& Task)
       : wrapped(static_cast<Awaitable&&>(Task)),
         executor(tmc::detail::this_thread::executor()),
@@ -296,6 +305,7 @@ public:
       static_cast<Awaitable&&>(wrapped), executor, continuation_executor, prio
     );
   }
+  TMC_DISABLE_WARNING_LIFETIME_SUGGESTIONS_END
 
   /// Submits the wrapped task to the executor immediately. It cannot be awaited
   /// afterward.
@@ -370,9 +380,14 @@ struct awaitable_traits<aw_spawn<Awaitable, Result>> {
   using self_type = aw_spawn<Awaitable, Result>;
   using awaiter_type = aw_spawn_impl<Awaitable, Result>;
 
+  // Whether the returned awaiter aliases the awaitable parameter depends on
+  // whether Awaitable is a reference type; see
+  // TMC_DISABLE_WARNING_LIFETIME_SUGGESTIONS in compat.hpp.
+  TMC_DISABLE_WARNING_LIFETIME_SUGGESTIONS_BEGIN
   static awaiter_type get_awaiter(self_type&& awaitable) noexcept {
     return static_cast<self_type&&>(awaitable).operator co_await();
   }
+  TMC_DISABLE_WARNING_LIFETIME_SUGGESTIONS_END
 };
 
 } // namespace detail
@@ -384,6 +399,10 @@ struct awaitable_traits<aw_spawn<Awaitable, Result>> {
 /// `run_on()`, `resume_on()`, `with_priority()`. The task must then be
 /// submitted for execution by calling exactly one of: `co_await`, `fork()`
 /// or `detach()`.
+// Whether the returned aw_spawn aliases the Aw parameter depends on whether
+// Awaitable is a reference type; see TMC_DISABLE_WARNING_LIFETIME_SUGGESTIONS
+// in compat.hpp.
+TMC_DISABLE_WARNING_LIFETIME_SUGGESTIONS_BEGIN
 template <typename Awaitable>
 aw_spawn<tmc::detail::forward_awaitable<Awaitable>>
 spawn(TMC_CORO_AWAIT_ELIDABLE_ARGUMENT Awaitable&& Aw) {
@@ -391,6 +410,7 @@ spawn(TMC_CORO_AWAIT_ELIDABLE_ARGUMENT Awaitable&& Aw) {
     static_cast<Awaitable&&>(Aw)
   );
 }
+TMC_DISABLE_WARNING_LIFETIME_SUGGESTIONS_END
 
 /// This is a dummy awaitable. Don't store this in a variable.
 /// For HALO to work, you must `co_await tmc::fork_clang()` immediately, which
@@ -403,9 +423,10 @@ class TMC_CORO_AWAIT_ELIDABLE aw_fork_clang : tmc::detail::AwaitTagNoGroupAsIs {
   size_t prio;
 
 public:
-  aw_fork_clang(Awaitable&& Task, tmc::ex_any* Executor, size_t Priority)
-      : wrapped(static_cast<Awaitable&&>(Task)), executor{Executor},
-        prio{Priority} {}
+  aw_fork_clang(
+    Awaitable&& Task, tmc::ex_any* Executor TMC_LIFETIMEBOUND, size_t Priority
+  )
+      : wrapped(static_cast<Awaitable&&>(Task)), executor{Executor}, prio{Priority} {}
 
   /// Never suspends.
   bool await_ready() const noexcept { return true; }
@@ -437,6 +458,12 @@ public:
 /// do_some_other_work();
 /// co_await std::move(forked_task);
 /// ```
+// Marking Executor [[clang::lifetimebound]] would be wrong here: when Exec is
+// deduced as a pointer type (e.g. the tmc::current_executor() default), the
+// reference binds to a temporary pointer object, and the annotation would
+// flag valid callers that store the returned awaitable; see
+// TMC_DISABLE_WARNING_LIFETIME_SUGGESTIONS in compat.hpp.
+TMC_DISABLE_WARNING_LIFETIME_SUGGESTIONS_BEGIN
 template <typename Awaitable, typename Exec = tmc::ex_any*>
 [[nodiscard(
   "You must co_await fork_clang() immediately for HALO to be possible."
@@ -451,6 +478,7 @@ aw_fork_clang<tmc::detail::forward_awaitable<Awaitable>> fork_clang(
     tmc::detail::get_executor_traits<Exec>::type_erased(Executor), Priority
   );
 }
+TMC_DISABLE_WARNING_LIFETIME_SUGGESTIONS_END
 
 /// Similar to `tmc::spawn(Aw)` but allows the child task's allocation to be
 /// elided by combining it into the parent's allocation (HALO). This works by

--- a/include/tmc/spawn_func.hpp
+++ b/include/tmc/spawn_func.hpp
@@ -42,8 +42,8 @@ template <typename Result> class aw_spawn_func_impl {
   friend aw_spawn_func<Result>;
 
   aw_spawn_func_impl(
-    std::function<Result()>&& Func, tmc::ex_any* Executor,
-    tmc::ex_any* ContinuationExecutor, size_t Prio
+    std::function<Result()>&& Func, tmc::ex_any* Executor TMC_LIFETIMEBOUND,
+    tmc::ex_any* ContinuationExecutor TMC_LIFETIMEBOUND, size_t Prio
   )
       : wrapped(std::move(Func)), executor(Executor),
         continuation_executor(ContinuationExecutor), prio(Prio) {}
@@ -96,7 +96,7 @@ public:
 
   /// Returns the value provided by the wrapped task.
   TMC_AWAIT_RESUME inline std::add_rvalue_reference_t<Result>
-  await_resume() noexcept
+  await_resume() noexcept TMC_LIFETIMEBOUND
     requires(!std::is_void_v<Result>)
   {
     if constexpr (std::is_default_constructible_v<Result>) {
@@ -129,7 +129,7 @@ template <typename Result> class aw_spawn_func_fork_impl {
 
   aw_spawn_func_fork_impl(
     std::function<Result()>&& Func, tmc::ex_any* Executor,
-    tmc::ex_any* ContinuationExecutor, size_t Prio
+    tmc::ex_any* ContinuationExecutor TMC_LIFETIMEBOUND, size_t Prio
   )
       : continuation_executor(ContinuationExecutor) {
 #if TMC_WORK_ITEM_IS(CORO)
@@ -210,7 +210,7 @@ public:
 
   /// Returns the value provided by the wrapped task.
   TMC_AWAIT_RESUME inline std::add_rvalue_reference_t<Result>
-  await_resume() noexcept
+  await_resume() noexcept TMC_LIFETIMEBOUND
     requires(!std::is_void_v<Result>)
   {
     if constexpr (std::is_default_constructible_v<Result>) {

--- a/include/tmc/spawn_group.hpp
+++ b/include/tmc/spawn_group.hpp
@@ -291,7 +291,7 @@ struct awaitable_traits<aw_spawn_group<MaxCount, Awaitable>> {
   using self_type = aw_spawn_group<MaxCount, Awaitable>;
   using awaiter_type = aw_spawn_group<MaxCount, Awaitable>&&;
 
-  static awaiter_type get_awaiter(self_type&& Aw) noexcept {
+  static awaiter_type get_awaiter(self_type&& Aw TMC_LIFETIMEBOUND) noexcept {
     return static_cast<self_type&&>(Aw);
   }
 };

--- a/include/tmc/spawn_many.hpp
+++ b/include/tmc/spawn_many.hpp
@@ -389,7 +389,8 @@ public:
   template <typename TaskIter>
   inline aw_spawn_many_impl(
     TaskIter Iter, size_t TaskCount, tmc::ex_any* Executor,
-    tmc::ex_any* ContinuationExecutor, size_t Prio, bool DoSymmetricTransfer
+    tmc::ex_any* ContinuationExecutor TMC_LIFETIMEBOUND, size_t Prio,
+    bool DoSymmetricTransfer
   )
     requires(requires(TaskIter a) {
               ++a;
@@ -475,7 +476,8 @@ public:
   template <typename TaskIter>
   inline aw_spawn_many_impl(
     TaskIter Begin, TaskIter End, size_t MaxCount, tmc::ex_any* Executor,
-    tmc::ex_any* ContinuationExecutor, size_t Prio, bool DoSymmetricTransfer
+    tmc::ex_any* ContinuationExecutor TMC_LIFETIMEBOUND, size_t Prio,
+    bool DoSymmetricTransfer
   )
     requires(requires(TaskIter a, TaskIter b) {
               ++a;
@@ -743,7 +745,8 @@ public:
   /// `std::array<Result, Count>`. If `Count` is a runtime parameter, returns
   /// a `std::vector<Result>` with capacity `Count`. If `Result` is not
   /// default-constructible, it will be wrapped in an optional.
-  TMC_AWAIT_RESUME inline std::add_rvalue_reference_t<ResultArray> await_resume() noexcept
+  TMC_AWAIT_RESUME inline std::add_rvalue_reference_t<ResultArray>
+  await_resume() noexcept TMC_LIFETIMEBOUND
     requires(!std::is_void_v<Result>)
   {
     return std::move(result_arr);
@@ -802,6 +805,10 @@ public:
   /// For use when `TaskCount` is a runtime parameter.
   /// It is recommended to call `spawn_many()` instead of using this
   /// constructor directly.
+  // Whether the stored iterator copy aliases caller-owned storage depends on
+  // the IterBegin type; see TMC_DISABLE_WARNING_LIFETIME_SUGGESTIONS in
+  // compat.hpp.
+  TMC_DISABLE_WARNING_LIFETIME_SUGGESTIONS_BEGIN
   aw_spawn_many(IterBegin TaskIterator, IterEnd Sentinel, size_t MaxCount)
       : iter{TaskIterator}, sentinel{Sentinel}, maxCount{MaxCount},
         executor(tmc::detail::this_thread::executor()),
@@ -813,6 +820,7 @@ public:
 #endif
   {
   }
+  TMC_DISABLE_WARNING_LIFETIME_SUGGESTIONS_END
 
   aw_spawn_many_impl<Result, Count, IsFunc> operator co_await() && noexcept {
 #ifndef NDEBUG

--- a/include/tmc/spawn_tuple.hpp
+++ b/include/tmc/spawn_tuple.hpp
@@ -91,8 +91,9 @@ template <typename... Awaitable> class aw_spawn_tuple_impl {
   }
 
   aw_spawn_tuple_impl(
-    AwaitableTuple&& Tasks, tmc::ex_any* Executor, tmc::ex_any* ContinuationExecutor,
-    size_t Prio, bool DoSymmetricTransfer
+    AwaitableTuple&& Tasks, tmc::ex_any* Executor,
+    tmc::ex_any* ContinuationExecutor TMC_LIFETIMEBOUND, size_t Prio,
+    bool DoSymmetricTransfer
   )
       : symmetric_task{nullptr}, continuation_executor{ContinuationExecutor} {
     std::array<work_item, WorkItemCount> taskArr;
@@ -201,7 +202,7 @@ public:
   /// void, its slot is represented by a std::monostate. If the awaitable would
   /// return a non-default-constructible type, that result will be wrapped in a
   /// std::optional.
-  TMC_AWAIT_RESUME inline ResultTuple&& await_resume() noexcept {
+  TMC_AWAIT_RESUME inline ResultTuple&& await_resume() noexcept TMC_LIFETIMEBOUND {
     return std::move(result);
   }
 

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -98,7 +98,7 @@ struct [[nodiscard(
     "You must submit or co_await task for execution. Failure to "
     "do so will result in a memory leak."
   )]] inline task&
-  resume_on(tmc::ex_any* Executor) & noexcept {
+  resume_on(tmc::ex_any* Executor) & noexcept TMC_LIFETIMEBOUND {
     // This overload is called by the other overloads.
     handle.promise().customizer.continuation_executor = Executor;
     return *this;
@@ -110,7 +110,7 @@ struct [[nodiscard(
     "You must submit or co_await task for execution. Failure to "
     "do so will result in a memory leak."
   )]] task&
-  resume_on(Exec&& Executor) & noexcept {
+  resume_on(Exec&& Executor) & noexcept TMC_LIFETIMEBOUND {
     return resume_on(
       tmc::detail::get_executor_traits<Exec>::type_erased(Executor)
     );
@@ -134,7 +134,7 @@ struct [[nodiscard(
     "You must submit or co_await task for execution. Failure to "
     "do so will result in a memory leak."
   )]] inline task&&
-  resume_on(tmc::ex_any* Executor) && noexcept {
+  resume_on(tmc::ex_any* Executor) && noexcept TMC_LIFETIMEBOUND {
     // This overload is called by the other overloads.
     handle.promise().customizer.continuation_executor = Executor;
     return std::move(*this);
@@ -146,7 +146,7 @@ struct [[nodiscard(
     "You must submit or co_await task for execution. Failure to "
     "do so will result in a memory leak."
   )]] task&&
-  resume_on(Exec&& Executor) && noexcept {
+  resume_on(Exec&& Executor) && noexcept TMC_LIFETIMEBOUND {
     handle.promise().customizer.continuation_executor =
       tmc::detail::get_executor_traits<Exec>::type_erased(Executor);
     return std::move(*this);
@@ -291,6 +291,10 @@ template <typename Result> struct task_promise {
     *customizer.result_ptr = static_cast<RV&&>(Value);
   }
 
+  // Whether the returned awaiter is lifetime-bound to the awaitable parameter
+  // depends on the Awaitable type; see TMC_DISABLE_WARNING_LIFETIME_SUGGESTIONS
+  // in compat.hpp.
+  TMC_DISABLE_WARNING_LIFETIME_SUGGESTIONS_BEGIN
   template <typename Awaitable>
   decltype(auto) await_transform(Awaitable&& awaitable) noexcept
     requires is_known_awaitable<Awaitable>
@@ -302,6 +306,7 @@ template <typename Result> struct task_promise {
       std::forward<Awaitable>(awaitable)
     );
   }
+  TMC_DISABLE_WARNING_LIFETIME_SUGGESTIONS_END
 
 #ifndef TMC_NO_UNKNOWN_AWAITABLES
   template <typename Awaitable>
@@ -388,6 +393,10 @@ template <> struct task_promise<void> {
 
   void return_void() noexcept {}
 
+  // Whether the returned awaiter is lifetime-bound to the awaitable parameter
+  // depends on the Awaitable type; see TMC_DISABLE_WARNING_LIFETIME_SUGGESTIONS
+  // in compat.hpp.
+  TMC_DISABLE_WARNING_LIFETIME_SUGGESTIONS_BEGIN
   template <typename Awaitable>
   decltype(auto) await_transform(Awaitable&& awaitable) noexcept
     requires is_known_awaitable<Awaitable>
@@ -399,6 +408,7 @@ template <> struct task_promise<void> {
       std::forward<Awaitable>(awaitable)
     );
   }
+  TMC_DISABLE_WARNING_LIFETIME_SUGGESTIONS_END
 
 #ifndef TMC_NO_UNKNOWN_AWAITABLES
   template <typename Awaitable>
@@ -498,7 +508,7 @@ public:
   }
 
   /// Returns the value provided by the awaited task.
-  TMC_AWAIT_RESUME inline Result&& await_resume() noexcept {
+  TMC_AWAIT_RESUME inline Result&& await_resume() noexcept TMC_LIFETIMEBOUND {
     if constexpr (std::is_default_constructible_v<Result>) {
       return std::move(result);
     } else {

--- a/include/tmc/topology.hpp
+++ b/include/tmc/topology.hpp
@@ -9,6 +9,8 @@
 
 #include "tmc/detail/impl.hpp" // IWYU pragma: keep
 
+#include "tmc/detail/compat.hpp"
+
 #include <cstddef>
 #include <vector>
 
@@ -34,7 +36,7 @@ struct cpu_kind {
     );
   }
 
-  friend constexpr value& operator|=(value& lhs, value rhs) {
+  friend constexpr value& operator|=(value& lhs TMC_LIFETIMEBOUND, value rhs) {
     lhs = lhs | rhs;
     return lhs;
   }
@@ -214,13 +216,13 @@ public:
   TMC_DECL topology_filter operator|(topology_filter const& rhs) const;
 
   /// Gets the allowed core indexes.
-  TMC_DECL std::vector<size_t> const& core_indexes() const;
+  TMC_DECL std::vector<size_t> const& core_indexes() const TMC_LIFETIMEBOUND;
 
   /// Gets the allowed group indexes.
-  TMC_DECL std::vector<size_t> const& group_indexes() const;
+  TMC_DECL std::vector<size_t> const& group_indexes() const TMC_LIFETIMEBOUND;
 
   /// Gets the allowed NUMA indexes.
-  TMC_DECL std::vector<size_t> const& numa_indexes() const;
+  TMC_DECL std::vector<size_t> const& numa_indexes() const TMC_LIFETIMEBOUND;
 
   /// Gets the allowed CPU kinds. This is a bitmap that may combine multiple
   /// cpu_kind values.

--- a/include/tmc/utils.hpp
+++ b/include/tmc/utils.hpp
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include "tmc/detail/compat.hpp"
+
 #include <type_traits>
 
 namespace tmc {
@@ -41,7 +43,7 @@ public:
 
   value_type operator*() { return func(it); }
 
-  auto& operator++() {
+  auto& operator++() TMC_LIFETIMEBOUND {
     ++it;
     return *this;
   }


### PR DESCRIPTION
Clang 23 adds several new diagnostic warnings (`-Wlifetime-safety` class) that can detect certain classes of dangling references. This warning suggests to add `[[clang::lifetimebound]]` to a number of methods that reference object or `this` parameters. To maintain the goal of building TMC + examples/tests without any warnings, I've added these attributes in TMC.

This should be backward compatible; it only serves to detect invalid usage (dangling references). If you're not building with Clang 23+, it will be inert.