### PR TITLE
add static_assert to clang HALO functions to prevent silent HALO failure

### DIFF
--- a/include/tmc/detail/task_wrapper.hpp
+++ b/include/tmc/detail/task_wrapper.hpp
@@ -11,19 +11,36 @@
 #include "tmc/detail/awaitable_customizer.hpp"
 #include "tmc/detail/compat.hpp"
 #include "tmc/detail/concepts_awaitable.hpp"
+#include "tmc/detail/impl.hpp" // IWYU pragma: keep
 
 #include <coroutine>
 #include <exception>
 
+#ifdef TMC_DEBUG_TASK_ALLOC_COUNT
+#include <atomic>
+#include <cstddef>
+#include <new>
+#endif
+
 namespace tmc {
 namespace detail {
+#ifdef TMC_DEBUG_TASK_ALLOC_COUNT
+#ifdef TMC_WINDOWS_DLL
+TMC_DECL extern std::atomic<size_t> g_task_alloc_count;
+#ifdef TMC_IMPL
+TMC_DECL constinit std::atomic<size_t> g_task_alloc_count = 0;
+#endif
+#else
+inline constinit std::atomic<size_t> g_task_alloc_count = 0;
+#endif
+#endif
 
 template <typename Result> struct task_wrapper_promise;
 template <typename Result> class aw_task_wrapper;
 
 // Same as task, but doesn't use await_transform.
 // Used to safely wrap unknown awaitables.
-template <typename Result> struct task_wrapper {
+template <typename Result> struct TMC_CORO_AWAIT_ELIDABLE task_wrapper {
   using promise_type = tmc::detail::task_wrapper_promise<Result>;
   using result_type = Result;
   std::coroutine_handle<promise_type> handle;
@@ -104,6 +121,20 @@ template <typename Result> struct task_wrapper_promise {
   ) {
     *customizer.result_ptr = static_cast<RV&&>(Value);
   }
+
+#ifdef TMC_DEBUG_TASK_ALLOC_COUNT
+  // Count frame allocations so that tests can detect whether HALO occurred.
+  static void* operator new(std::size_t n) {
+    ++tmc::detail::g_task_alloc_count;
+    return ::operator new(n);
+  }
+
+  // Aligned new is necessary to support -fcoro-aligned-allocation
+  static void* operator new(std::size_t n, std::align_val_t al) {
+    ++tmc::detail::g_task_alloc_count;
+    return ::operator new(n, al);
+  }
+#endif
 };
 
 template <> struct task_wrapper_promise<void> {
@@ -134,6 +165,20 @@ template <> struct task_wrapper_promise<void> {
 #endif
 
   void return_void() noexcept {}
+
+#ifdef TMC_DEBUG_TASK_ALLOC_COUNT
+  // Count frame allocations so that tests can detect whether HALO occurred.
+  static void* operator new(std::size_t n) {
+    ++tmc::detail::g_task_alloc_count;
+    return ::operator new(n);
+  }
+
+  // Aligned new is necessary to support -fcoro-aligned-allocation
+  static void* operator new(std::size_t n, std::align_val_t al) {
+    ++tmc::detail::g_task_alloc_count;
+    return ::operator new(n, al);
+  }
+#endif
 };
 
 template <typename Result>

--- a/include/tmc/fork_group.hpp
+++ b/include/tmc/fork_group.hpp
@@ -249,6 +249,13 @@ public:
     Exec&& Executor = tmc::current_executor(),
     size_t Priority = tmc::current_priority()
   ) {
+    static_assert(
+      tmc::detail::get_awaitable_traits<Awaitable>::mode !=
+        tmc::detail::WRAPPER,
+      "This type needs a task wrapper. For allocation-free operation, wrap it yourself with `tmc::as_task()`; the explicit wrapper can be HALO'd. "
+      "`co_await fg.fork_clang(tmc::as_task(awaitable));`"
+      " Otherwise, use fg.fork(awaitable) which will internally allocate the wrapper."
+    );
     fork(static_cast<Awaitable&&>(Aw), static_cast<Exec&&>(Executor), Priority);
     return aw_fork_group_fork_clang{};
   }

--- a/include/tmc/mux_many.hpp
+++ b/include/tmc/mux_many.hpp
@@ -509,6 +509,12 @@ public:
     size_t Idx, TMC_CORO_AWAIT_ELIDABLE_ARGUMENT Aw&& Awaitable,
     Exec&& Executor = tmc::current_executor(), size_t Priority = tmc::current_priority()
   ) {
+    static_assert(
+      tmc::detail::get_awaitable_traits<Aw>::mode != tmc::detail::WRAPPER,
+      "This type needs a task wrapper. For allocation-free operation, wrap it yourself with `tmc::as_task()`; the explicit wrapper can be HALO'd. "
+      "`co_await mux.fork_clang(i, tmc::as_task(awaitable));`"
+      " Otherwise, use mux.fork(i, awaitable) which will internally allocate the wrapper."
+    );
     fork(Idx, static_cast<Aw&&>(Awaitable), static_cast<Exec&&>(Executor), Priority);
     return mux_many_fork_clang{};
   }

--- a/include/tmc/mux_tuple.hpp
+++ b/include/tmc/mux_tuple.hpp
@@ -391,6 +391,12 @@ public:
     TMC_CORO_AWAIT_ELIDABLE_ARGUMENT Aw&& Awaitable,
     Exec&& Executor = tmc::current_executor(), size_t Priority = tmc::current_priority()
   ) {
+    static_assert(
+      tmc::detail::get_awaitable_traits<Aw>::mode != tmc::detail::WRAPPER,
+      "This type needs a task wrapper. For allocation-free operation, wrap it yourself with `tmc::as_task()`; the explicit wrapper can be HALO'd. "
+      "`co_await mux.fork_clang<I>(tmc::as_task(awaitable));`"
+      " Otherwise, use mux.fork<I>(awaitable) which will internally allocate the wrapper."
+    );
     fork<I>(static_cast<Aw&&>(Awaitable), static_cast<Exec&&>(Executor), Priority);
     return mux_tuple_fork_clang{};
   }

--- a/include/tmc/spawn.hpp
+++ b/include/tmc/spawn.hpp
@@ -473,6 +473,12 @@ aw_fork_clang<tmc::detail::forward_awaitable<Awaitable>> fork_clang(
   Exec&& Executor = tmc::current_executor(),
   size_t Priority = tmc::current_priority()
 ) {
+  static_assert(
+    tmc::detail::get_awaitable_traits<Awaitable>::mode != tmc::detail::WRAPPER,
+    "This type needs a task wrapper. For allocation-free operation, wrap it yourself with `tmc::as_task()`; the explicit wrapper can be HALO'd. "
+    "`auto forked = co_await tmc::fork_clang(tmc::as_task(awaitable));`"
+    " Otherwise, use tmc::spawn(awaitable).fork() which will internally allocate the wrapper."
+  );
   return aw_fork_clang<tmc::detail::forward_awaitable<Awaitable>>(
     static_cast<Awaitable&&>(Aw),
     tmc::detail::get_executor_traits<Exec>::type_erased(Executor), Priority
@@ -497,6 +503,12 @@ aw_spawn<tmc::detail::forward_awaitable<Awaitable>> spawn_clang(
   Exec&& Executor = tmc::current_executor(),
   size_t Priority = tmc::current_priority()
 ) {
+  static_assert(
+    tmc::detail::get_awaitable_traits<Awaitable>::mode != tmc::detail::WRAPPER,
+    "This type needs a task wrapper. For allocation-free operation, wrap it yourself with `tmc::as_task()`; the explicit wrapper can be HALO'd. "
+    "`co_await tmc::spawn_clang(tmc::as_task(awaitable));`"
+    " Otherwise, use tmc::spawn(awaitable) which will internally allocate the wrapper."
+  );
   return tmc::spawn(static_cast<Awaitable&&>(Aw))
     .run_on(Executor)
     .with_priority(Priority);

--- a/include/tmc/spawn_group.hpp
+++ b/include/tmc/spawn_group.hpp
@@ -165,6 +165,13 @@ public:
   )]]
   aw_spawn_group_add_clang
   add_clang(TMC_CORO_AWAIT_ELIDABLE_ARGUMENT Awaitable&& Aw) {
+    static_assert(
+      tmc::detail::get_awaitable_traits<Awaitable>::mode !=
+        tmc::detail::WRAPPER,
+      "This type needs a task wrapper. For allocation-free operation, wrap it yourself with `tmc::as_task()`; the explicit wrapper can be HALO'd. "
+      "`co_await sg.add_clang(tmc::as_task(awaitable));`"
+      " Otherwise, use sg.add(awaitable) which will internally allocate the wrapper."
+    );
     add(std::move(Aw));
     return aw_spawn_group_add_clang{};
   }

--- a/include/tmc/spawn_tuple.hpp
+++ b/include/tmc/spawn_tuple.hpp
@@ -464,6 +464,14 @@ template <typename... Awaitable>
 [[nodiscard("You must co_await fork_tuple_clang() immediately for HALO to be possible.")]]
 aw_fork_tuple_clang<tmc::detail::forward_awaitable<Awaitable>...>
 fork_tuple_clang(TMC_CORO_AWAIT_ELIDABLE_ARGUMENT Awaitable&&... Awaitables) {
+  static_assert(
+    ((tmc::detail::get_awaitable_traits<Awaitable>::mode !=
+      tmc::detail::WRAPPER) &&
+     ...),
+    "This type needs a task wrapper. For allocation-free operation, wrap it yourself with `tmc::as_task()`; the explicit wrapper can be HALO'd. "
+    "auto forked = `co_await tmc::fork_tuple_clang(tmc::as_task(awaitable), ...);`"
+    " Otherwise, use spawn_tuple(awaitable...).fork() which will internally allocate the wrapper."
+  );
   return aw_fork_tuple_clang<tmc::detail::forward_awaitable<Awaitable>...>(
     std::forward_as_tuple(static_cast<Awaitable&&>(Awaitables)...)
   );

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -561,6 +561,7 @@ using as_task_return_t = std::conditional_t<
 } // namespace detail
 
 /// Returns a new task that awaits the given awaitable and returns its result.
+/// Ignore the `Empty` parameter - it is an overload resolution hack only.
 ///
 /// The awaitable is forwarded according to these rules:
 /// - Lvalues are held by lvalue reference; they must outlive the returned task.

--- a/include/tmc/task.hpp
+++ b/include/tmc/task.hpp
@@ -5,8 +5,6 @@
 
 #pragma once
 
-#include "tmc/detail/impl.hpp" // IWYU pragma: keep
-
 #include "tmc/detail/awaitable_customizer.hpp"
 #include "tmc/detail/compat.hpp"
 #include "tmc/detail/concepts_awaitable.hpp" // IWYU pragma: keep
@@ -28,16 +26,6 @@
 
 namespace tmc {
 namespace detail {
-#ifdef TMC_DEBUG_TASK_ALLOC_COUNT
-#ifdef TMC_WINDOWS_DLL
-TMC_DECL extern std::atomic<size_t> g_task_alloc_count;
-#ifdef TMC_IMPL
-TMC_DECL constinit std::atomic<size_t> g_task_alloc_count = 0;
-#endif
-#else
-inline constinit std::atomic<size_t> g_task_alloc_count = 0;
-#endif
-#endif
 
 template <typename Result> struct task_promise;
 } // namespace detail
@@ -111,9 +99,7 @@ struct [[nodiscard(
     "do so will result in a memory leak."
   )]] task&
   resume_on(Exec&& Executor) & noexcept TMC_LIFETIMEBOUND {
-    return resume_on(
-      tmc::detail::get_executor_traits<Exec>::type_erased(Executor)
-    );
+    return resume_on(tmc::detail::get_executor_traits<Exec>::type_erased(Executor));
   }
   /// When this task completes, the awaiting coroutine will be resumed
   /// on the provided executor.
@@ -123,9 +109,7 @@ struct [[nodiscard(
     "do so will result in a memory leak."
   )]] task&
   resume_on(Exec* Executor) & noexcept {
-    return resume_on(
-      tmc::detail::get_executor_traits<Exec>::type_erased(*Executor)
-    );
+    return resume_on(tmc::detail::get_executor_traits<Exec>::type_erased(*Executor));
   }
 
   /// When this task completes, the awaiting coroutine will be resumed
@@ -283,11 +267,11 @@ template <typename Result> struct task_promise {
   [[noreturn]] void unhandled_exception() noexcept { std::terminate(); }
 
   template <typename RV>
-  void
-  return_value(RV&& Value) noexcept(std::is_nothrow_move_constructible_v<RV>)
+  void return_value(RV&& Value) noexcept(std::is_nothrow_move_constructible_v<RV>)
     requires(requires() {
-      { *customizer.result_ptr = static_cast<RV &&>(Value) };
-    }) {
+      { *customizer.result_ptr = static_cast<RV&&>(Value) };
+    })
+  {
     *customizer.result_ptr = static_cast<RV&&>(Value);
   }
 
@@ -338,8 +322,7 @@ template <typename Result> struct task_promise {
     // DEBUG - Print the size of the coroutine allocation.
     // std::printf("task_promise new %zu -> %zu\n", n, (n + TMC_CACHE_LINE_SIZE
     // - 1) & static_cast<size_t>(0-TMC_CACHE_LINE_SIZE));
-    n = (n + TMC_CACHE_LINE_SIZE - 1) &
-        static_cast<size_t>(0 - TMC_CACHE_LINE_SIZE);
+    n = (n + TMC_CACHE_LINE_SIZE - 1) & static_cast<size_t>(0 - TMC_CACHE_LINE_SIZE);
     return ::operator new(n);
   }
 
@@ -351,30 +334,24 @@ template <typename Result> struct task_promise {
 
     // std::printf("task_promise new %zu -> %zu\n", n, (n + TMC_CACHE_LINE_SIZE
     // - 1) & static_cast<size_t>(0-TMC_CACHE_LINE_SIZE));
-    n = (n + TMC_CACHE_LINE_SIZE - 1) &
-        static_cast<size_t>(0 - TMC_CACHE_LINE_SIZE);
+    n = (n + TMC_CACHE_LINE_SIZE - 1) & static_cast<size_t>(0 - TMC_CACHE_LINE_SIZE);
     return ::operator new(n, al);
   }
 
 #if TMC_SIZED_DEALLOCATION
   static void operator delete(void* ptr, std::size_t n) noexcept {
-    n = (n + TMC_CACHE_LINE_SIZE - 1) &
-        static_cast<size_t>(0 - TMC_CACHE_LINE_SIZE);
+    n = (n + TMC_CACHE_LINE_SIZE - 1) & static_cast<size_t>(0 - TMC_CACHE_LINE_SIZE);
     return ::operator delete(ptr, n);
   }
-  static void
-  operator delete(void* ptr, std::size_t n, std::align_val_t al) noexcept {
-    n = (n + TMC_CACHE_LINE_SIZE - 1) &
-        static_cast<size_t>(0 - TMC_CACHE_LINE_SIZE);
+  static void operator delete(void* ptr, std::size_t n, std::align_val_t al) noexcept {
+    n = (n + TMC_CACHE_LINE_SIZE - 1) & static_cast<size_t>(0 - TMC_CACHE_LINE_SIZE);
     return ::operator delete(ptr, n, al);
   }
 #endif
 
 #ifndef __clang__
   // GCC creates a TON of warnings if this is missing with the noexcept new
-  static task<Result> get_return_object_on_allocation_failure() noexcept {
-    return {};
-  }
+  static task<Result> get_return_object_on_allocation_failure() noexcept { return {}; }
 #endif
 };
 
@@ -386,9 +363,7 @@ template <> struct task_promise<void> {
   inline mt1_continuation_resumer<task_promise> final_suspend() const noexcept {
     return {};
   }
-  task<void> get_return_object() noexcept {
-    return {task<void>::from_promise(*this)};
-  }
+  task<void> get_return_object() noexcept { return {task<void>::from_promise(*this)}; }
   [[noreturn]] void unhandled_exception() noexcept { std::terminate(); }
 
   void return_void() noexcept {}
@@ -440,8 +415,7 @@ template <> struct task_promise<void> {
     // DEBUG - Print the size of the coroutine allocation.
     // std::printf("task_promise new %zu -> %zu\n", n, (n + TMC_CACHE_LINE_SIZE
     // - 1) & static_cast<size_t>(0-TMC_CACHE_LINE_SIZE));
-    n = (n + TMC_CACHE_LINE_SIZE - 1) &
-        static_cast<size_t>(0 - TMC_CACHE_LINE_SIZE);
+    n = (n + TMC_CACHE_LINE_SIZE - 1) & static_cast<size_t>(0 - TMC_CACHE_LINE_SIZE);
     return ::operator new(n);
   }
 
@@ -453,30 +427,24 @@ template <> struct task_promise<void> {
 
     // std::printf("task_promise new %zu -> %zu\n", n, (n + TMC_CACHE_LINE_SIZE
     // - 1) & static_cast<size_t>(0-TMC_CACHE_LINE_SIZE));
-    n = (n + TMC_CACHE_LINE_SIZE - 1) &
-        static_cast<size_t>(0 - TMC_CACHE_LINE_SIZE);
+    n = (n + TMC_CACHE_LINE_SIZE - 1) & static_cast<size_t>(0 - TMC_CACHE_LINE_SIZE);
     return ::operator new(n, al);
   }
 
 #if TMC_SIZED_DEALLOCATION
   static void operator delete(void* ptr, std::size_t n) noexcept {
-    n = (n + TMC_CACHE_LINE_SIZE - 1) &
-        static_cast<size_t>(0 - TMC_CACHE_LINE_SIZE);
+    n = (n + TMC_CACHE_LINE_SIZE - 1) & static_cast<size_t>(0 - TMC_CACHE_LINE_SIZE);
     return ::operator delete(ptr, n);
   }
-  static void
-  operator delete(void* ptr, std::size_t n, std::align_val_t al) noexcept {
-    n = (n + TMC_CACHE_LINE_SIZE - 1) &
-        static_cast<size_t>(0 - TMC_CACHE_LINE_SIZE);
+  static void operator delete(void* ptr, std::size_t n, std::align_val_t al) noexcept {
+    n = (n + TMC_CACHE_LINE_SIZE - 1) & static_cast<size_t>(0 - TMC_CACHE_LINE_SIZE);
     return ::operator delete(ptr, n, al);
   }
 #endif
 
 #ifndef __clang__
   // GCC creates a TON of warnings if this is missing with the noexcept new
-  static task<void> get_return_object_on_allocation_failure() noexcept {
-    return {};
-  }
+  static task<void> get_return_object_on_allocation_failure() noexcept { return {}; }
 #endif
 };
 } // namespace detail
@@ -488,22 +456,16 @@ template <typename Awaitable, typename Result> class aw_task {
   friend Awaitable;
   friend tmc::detail::awaitable_traits<Awaitable>;
   aw_task(Awaitable&& Handle) noexcept : handle(std::move(Handle)) {
-    assert(
-      handle.address() != nullptr &&
-      "You may only submit or co_await this once."
-    );
+    assert(handle.address() != nullptr && "You may only submit or co_await this once.");
   }
 
 public:
   inline constexpr bool await_ready() const noexcept { return false; }
-  inline std::coroutine_handle<>
-  await_suspend(std::coroutine_handle<> Outer) noexcept {
+  inline std::coroutine_handle<> await_suspend(std::coroutine_handle<> Outer) noexcept {
     tmc::detail::get_awaitable_traits<Awaitable>::set_continuation(
       handle, Outer.address()
     );
-    tmc::detail::get_awaitable_traits<Awaitable>::set_result_ptr(
-      handle, &result
-    );
+    tmc::detail::get_awaitable_traits<Awaitable>::set_result_ptr(handle, &result);
     return std::move(handle);
   }
 
@@ -529,16 +491,12 @@ template <typename Awaitable> class aw_task<Awaitable, void> {
   friend Awaitable;
   friend tmc::detail::awaitable_traits<Awaitable>;
   aw_task(Awaitable&& Handle) noexcept : handle(std::move(Handle)) {
-    assert(
-      handle.address() != nullptr &&
-      "You may only submit or co_await this once."
-    );
+    assert(handle.address() != nullptr && "You may only submit or co_await this once.");
   }
 
 public:
   inline constexpr bool await_ready() const noexcept { return false; }
-  inline std::coroutine_handle<>
-  await_suspend(std::coroutine_handle<> Outer) noexcept {
+  inline std::coroutine_handle<> await_suspend(std::coroutine_handle<> Outer) noexcept {
     tmc::detail::get_awaitable_traits<Awaitable>::set_continuation(
       handle, Outer.address()
     );
@@ -575,13 +533,11 @@ template <typename Result> struct awaitable_traits<tmc::task<Result>> {
     Awaitable.promise().customizer.result_ptr = ResultPtr;
   }
 
-  static void
-  set_continuation(self_type& Awaitable, void* Continuation) noexcept {
+  static void set_continuation(self_type& Awaitable, void* Continuation) noexcept {
     Awaitable.promise().customizer.continuation = Continuation;
   }
 
-  static void
-  set_continuation_executor(self_type& Awaitable, void* ContExec) noexcept {
+  static void set_continuation_executor(self_type& Awaitable, void* ContExec) noexcept {
     Awaitable.promise().customizer.continuation_executor = ContExec;
   }
 
@@ -593,5 +549,71 @@ template <typename Result> struct awaitable_traits<tmc::task<Result>> {
     Awaitable.promise().customizer.flags = Flags;
   }
 };
+
+// The return type of tmc::as_task(): a tmc::task for known awaitables (those
+// with a specialized awaitable_traits), or a task_wrapper for unknown
+// awaitables (which restores the awaiting task to its original executor and
+// priority, like safe_wrap() does).
+template <typename Awaitable, typename Result>
+using as_task_return_t = std::conditional_t<
+  tmc::detail::is_known_awaitable<Awaitable>, tmc::task<Result>,
+  tmc::detail::task_wrapper<Result>>;
 } // namespace detail
+
+/// Returns a new task that awaits the given awaitable and returns its result.
+///
+/// The awaitable is forwarded according to these rules:
+/// - Lvalues are held by lvalue reference; they must outlive the returned task.
+/// - Move-constructible rvalues are stored in the returned task's coroutine
+///   frame by value.
+/// - Non-movable rvalues are held by rvalue reference; to avoid UAF, the returned task
+///   must complete within the same full-expression (e.g. by direct `co_await`).
+template <
+  typename Awaitable, typename Result = tmc::detail::awaitable_result_t<Awaitable>,
+  typename... Empty>
+  requires(sizeof...(Empty) == 0 && std::is_move_constructible_v<Awaitable>)
+tmc::detail::as_task_return_t<Awaitable, Result> as_task(
+  TMC_CORO_AWAIT_ELIDABLE_ARGUMENT Awaitable Aw, Empty...
+) noexcept(std::is_nothrow_move_constructible_v<Awaitable>) {
+  // The empty function parameter pack above is intentional. It makes this
+  // by-value overload less specialized than the forwarding-reference overload
+  // for lvalue arguments. Otherwise a plain `Awaitable` overload and an `Awaitable&`
+  // overload would be ambiguous.
+  static_assert(
+    !std::is_same_v<Result, tmc::detail::unknown_t>,
+    "This doesn't appear to be an awaitable."
+  );
+  if constexpr (std::is_void_v<Result>) {
+    co_await std::move(Aw);
+  } else {
+    co_return co_await std::move(Aw);
+  }
+}
+
+/// Returns a new task that awaits the given awaitable and returns its result.
+///
+/// The awaitable is forwarded according to these rules:
+/// - Lvalues are held by lvalue reference; they must outlive the returned task.
+/// - Move-constructible rvalues are stored in the returned task's coroutine
+///   frame by value.
+/// - Non-movable rvalues are held by rvalue reference; to avoid UAF, the returned task
+///   must complete within the same full-expression (e.g. by direct `co_await`).
+template <
+  typename Awaitable, typename Result = tmc::detail::awaitable_result_t<Awaitable>>
+  requires(
+    std::is_lvalue_reference_v<Awaitable> ||
+    !std::is_move_constructible_v<std::decay_t<Awaitable>>
+  )
+tmc::detail::as_task_return_t<Awaitable, Result>
+as_task(TMC_CORO_AWAIT_ELIDABLE_ARGUMENT Awaitable&& Aw) noexcept {
+  static_assert(
+    !std::is_same_v<Result, tmc::detail::unknown_t>,
+    "This doesn't appear to be an awaitable."
+  );
+  if constexpr (std::is_void_v<Result>) {
+    co_await static_cast<Awaitable&&>(Aw);
+  } else {
+    co_return co_await static_cast<Awaitable&&>(Aw);
+  }
+}
 } // namespace tmc


### PR DESCRIPTION
Motivating example, which previously would compile, but HALO doesn't work - a task wrapper is generated internally which causes an allocation. This is most relevant in the "join streams" usage of mux, where an awaitable is being re-forked into the same slot repeatedly.
```
co_await mux.fork_clang<0>(q.pull()); // secretly allocates a wrapper task
```

Now there is a static_assert that detects when the wrapper would be created internally, and directs you to use the newly added `tmc::as_task` wrapper function at the call site instead. Since this wrapper is created externally, it can be HALO'd.
```
co_await q.pull(); // 0 allocations
mux.fork<0>(q.pull()); // 1 allocation
co_await mux.fork_clang<0>(q.pull()); // 1 allocation, user wanted HALO - no longer compiles
co_await mux.fork_clang<0>(tmc::as_task(q.pull())); // 0 allocations
```

Note that this static_assert only fires then the awaitable mode is actually WRAPPER. In other cases, no wrapper is needed for allocation-free operation.