### PR TITLE
barrier and rw_lock wake waiters in batches

### DIFF
--- a/include/tmc/detail/barrier.ipp
+++ b/include/tmc/detail/barrier.ipp
@@ -39,16 +39,18 @@ bool aw_barrier::await_suspend(std::coroutine_handle<> Outer) noexcept {
   // Reset this
   parent.done_count = parent.start_count.load();
 
-  // Resume the waiters
-  while (curr != nullptr) {
-    auto next = curr->next;
-    if (curr != &me) {
-      // Symmetric transfer to this coroutine.
-      // Others are posted to the executor.
-      curr->waiter.resume();
-    }
-    curr = next;
+  // This coroutine resumes by symmetric transfer (returning false), so unlink
+  // `me` from the chain before waking the others in batches. `me` is
+  // guaranteed to be in the chain since it was added above.
+  tmc::detail::waiter_list_node head;
+  head.next = curr;
+  auto prev = &head;
+  while (prev->next != &me) {
+    prev = prev->next;
   }
+  prev->next = me.next;
+
+  tmc::detail::wake_waiters_in_batches(head.next);
   return false;
 }
 

--- a/include/tmc/detail/manual_reset_event.ipp
+++ b/include/tmc/detail/manual_reset_event.ipp
@@ -11,58 +11,10 @@
 #include "tmc/detail/waiter_list.hpp"
 #include "tmc/manual_reset_event.hpp"
 
-#include <array>
 #include <atomic>
 #include <coroutine>
 
 namespace tmc {
-namespace detail {
-// Submits a chain of waiters to their continuation executors, grouping
-// consecutive waiters that share an executor and priority into bulk posts.
-// Returns the number of waiters woken.
-inline size_t wake_waiters_in_batches(tmc::detail::waiter_list_node* curr) noexcept {
-  std::array<tmc::work_item, 64> batch;
-  size_t batchSize = 0;
-  tmc::ex_any* continuationExecutor = nullptr;
-  size_t continuationPriority = 0;
-  size_t wakeCount = 0;
-
-  while (curr != nullptr) {
-    auto next = curr->next;
-
-    // A batch can only be posted to a single executor at a single priority.
-    // If this waiter's executor or priority differs from the batch in
-    // progress, post that batch before starting a new one for this waiter.
-    if (batchSize != 0 && (curr->waiter.continuation_executor != continuationExecutor ||
-                           curr->waiter.continuation_priority != continuationPriority)) {
-      continuationExecutor->post_bulk(batch.data(), batchSize, continuationPriority);
-      batchSize = 0;
-    }
-
-    if (batchSize == 0) {
-      continuationExecutor = curr->waiter.continuation_executor;
-      continuationPriority = curr->waiter.continuation_priority;
-    }
-
-    batch[batchSize] = curr->waiter.continuation;
-    ++batchSize;
-    ++wakeCount;
-    if (batchSize == batch.size()) {
-      continuationExecutor->post_bulk(batch.data(), batchSize, continuationPriority);
-      batchSize = 0;
-    }
-
-    curr = next;
-  }
-
-  if (batchSize != 0) {
-    continuationExecutor->post_bulk(batch.data(), batchSize, continuationPriority);
-  }
-
-  return wakeCount;
-}
-} // namespace detail
-
 bool aw_manual_reset_event::await_suspend(std::coroutine_handle<> Outer) noexcept {
   me.waiter.continuation = Outer;
   me.waiter.continuation_executor = tmc::detail::this_thread::executor();

--- a/include/tmc/detail/rw_lock.ipp
+++ b/include/tmc/detail/rw_lock.ipp
@@ -180,12 +180,7 @@ template <bool PreferWriters> void rw_lock::try_wake(state_t V) noexcept {
       }
       wakeTail->next = nullptr;
 
-      auto toWake = wakeHead.next;
-      while (toWake != nullptr) {
-        auto next = toWake->next;
-        toWake->waiter.resume();
-        toWake = next;
-      }
+      tmc::detail::wake_waiters_in_batches(wakeHead.next);
       return;
     }
   }

--- a/include/tmc/detail/waiter_list.hpp
+++ b/include/tmc/detail/waiter_list.hpp
@@ -60,6 +60,11 @@ struct waiter_list_node {
   suspend(waiter_data_base* Parent, std::coroutine_handle<> Outer) noexcept;
 };
 
+/// Submits a chain of waiters to their continuation executors, grouping
+/// consecutive waiters that share an executor and priority into bulk posts of
+/// up to 64 at a time. Returns the number of waiters woken.
+TMC_DECL size_t wake_waiters_in_batches(waiter_list_node* Curr) noexcept;
+
 /// Two-stack waiter queue with FIFO wake order.
 ///
 /// `input` is a lock-free Treiber stack that producers push to via
@@ -84,11 +89,12 @@ public:
     waiter_list_node& Node, std::coroutine_handle<> Outer
   ) noexcept;
 
-  /// Wakes all waiters. Not guaranteed to wake in FIFO order (which doesn't
-  /// matter since waking all waiters doesn't guarantee they get *processed* in
-  /// FIFO order either after going through their executor queues). Both lists
-  /// become empty. Thread-safe with concurrent `configure_and_add_waiter`, but
-  /// not with concurrent consumers (`maybe_wake`, `must_take_1`, `take_all`).
+  /// Wakes all waiters, posting them to their executors in batches. Not
+  /// guaranteed to wake in FIFO order (which doesn't matter since waking all
+  /// waiters doesn't guarantee they get *processed* in FIFO order either after
+  /// going through their executor queues). Both lists become empty.
+  /// Thread-safe with concurrent `configure_and_add_waiter`, but not with
+  /// concurrent consumers (`maybe_wake`, `must_take_1`, `take_all`).
   TMC_DECL void wake_all() noexcept;
 
   /// Returns the number of waiters currently in the list (both `output` and

--- a/include/tmc/detail/waiter_list.ipp
+++ b/include/tmc/detail/waiter_list.ipp
@@ -10,6 +10,7 @@
 #include "tmc/detail/thread_locals.hpp"
 #include "tmc/detail/waiter_list.hpp"
 
+#include <array>
 #include <atomic>
 #include <cassert>
 #include <coroutine>
@@ -125,14 +126,55 @@ void waiter_list::configure_and_add_waiter(
   ));
 }
 
-void waiter_list::wake_all() noexcept {
-  auto curr = take_all();
-  while (curr != nullptr) {
-    auto next = curr->next;
-    curr->waiter.resume();
-    curr = next;
+size_t wake_waiters_in_batches(waiter_list_node* Curr) noexcept {
+  std::array<tmc::work_item, 64> batch;
+  size_t batchSize = 0;
+  tmc::ex_any* continuationExecutor = nullptr;
+  size_t continuationPriority = 0;
+  size_t wakeCount = 0;
+
+  while (Curr != nullptr) {
+    auto next = Curr->next;
+
+    // A batch can only be posted to a single executor at a single priority.
+    // If this waiter's executor or priority differs from the batch in
+    // progress, post that batch before starting a new one for this waiter.
+    if (batchSize != 0 && (Curr->waiter.continuation_executor != continuationExecutor ||
+                           Curr->waiter.continuation_priority != continuationPriority)) {
+      tmc::detail::post_bulk_checked(
+        continuationExecutor, batch.data(), batchSize, continuationPriority
+      );
+      batchSize = 0;
+    }
+
+    if (batchSize == 0) {
+      continuationExecutor = Curr->waiter.continuation_executor;
+      continuationPriority = Curr->waiter.continuation_priority;
+    }
+
+    batch[batchSize] = Curr->waiter.continuation;
+    ++batchSize;
+    ++wakeCount;
+    if (batchSize == batch.size()) {
+      tmc::detail::post_bulk_checked(
+        continuationExecutor, batch.data(), batchSize, continuationPriority
+      );
+      batchSize = 0;
+    }
+
+    Curr = next;
   }
+
+  if (batchSize != 0) {
+    tmc::detail::post_bulk_checked(
+      continuationExecutor, batch.data(), batchSize, continuationPriority
+    );
+  }
+
+  return wakeCount;
 }
+
+void waiter_list::wake_all() noexcept { wake_waiters_in_batches(take_all()); }
 
 waiter_list_node* waiter_list::take_all() noexcept {
   // Drain the input stack. take_all is only used when every waiter will be


### PR DESCRIPTION
Followup to https://github.com/tzcnt/TooManyCooks/pull/263 that expands the functionality to `tmc::barrier` and `tmc::rw_lock` (when waking readers only).

Wake waiters in batches of up to 64. This reduces overhead when there are many waiting tasks.